### PR TITLE
Admin

### DIFF
--- a/app/controllers/configs_controller.rb
+++ b/app/controllers/configs_controller.rb
@@ -22,6 +22,8 @@ class ConfigsController < ApplicationController
   # POST /configs or /configs.json
   def create # rubocop:disable Metrics/MethodLength
     @config = Config.new(config_params)
+
+    @config.validate
     increment_setup_step
 
     respond_to do |format|
@@ -74,7 +76,7 @@ class ConfigsController < ApplicationController
   def increment_setup_step
     case @config.setup_step
     when 'host'
-      @config.setup_step = 'core' if @config.verify_host
+      @config.setup_step = 'core' if @config.verified?
     when 'core'
       @config.setup_step = 'fields' if @config.solr_core.present?
     when 'fields'

--- a/spec/views/configs/edit.html.erb_spec.rb
+++ b/spec/views/configs/edit.html.erb_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe 'configs/edit' do
-  let(:config) { FactoryBot.create(:config) }
+  let(:config) { FactoryBot.build(:config) }
 
   before do
+    allow(config).to receive(:solr_host_responsive)
+    config.save!
     assign(:config, config)
   end
 

--- a/spec/views/configs/index.html.erb_spec.rb
+++ b/spec/views/configs/index.html.erb_spec.rb
@@ -1,8 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe 'configs/index' do
+  let(:config) { FactoryBot.build(:config) }
+  let(:another) { FactoryBot.build(:config) }
+
   before do
-    assign(:configs, [FactoryBot.create(:config), FactoryBot.create(:config)])
+    allow(config).to receive(:solr_host_responsive)
+    config.save!
+    allow(another).to receive(:solr_host_responsive)
+    another.save!
+    assign(:configs, [config, another])
   end
 
   it 'renders a list of configs' do

--- a/spec/views/configs/show.html.erb_spec.rb
+++ b/spec/views/configs/show.html.erb_spec.rb
@@ -1,19 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe 'configs/show', :aggregate_failures do
+  let(:config) { FactoryBot.build(:config) }
+
   before do
-    assign(:config, Config.create!(
-                      solr_host: 'Solr Host',
-                      solr_core: 'Solr Core',
-                      solr_version: '3.2.1',
-                      fields: 'some json here...'
-                    ))
+    allow(config).to receive(:solr_host_responsive)
+    config.save!
+    assign(:config, config)
   end
 
   it 'renders attributes in <p>' do
     render
-    expect(rendered).to match(/Solr Host/)
-    expect(rendered).to match(/Solr Core/)
+    expect(rendered).to match(/localhost/)
+    expect(rendered).to match(/blacklight-core/)
     expect(rendered).to match(/json/)
   end
 end


### PR DESCRIPTION
Adds checks and feedback for the following:
* solr_host must have vaild URL form
* solr_host must be responding
* solr_host must not return http errors
* solr_host must be running a solr service

Refactors validations for additional clarity

Stub out validations that would otherwise make live Solr calls in view specs