### PR TITLE
Extract Configs field listing to it's own partial

### DIFF
--- a/app/views/configs/_fields_form.html.erb
+++ b/app/views/configs/_fields_form.html.erb
@@ -1,0 +1,11 @@
+<%= fields_for @config do |form| %>
+  <div>
+    <%= form.label :fields -%><span style='display: inline-block; width: 1.5rem;'>&nbsp;</span>
+    <% if @config.setup_step == 'fields' %>
+      <%= form.text_field :fields -%>
+      <%= button_tag 'Save Fields', type: 'submit', id: 'update_fields' -%>
+    <% else %>
+      <%= form.text_field :fields, disabled: true -%>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/configs/_form.html.erb
+++ b/app/views/configs/_form.html.erb
@@ -14,13 +14,5 @@
   <%= form.hidden_field :setup_step %>
   <%= render 'host_form', config: @config -%>
   <%= render 'core_form', config: @config -%>
-
-  <div>
-    <%= form.label :fields -%><span style='display: inline-block; width: 1.5rem;'>&nbsp;</span>
-    <%= form.text_field :fields, disabled: config.setup_step != 'fields' -%>
-    <% if @config.setup_step == 'fields' %>
-      <%= form.submit 'Finish'  %>
-    <% end %>
-  </div>
-
+  <%= render 'fields_form', config: @config %>
 <% end %>

--- a/spec/views/configs/_fields_form.html.erb_spec.rb
+++ b/spec/views/configs/_fields_form.html.erb_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'configs/_fields_form' do
+  context 'when in "host" setup step' do
+    before do
+      @config = Config.new(setup_step: 'host')
+      render
+    end
+
+    it 'disables the field input' do
+      expect(rendered).to have_field 'config[fields]', disabled: true
+    end
+
+    it 'does not have an update fields button' do
+      expect(rendered).not_to have_button 'update_fields'
+    end
+  end
+
+  context 'when in "fields" setup step' do
+    before do
+      @config = Config.new(setup_step: 'fields')
+      render
+    end
+
+    it 'disables the field input' do
+      expect(rendered).to have_field 'config[fields]'
+    end
+
+    it 'shows an update fields button' do
+      expect(rendered).to have_button 'update_fields'
+    end
+  end
+end

--- a/spec/views/configs/new.html.erb_spec.rb
+++ b/spec/views/configs/new.html.erb_spec.rb
@@ -10,4 +10,13 @@ RSpec.describe 'configs/new' do
     expect(rendered).to have_field('config[solr_host]')
     expect(rendered).to have_field('config[solr_core]', disabled: true)
   end
+
+  it 'renders the expected partials', :aggregate_failures do
+    allow(view).to receive(:render).and_call_original
+    render
+
+    expect(view).to have_received(:render).with('host_form', any_args)
+    expect(view).to have_received(:render).with('core_form', any_args)
+    expect(view).to have_received(:render).with('fields_form', any_args)
+  end
 end


### PR DESCRIPTION
We want to add code to display individual fields which will increase the complexity of the config/_form partial.

So, this change extracts the fields portion to a separate partial that parallels how we have handled the Solr host and Solr core settings.