### PR TITLE
Refactor suggested_label to handle suffixes more reliably

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -62,8 +62,8 @@ class Config < ApplicationRecord
   end
 
   def populate_fields
-    self.fields = available_fields.map do |name, _config|
-      FieldConfig.new(solr_field_name: name)
+    self.fields = available_fields.map do |name, config|
+      FieldConfig.new(solr_field_name: name, solr_suffix: config['dynamicBase'])
     end
   end
 end

--- a/app/models/field_config.rb
+++ b/app/models/field_config.rb
@@ -5,23 +5,25 @@ class FieldConfig
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attribute :solr_field_name
-  attribute :display_label
+  attribute :solr_field_name, :string
+  attribute :solr_suffix, :string
+  attribute :display_label, :string
   attribute :enabled, :boolean, default: true
   attribute :searchable, :boolean, default: true
   attribute :facetable, :boolean, default: false
   attribute :search_results, :boolean, default: true
   attribute :item_view, :boolean, default: true
 
-  def display_label
-    attributes['display_label'] || self.display_label = suggested_label
+  def initialize(*)
+    super
+    self.display_label ||= suggested_label
   end
 
   # Name stripped of leading and trailing underscores and solr suffixes
   def suggested_label
     return unless solr_field_name
 
-    solr_field_name.match(/_*(.*[^_])(_+[^_]*)$/i)[1].titleize
+    solr_field_name&.delete_suffix(solr_suffix.to_s.delete_prefix('*'))&.titleize&.strip
   end
 
   def ==(other)


### PR DESCRIPTION
ISSUE
The regex previously used raised errors simple single word field names like "id".

FIX
Use the suffix information provided by Solr to more easily and reliably remove any dynamic suffixes

This change also sets the display_label at initialization time instead of waiting until the first time the attribute is read.