### PR TITLE
Add Work model to represent individual items in the repository

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,10 @@ AllCops:
 Rails/I18nLocaleTexts:
   Enabled: false
 
+Rails/NotNullColumn:
+  Exclude:
+    - 'db/migrate/20230412212141_add_blueprint_to_works.rb'
+
 RSpec/FactoryBot/SyntaxMethods:
   Enabled: false
 

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -13,6 +13,19 @@ class Field < ApplicationRecord
 
   before_create :set_order
 
+  enum data_type: {
+    text: 0,
+    string: 1,
+    integer: 2,
+    float: 3,
+    date: 4,
+    boolean: 5
+  }
+
+  def dynamic_field_name
+    "#{name}_#{type_flag}si#{multi_flag}"
+  end
+
   private
 
   def set_order
@@ -20,5 +33,23 @@ class Field < ApplicationRecord
 
     fields = Blueprint.find(blueprint_id).fields
     self.order = fields.count
+  end
+
+  DATA_TYPE_MAPPER = {
+    'text' => 'te',
+    'string' => 'st',
+    'integer' => 'in',
+    'float' => 'fl',
+    'date' => 'dt',
+    'boolean' => 'bo'
+  }.freeze
+  def type_flag
+    DATA_TYPE_MAPPER.fetch(data_type, 'xx')
+  end
+
+  def multi_flag
+    return 'm' if multiple
+
+    ''
   end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,0 +1,15 @@
+# Primary descriptive object
+class Work < ApplicationRecord
+  belongs_to :blueprint
+
+  def to_solr
+    doc = []
+    doc << ['blueprint_stsi', blueprint.name]
+    blueprint.fields.each do |field|
+      label = field.dynamic_field_name
+      value = description[field['name']]
+      doc << [label, value]
+    end
+    doc.to_h
+  end
+end

--- a/db/migrate/20230412193217_create_works.rb
+++ b/db/migrate/20230412193217_create_works.rb
@@ -1,0 +1,9 @@
+class CreateWorks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :works do |t|
+      t.json :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230412212141_add_blueprint_to_works.rb
+++ b/db/migrate/20230412212141_add_blueprint_to_works.rb
@@ -1,0 +1,5 @@
+class AddBlueprintToWorks < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :works, :blueprint, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_03_224500) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_13_171328) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,5 +32,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_224500) do
     t.index ["blueprint_id"], name: "index_fields_on_blueprint_id"
   end
 
+  create_table "works", force: :cascade do |t|
+    t.json "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "blueprint_id", null: false
+    t.index ["blueprint_id"], name: "index_works_on_blueprint_id"
+  end
+
   add_foreign_key "fields", "blueprints"
+  add_foreign_key "works", "blueprints"
 end

--- a/spec/factories/blueprints.rb
+++ b/spec/factories/blueprints.rb
@@ -2,4 +2,15 @@ FactoryBot.define do
   factory :blueprint do
     name { 'MyString' }
   end
+
+  factory :core_blueprint, class: 'Blueprint' do
+    name { 'basic_metadata_mapping' }
+    fields do
+      [
+        association(:field, name: 'title', data_type: 'text'),
+        association(:field, name: 'author', data_type: 'text', multiple: true),
+        association(:field, name: 'date', data_type: 'date')
+      ]
+    end
+  end
 end

--- a/spec/factories/fields.rb
+++ b/spec/factories/fields.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     blueprint
     required { false }
     multiple { false }
-    data_type { 3 }
+    data_type { 'string' }
     order { 0 }
   end
 end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :work do
+    description { '' }
+  end
+end

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -1,21 +1,21 @@
 require 'rails_helper'
 
-RSpec.describe Field do
+RSpec.describe Field, :aggregate_failures do
   let(:new_field) { described_class.new }
   let(:blueprint) {  Blueprint.create!(name: 'Field-Testing') }
 
-  it 'must belong to a blueprint', :aggregate_failures do
+  it 'must belong to a blueprint' do
     expect { new_field.save! }.to raise_exception ActiveRecord::RecordInvalid
     expect(new_field.errors.full_messages).to include 'Blueprint must exist'
   end
 
-  it 'must have a name', :aggregate_failures do
+  it 'must have a name' do
     new_field.blueprint = blueprint
     expect { new_field.save! }.to raise_exception ActiveRecord::RecordInvalid
     expect(new_field.errors.full_messages).to include "Name can't be blank"
   end
 
-  it 'name can only use valid characters', :aggregate_failures do
+  it 'name can only use valid characters' do
     new_field.blueprint = blueprint
     new_field.name = 'bad name!'
     expect(new_field.save).to be false
