### PR TITLE
Populate suggested display_label values

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -62,10 +62,8 @@ class Config < ApplicationRecord
   end
 
   def populate_fields
-    fields = []
-    available_fields.each do |name, _config|
-      fields << FieldConfig.new(solr_field_name: name)
+    self.fields = available_fields.map do |name, _config|
+      FieldConfig.new(solr_field_name: name)
     end
-    self.fields = fields
   end
 end

--- a/app/models/field_config.rb
+++ b/app/models/field_config.rb
@@ -13,8 +13,14 @@ class FieldConfig
   attribute :search_results, :boolean, default: true
   attribute :item_view, :boolean, default: true
 
+  def display_label
+    attributes['display_label'] || self.display_label = suggested_label
+  end
+
   # Name stripped of leading and trailing underscores and solr suffixes
   def suggested_label
+    return unless solr_field_name
+
     solr_field_name.match(/_*(.*[^_])(_+[^_]*)$/i)[1].titleize
   end
 

--- a/spec/fixtures/files/solr/tenejo_admin_luke.json
+++ b/spec/fixtures/files/solr/tenejo_admin_luke.json
@@ -25,104 +25,12 @@
     "lastModified": "2023-03-23T19:08:30.897Z"
   },
   "fields": {
-    "_version_": {
-      "type": "long",
-      "schema": "I-S-U-----OF------",
-      "docs": 34927
-    },
-    "accessControl_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 7161
-    },
-    "accessTo_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 6628
-    },
-    "actionable_workflow_roles_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 2
-    },
     "admin_set_sim": {
       "type": "string",
       "schema": "I---UM----OF-----l",
       "dynamicBase": "*_sim",
       "index": "(unstored field)",
       "docs": 227
-    },
-    "admin_set_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "index": "ITS---------------",
-      "docs": 227
-    },
-    "all_text_timv": {
-      "type": "text",
-      "schema": "IT--UMVop---------",
-      "docs": 4
-    },
-    "alpha_channels_ssi": {
-      "type": "string",
-      "schema": "I-S-U-----OF-----l",
-      "dynamicBase": "*_ssi",
-      "docs": 6874
-    },
-    "alternative_title_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "index": "ITS---------------",
-      "docs": 2
-    },
-    "based_near_label_sim": {
-      "type": "string",
-      "schema": "I---UM----OF-----l",
-      "dynamicBase": "*_sim",
-      "docs": 1
-    },
-    "based_near_label_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 1
-    },
-    "based_near_sim": {
-      "type": "string",
-      "schema": "I---UM----OF-----l",
-      "dynamicBase": "*_sim",
-      "docs": 1
-    },
-    "based_near_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 1
-    },
-    "collection_type_gid_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "index": "ITS-------OF------",
-      "docs": 45
-    },
-    "contributor_sim": {
-      "type": "string",
-      "schema": "I---UM----OF-----l",
-      "dynamicBase": "*_sim",
-      "index": "(unstored field)",
-      "docs": 67
-    },
-    "contributor_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 67
     },
     "creator_sim": {
       "type": "string",
@@ -143,174 +51,11 @@
       "dynamicBase": "*_ssi",
       "docs": 178
     },
-    "date_issued_ssi": {
-      "type": "string",
-      "schema": "I-S-U-----OF-----l",
-      "dynamicBase": "*_ssi",
-      "docs": 1
-    },
-    "date_modified_dtsi": {
-      "type": "date",
-      "schema": "I-S-U-----OF------",
-      "dynamicBase": "*_dtsi",
-      "docs": 6899
-    },
-    "date_uploaded_dtsi": {
-      "type": "date",
-      "schema": "I-S-U-----OF------",
-      "dynamicBase": "*_dtsi",
-      "docs": 271
-    },
-    "depositor_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 275
-    },
-    "depositor_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "index": "ITS---------------",
-      "docs": 275
-    },
     "description_tesim": {
       "type": "text_en",
       "schema": "ITS-UM------------",
       "dynamicBase": "*_tesim",
       "docs": 227
-    },
-    "digest_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "index": "ITS-------OF------",
-      "docs": 6889
-    },
-    "duration_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 6
-    },
-    "edit_access_group_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 10
-    },
-    "edit_access_person_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 8
-    },
-    "extent_sim": {
-      "type": "string",
-      "schema": "I---UM----OF-----l",
-      "dynamicBase": "*_sim",
-      "docs": 24
-    },
-    "extent_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 24
-    },
-    "file_format_sim": {
-      "type": "string",
-      "schema": "I---UM----OF-----l",
-      "dynamicBase": "*_sim",
-      "docs": 6889
-    },
-    "file_format_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "index": "ITS---------------",
-      "docs": 6889
-    },
-    "file_set_ids_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 227
-    },
-    "file_size_lts": {
-      "type": "tlong",
-      "schema": "--S---------------",
-      "dynamicBase": "*_lts"
-    },
-    "file_title_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 3
-    },
-    "generic_type_si": {
-      "type": "string",
-      "schema": "I---U-----OF-----l",
-      "dynamicBase": "*_si",
-      "docs": 6889
-    },
-    "generic_type_sim": {
-      "type": "string",
-      "schema": "I---UM----OF-----l",
-      "dynamicBase": "*_sim",
-      "docs": 273
-    },
-    "genre_sim": {
-      "type": "string",
-      "schema": "I---UM----OF-----l",
-      "dynamicBase": "*_sim",
-      "docs": 15
-    },
-    "genre_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 15
-    },
-    "hasEmbargo_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 228
-    },
-    "hasFormat_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 2
-    },
-    "hasLease_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 228
-    },
-    "hasRelatedImage_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 7147
-    },
-    "hasRelatedMediaFragment_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 7116
-    },
-    "has_model_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 34927
-    },
-    "height_is": {
-      "type": "int",
-      "schema": "--S---------------",
-      "dynamicBase": "*_is"
     },
     "human_readable_type_sim": {
       "type": "string",
@@ -318,29 +63,11 @@
       "dynamicBase": "*_sim",
       "docs": 7162
     },
