### PR TITLE
Add support for FieldConfig objects in Config fields attribute

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -4,7 +4,8 @@ class Config < ApplicationRecord
   validate  :solr_host_responsive, on: :create
   validates :solr_version, presence: true, on: :update
   validates :solr_core, presence: true
-  validates :fields, presence: true
+
+  attribute :fields, FieldConfig::ListType.new, default: -> { [] }
 
   enum setup_step: {
     host: %i[solr_host solr_version],
@@ -58,5 +59,13 @@ class Config < ApplicationRecord
     errors.add :solr_host, 'returned unexpected HTTP error'
   rescue RSolr::Error::ConnectionRefused
     errors.add :solr_host, "#{solr_host} is not responding"
+  end
+
+  def populate_fields
+    fields = []
+    available_fields.each do |name, _config|
+      fields << FieldConfig.new(solr_field_name: name)
+    end
+    self.fields = fields
   end
 end

--- a/spec/factories/configs.rb
+++ b/spec/factories/configs.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     solr_host { 'http://localhost:8983' }
     solr_core { 'blacklight-core' }
     solr_version { '3.2.1' }
-    fields { 'some json here...' }
+    fields { { solr_field_name: 'solr_field', display_label: 'Label' } }
   end
 end

--- a/spec/models/config_spec.rb
+++ b/spec/models/config_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Config, :aggregate_failures do
-  let(:config) { described_class.new(FactoryBot.attributes_for(:config)) }
+  let(:config) { FactoryBot.build(:config) }
 
   let(:solr_client) { RSolr::Client.new(nil) }
 
@@ -155,6 +155,20 @@ RSpec.describe Config, :aggregate_failures do
     it 'returns an empty list when there is a connection problem or misconfiguration' do
       config.solr_core = '- not - a - valid - core -'
       expect(config.available_fields).to eq []
+    end
+  end
+
+  describe '#populate_fields' do
+    let(:config) { FactoryBot.build(:config, solr_core: 'tenejo') }
+
+    it 'has the same number of elements as the solr index' do
+      config.populate_fields
+      expect(config.fields.count).to eq config.available_fields.count
+    end
+
+    it 'populates the fields attribute with a list of FieldConfig objects' do
+      config.populate_fields
+      expect(config.fields.map(&:class).uniq).to eq [FieldConfig]
     end
   end
 end

--- a/spec/requests/configs_spec.rb
+++ b/spec/requests/configs_spec.rb
@@ -114,7 +114,10 @@ RSpec.describe '/configs' do
 
   describe 'PATCH /update' do
     context 'with valid parameters' do # rubocop:disable RSpec/MultipleMemoizedHelpers
-      let(:new_attributes) { { fields: 'some json fields here...' } }
+      let(:new_attributes) do
+        { fields: [{ solr_field_name: 'index_field1', display_label: 'Label' },
+                   { solr_field_name: 'another_index_field', display_label: 'Another Label' }] }
+      end
 
       it 'updates the requested config' do
         config = Config.create! valid_attributes

--- a/spec/views/configs/index.html.erb_spec.rb
+++ b/spec/views/configs/index.html.erb_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe 'configs/index' do
     cell_selector = Rails::VERSION::STRING >= '7' ? 'div>p' : 'tr>td'
     assert_select cell_selector, text: Regexp.new('localhost'.to_s), count: 2
     assert_select cell_selector, text: Regexp.new('blacklight'.to_s), count: 2
-    assert_select cell_selector, text: Regexp.new('json'.to_s), count: 2
+    assert_select cell_selector, text: Regexp.new('FieldConfig'.to_s), count: 2
   end
 end

--- a/spec/views/configs/show.html.erb_spec.rb
+++ b/spec/views/configs/show.html.erb_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe 'configs/show', :aggregate_failures do
     render
     expect(rendered).to match(/localhost/)
     expect(rendered).to match(/blacklight-core/)
-    expect(rendered).to match(/json/)
+    expect(rendered).to match(/FieldConfig/)
   end
 end


### PR DESCRIPTION
First pass at integrating ActiveModel FieldConfig object in ActiveRecord Config records.

* Allow Config `fields` attribue to store and round-trip FieldConfig objects, inlcuding serialization and deserialization to a Postgres jsonb column
* Update specs to interact with valid json objects for `fields` instead of simple strings

TODO
* Update views to display human-friendly versions of FieldConfig data