@@ -36,12 +36,44 @@ RSpec.describe Field do
       expect(new_field.order).to be_nil
     end
 
-    it 'orders new fields at the end', :aggregate_failures do
+    it 'orders new fields at the end' do
       field1 = described_class.create!(blueprint: blueprint, name: 'field_1')
       field2 = described_class.create!(blueprint: blueprint, name: 'field_2')
       field3 = described_class.create!(blueprint: blueprint, name: 'field_3')
       expect(field3.order).to be > field2.order
       expect(field2.order).to be > field1.order
+    end
+  end
+
+  describe '#dynamic_field_name' do
+    let(:new_field) { described_class.new(blueprint: blueprint, name: 'attribute') }
+
+    it 'includes the base name' do
+      expect(new_field.dynamic_field_name).to match(/attribute/)
+    end
+
+    it 'includes a multiple flag (m)' do
+      new_field.multiple = false
+      expect(new_field.dynamic_field_name).to match(/[^m]$/)
+      new_field.multiple = true
+      expect(new_field.dynamic_field_name).to match(/m$/)
+    end
+
+    it 'includes a type flag' do # rubocop:disable RSpec/ExampleLength
+      new_field.data_type = 'text'
+      expect(new_field.dynamic_field_name).to match(/_te/)
+      new_field.data_type = 'string'
+      expect(new_field.dynamic_field_name).to match(/_st/)
+      new_field.data_type = 'integer'
+      expect(new_field.dynamic_field_name).to match(/_in/)
+      new_field.data_type = 'float'
+      expect(new_field.dynamic_field_name).to match(/_fl/)
+      new_field.data_type = 'date'
+      expect(new_field.dynamic_field_name).to match(/_dt/)
+      new_field.data_type = 'boolean'
+      expect(new_field.dynamic_field_name).to match(/_bo/)
+      new_field.data_type = nil
+      expect(new_field.dynamic_field_name).to match(/_xx/)
     end
   end
 end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Work do
+  let(:new_work) { described_class.new }
+  let(:basic_description) do
+    {
+      'title' => 'One Hundred Years of Solitute',
+      'author' => 'Márquez, Gabriel García',
+      'date' => '1967'
+    }
+  end
+
+  describe '#description' do
+    it 'defaults to nil' do
+      expect(new_work.description).to be_nil
+    end
+
+    it 'accepts JSON' do
+      new_work.description = basic_description.as_json
+      expect(new_work.description['date']).to eq '1967'
+    end
+  end
+
+  describe '#blueprint' do
+    it 'must have a value' do
+      new_work.blueprint = nil
+      expect(new_work).not_to be_valid
+    end
+
+    it 'must be a kind of Blueprint' do
+      expect { new_work.blueprint = 'not a blueprint' }.to raise_exception ActiveRecord::AssociationTypeMismatch
+    end
+
+    it 'must refer to an existing Blueprint' do
+      placeholder = FactoryBot.create(:blueprint)
+      work = described_class.new(blueprint: placeholder)
+      expect { work.save! }.not_to raise_exception
+    end
+  end
+
+  describe '#to_solr' do
+    let(:solr_doc) do
+      {
+        'blueprint_stsi' => 'basic_metadata_mapping',
+        'title_tesi' => 'One Hundred Years of Solitute',
+        'author_tesim' => 'Márquez, Gabriel García',
+        'date_dtsi' => '1967'
+      }
+    end
+
+    it 'renders a solr document' do
+      new_work.description = basic_description.as_json
+      new_work.blueprint = FactoryBot.create(:core_blueprint)
+      expect(new_work.to_solr).to eq solr_doc
+    end
+  end
+end

--- a/spec/views/fields/index.html.erb_spec.rb
+++ b/spec/views/fields/index.html.erb_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe 'fields/index' do
     assert_select 'div>p', text: /Name/, count: 2
     assert_select 'div>p', text: /false/, count: 4
     assert_select 'div>p', text: /Order:\s+0/, count: 2
-    assert_select 'div>p', text: /Type:\s+3/, count: 2
+    assert_select 'div>p', text: /Type:\s+string/, count: 2
   end
 end

--- a/spec/views/fields/show.html.erb_spec.rb
+++ b/spec/views/fields/show.html.erb_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe 'fields/show' do
     expect(rendered).to match(/false/)
     expect(rendered).to match(/false/)
     expect(rendered).to match(/0/)
-    expect(rendered).to match(/3/)
+    expect(rendered).to match(/string/)
   end
 end


### PR DESCRIPTION
A work has a `blueprint` that describes associated metadata and controls how metadata is indexed into solr.

Each work has a JSON field called `description` that can store abritrary JSON.  The `Blueprint` controls how this JSON is indexed for searching and faceting works.