-    "human_readable_type_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 7162
-    },
-    "id": {
-      "type": "string",
-      "schema": "I-S-U-----OF-----l",
-      "docs": 34927
-    },
     "identifier_ssi": {
       "type": "string",
       "schema": "I-S-U-----OF-----l",
       "dynamicBase": "*_ssi",
       "docs": 268
-    },
-    "isPartOf_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "index": "ITS-------OF------",
-      "docs": 227
     },
     "keyword_sim": {
       "type": "string",
@@ -354,205 +81,17 @@
       "dynamicBase": "*_tesim",
       "docs": 218
     },
-    "label_ssi": {
-      "type": "string",
-      "schema": "I-S-U-----OF-----l",
-      "dynamicBase": "*_ssi",
-      "docs": 6889
-    },
-    "label_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 6889
-    },
     "language_sim": {
       "type": "string",
       "schema": "I---UM----OF-----l",
       "dynamicBase": "*_sim",
       "docs": 2
     },
-    "language_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 2
-    },
-    "license_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 10
-    },
-    "member_ids_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 227
-    },
-    "member_of_collection_ids_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 238
-    },
-    "member_of_collections_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "index": "ITS-------OF------",
-      "docs": 225
-    },
-    "mime_type_ssi": {
-      "type": "string",
-      "schema": "I-S-U-----OF-----l",
-      "dynamicBase": "*_ssi",
-      "index": "ITS-------OF------",
-      "docs": 6889
-    },
-    "nesting_collection__ancestors_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 238
-    },
-    "nesting_collection__deepest_nested_depth_isi": {
-      "type": "int",
-      "schema": "I-S-U-----OF------",
-      "dynamicBase": "*_isi",
-      "index": "-TS---------------",
-      "docs": 272
-    },
-    "nesting_collection__parent_ids_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 238
-    },
-    "nesting_collection__pathnames_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "index": "ITS-------OF------",
-      "docs": 272
-    },
-    "ordered_targets_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 171
-    },
-    "original_checksum_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 6887
-    },
-    "original_file_id_ssi": {
-      "type": "string",
-      "schema": "I-S-U-----OF-----l",
-      "dynamicBase": "*_ssi",
-      "docs": 6889
-    },
-    "other_identifiers_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 22
-    },
-    "page_count_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 4
-    },
-    "proxyFor_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 6740
-    },
-    "proxy_in_ssi": {
-      "type": "string",
-      "schema": "I-S-U-----OF-----l",
-      "dynamicBase": "*_ssi",
-      "docs": 171
-    },
-    "publisher_sim": {
-      "type": "string",
-      "schema": "I---UM----OF-----l",
-      "dynamicBase": "*_sim",
-      "index": "(unstored field)",
-      "docs": 61
-    },
-    "publisher_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 61
-    },
-    "read_access_group_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "index": "ITS-------OF------",
-      "docs": 7133
-    },
-    "related_url_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 39
-    },
-    "resource_format_sim": {
-      "type": "string",
-      "schema": "I---UM----OF-----l",
-      "dynamicBase": "*_sim",
-      "docs": 9
-    },
-    "resource_format_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 9
-    },
     "resource_type_sim": {
       "type": "string",
       "schema": "I---UM----OF-----l",
       "dynamicBase": "*_sim",
       "docs": 224
-    },
-    "resource_type_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 224
-    },
-    "rights_notes_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 8
-    },
-    "rights_statement_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "index": "ITS---------------",
-      "docs": 260
-    },
-    "sample_rate_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "docs": 5
-    },
-    "source_tesim": {
-      "type": "text_en",
-      "schema": "ITS-UM------------",
-      "dynamicBase": "*_tesim",
-      "index": "ITS---------------",
-      "docs": 64
     },
     "subject_sim": {
       "type": "string",
@@ -566,42 +105,6 @@
       "dynamicBase": "*_tesim",
       "docs": 65
     },
