### PR TITLE
Add field-level config object

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ Rails/I18nLocaleTexts:
 RSpec/FactoryBot/SyntaxMethods:
   Enabled: false
 
+RSpec/ExampleLength:
+  CountAsOne: ['array', 'hash', 'heredoc']
+
 Style/Documentation:
   Exclude:
     - 'db/**/*'
@@ -21,6 +24,9 @@ Style/FrozenStringLiteralComment:
 
 Style/HashSyntax:
   EnforcedShorthandSyntax: never
+
+Style/WordArray:
+  Enabled: false
 
 Naming/VariableNumber:
   CheckSymbols: false

--- a/app/models/field_config.rb
+++ b/app/models/field_config.rb
@@ -1,0 +1,20 @@
+# Configuration object for individual fields
+# Generally serialized into a and array and
+# Stored as JSONB as part of a persisted object
+class FieldConfig
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :solr_field_name
+  attribute :display_label
+  attribute :enabled, :boolean, default: true
+  attribute :searchable, :boolean, default: true
+  attribute :facetable, :boolean, default: false
+  attribute :search_results, :boolean, default: true
+  attribute :item_view, :boolean, default: true
+
+  # Name stripped of leading and trailing underscores and solr suffixes
+  def suggested_label
+    solr_field_name.match(/_*(.*[^_])(_+[^_]*)$/i)[1].titleize
+  end
+end

--- a/spec/models/field_config_spec.rb
+++ b/spec/models/field_config_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe FieldConfig, :aggregate_failures do
+  let(:new_field) { described_class.new }
+  let(:expected_attributes) do
+    [
+      'solr_field_name',
+      'enabled',
+      'display_label',
+      'searchable',
+      'facetable',
+      'search_results',
+      'item_view'
+    ]
+  end
+
+  it 'has expected attributes' do
+    expect(new_field.attribute_names)
+      .to match_array(expected_attributes)
+  end
+
+  context 'when assiged' do
+    # see https://api.rubyonrails.org/classes/ActiveModel/Type/Boolean.html
+    it 'coreces "enabled" to boolean' do
+      new_field.enabled = 'false' # assiging a string
+      expect(new_field.enabled).to be false # instead of a String
+    end
+
+    it 'coerces "searchable" to boolean' do
+      new_field.searchable = :off
+      expect(new_field.searchable).to be false
+    end
+
+    it 'coerces "facetable" to boolean' do
+      new_field.facetable = :false # rubocop:disable Lint/BooleanSymbol
+      expect(new_field.facetable).to be false
+    end
+
+    it 'coerces "search_results" to boolean' do
+      new_field.search_results = 0
+      expect(new_field.search_results).to be false
+    end
+
+    it 'coerces "item_view" to boolean' do
+      new_field.item_view = 'F'
+      expect(new_field.item_view).to be false
+    end
+  end
+
+  context 'with defaults' do
+    it 'enbales the field overall' do
+      expect(new_field.enabled).to be true
+    end
+
+    it 'enables searching the field' do
+      expect(new_field.searchable).to be true
+    end
+
+    it 'disables faceting the field' do
+      expect(new_field.facetable).to be false
+    end
+
+    it 'displays the field in search results' do
+      expect(new_field.search_results).to be true
+    end
+
+    it 'displays the field in single item views' do
+      expect(new_field.item_view).to be true
+    end
+  end
+
+  it 'provides label suggestions' do
+    new_field.solr_field_name = '__Rights-Statement_tsi'
+    expect(new_field.suggested_label).to eq 'Rights Statement'
+    new_field.solr_field_name = '__title__'
+    expect(new_field.suggested_label).to eq 'Title'
+  end
+
+  it 'serializes to JSON' do
+    field = described_class.new(solr_field_name: 'title_tesim', display_label: 'Title')
+    expect(field.as_json['attributes']).to eq({
+                                                'solr_field_name' => 'title_tesim',
+                                                'display_label' => 'Title',
+                                                'enabled' => true,
+                                                'searchable' => true,
+                                                'search_results' => true,
+                                                'item_view' => true,
+                                                'facetable' => false
+                                              })
+  end
+
+  it 'supports mass assignment' do
+    field = described_class.new
+    expect(field.solr_field_name).to be_nil
+    expect { field.assign_attributes(solr_field_name: 'title_tesim', display_label: 'Title') }.not_to raise_exception
+    expect(field.solr_field_name).to eq 'title_tesim'
+  end
+end


### PR DESCRIPTION
Create a configuration object that lets us manage field-level configuration information such as which views to display a field on and how to map solr field names to UI display labels.