-    "suggest": {
-      "type": "textSuggest",
-      "schema": "IT--UM------------",
-      "dynamicBase": "*suggest",
-      "index": "(unstored field)",
-      "docs": 34927
-    },
-    "suppressed_bsi": {
-      "type": "boolean",
-      "schema": "I-S-U-----OF-----l",
-      "dynamicBase": "*_bsi",
-      "index": "ITS-------OF------",
-      "docs": 227
-    },
-    "system_create_dtsi": {
-      "type": "date",
-      "schema": "I-S-U-----OF------",
-      "dynamicBase": "*_dtsi",
-      "docs": 34927
-    },
-    "system_modified_dtsi": {
-      "type": "date",
-      "schema": "I-S-U-----OF------",
-      "dynamicBase": "*_dtsi",
-      "docs": 34927
-    },
-    "thumbnail_path_ss": {
-      "type": "string",
-      "schema": "--S--------------l",
-      "dynamicBase": "*_ss"
-    },
-    "timestamp": {
-      "type": "date",
-      "schema": "I-S-U-----OF------",
-      "docs": 34927
-    },
     "title_sim": {
       "type": "string",
       "schema": "I---UM----OF-----l",
@@ -613,24 +116,6 @@
       "schema": "ITS-UM------------",
       "dynamicBase": "*_tesim",
       "docs": 7162
-    },
-    "visibility_ssi": {
-      "type": "string",
-      "schema": "I-S-U-----OF-----l",
-      "dynamicBase": "*_ssi",
-      "index": "ITS-------OF------",
-      "docs": 7161
-    },
-    "width_is": {
-      "type": "int",
-      "schema": "--S---------------",
-      "dynamicBase": "*_is"
-    },
-    "workflow_state_name_ssim": {
-      "type": "string",
-      "schema": "I-S-UM----OF-----l",
-      "dynamicBase": "*_ssim",
-      "docs": 2
     }
   },
   "info": {

--- a/spec/models/config_spec.rb
+++ b/spec/models/config_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Config, :aggregate_failures do
   describe '#available_fields' do
     it 'returns a list of fields indexed in the core' do
       config.solr_core = 'tenejo'
-      expect(config.available_fields).to include('title_sim', 'system_create_dtsi')
+      expect(config.available_fields).to include('title_sim', 'description_tesim')
     end
 
     it 'includes configuration info for each field' do
@@ -166,9 +166,15 @@ RSpec.describe Config, :aggregate_failures do
       expect(config.fields.count).to eq config.available_fields.count
     end
 
-    it 'populates the fields attribute with a list of FieldConfig objects' do
+    it 'populates "fields" with a list of FieldConfig objects' do
       config.populate_fields
       expect(config.fields.map(&:class).uniq).to eq [FieldConfig]
+    end
+
+    it 'adds a suggested label in the initial list' do
+      config.populate_fields
+      resource_type = config.fields.select { |f| f.solr_field_name.match(/resource_type/) }.first
+      expect(resource_type.display_label).to eq 'Resource Type'
     end
   end
 end

--- a/spec/models/field_config_spec.rb
+++ b/spec/models/field_config_spec.rb
@@ -69,11 +69,10 @@ RSpec.describe FieldConfig, :aggregate_failures do
     end
   end
 
-  it 'provides label suggestions' do
+  it 'populates suggested display_label values based on the solr_field_name' do
+    expect(new_field.display_label).to be_nil
     new_field.solr_field_name = '__Rights-Statement_tsi'
-    expect(new_field.suggested_label).to eq 'Rights Statement'
-    new_field.solr_field_name = '__title__'
-    expect(new_field.suggested_label).to eq 'Title'
+    expect(new_field.display_label).to eq 'Rights Statement'
   end
 
   it 'serializes to JSON' do


### PR DESCRIPTION
When a `solr_field_name` is avaialbe and `display_label` is blank for a FieldConfig object:
* Set the `display_label` based on the field name
  * Strip leading and trailing underscores
  * Replace internal underscores with spaces
  * Strip any dynamic solr field suffix
  * Convert the result to title case

Also thins down the prototype Solr index configuration response since we only need a handful of the actual fields to drive tests.  This speeds up tests that parse that specific JSON.