### PR TITLE
Add friendly display of field-level configuration

### DIFF
--- a/app/views/configs/_config.html.erb
+++ b/app/views/configs/_config.html.erb
@@ -10,8 +10,8 @@
   </p>
 
   <p>
-    <strong>Fields:</strong>
-    <%= config.fields %>
+    <strong>Field count:</strong>
+    <%= config.fields.count %>
   </p>
 
 </div>

--- a/app/views/configs/show.html.erb
+++ b/app/views/configs/show.html.erb
@@ -1,6 +1,40 @@
+<h1>Solr Configuration</h1>
 <p style="color: green"><%= notice %></p>
 
-<%= render @config %>
+<div>
+  <strong>Solr host:</strong>
+  <%= @config.solr_host %>
+</div>
+
+<div>
+  <strong>Solr core:</strong>
+  <%= @config.solr_core %>
+</div>
+
+<table id='field_configs'>
+  <thead><tr>
+    <td class='name'>Solr Field</td>
+    <td class='enabled'>Enabled</td>
+    <td class='label'>Label</td>
+    <td class='search'>Search</td>
+    <td class='facet'>Facet</td>
+    <td class='index'>List</td>
+    <td class='show'>Item</td>
+  </tr></thead>
+  <tbody>
+  <% @config.fields.each_with_index do |field, i| %>
+    <tr id="<%= "fields_row_#{i}" -%>">
+      <td class='name'><%= field.solr_field_name -%></td>
+      <td class='enabled'><%= check_box_tag "fields[#{i}][enabled]", 'yes', field.enabled, disabled: true -%></td>
+      <td class='label'><%= field.display_label -%></td>
+      <td class='search'><%= check_box_tag "fields[#{i}][searchable]", 'yes', field.searchable, disabled: true -%></td>
+      <td class='facet'><%= check_box_tag "fields[#{i}][facetable]", 'yes', field.facetable, disabled: true -%></td>
+      <td class='index'><%= check_box_tag "fields[#{i}][search_results]", 'yes', field.search_results, disabled: true -%></td>
+      <td class='show'><%= check_box_tag "fields[#{i}][item_view]", 'yes', field.item_view, disabled: true -%></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
 
 <div>
   <%= link_to "Edit this config", edit_config_path(@config) %> |

--- a/spec/views/configs/index.html.erb_spec.rb
+++ b/spec/views/configs/index.html.erb_spec.rb
@@ -17,6 +17,5 @@ RSpec.describe 'configs/index' do
     cell_selector = Rails::VERSION::STRING >= '7' ? 'div>p' : 'tr>td'
     assert_select cell_selector, text: Regexp.new('localhost'.to_s), count: 2
     assert_select cell_selector, text: Regexp.new('blacklight'.to_s), count: 2
-    assert_select cell_selector, text: Regexp.new('FieldConfig'.to_s), count: 2
   end
 end

--- a/spec/views/configs/show.html.erb_spec.rb
+++ b/spec/views/configs/show.html.erb_spec.rb
@@ -7,12 +7,52 @@ RSpec.describe 'configs/show', :aggregate_failures do
     allow(config).to receive(:solr_host_responsive)
     config.save!
     assign(:config, config)
+    render
   end
 
-  it 'renders attributes in <p>' do
-    render
+  it 'displays the Solr host' do
     expect(rendered).to match(/localhost/)
+  end
+
+  it 'displays the Solr core' do
     expect(rendered).to match(/blacklight-core/)
-    expect(rendered).to match(/FieldConfig/)
+  end
+
+  context 'with multiple fields configured' do
+    let(:title_field) { FieldConfig.new(solr_field_name: 'title_tesi', solr_suffix: '*_tesi') }
+    let(:keyword_field) { FieldConfig.new(solr_field_name: 'keyword_ssim', solr_suffix: '*_ssim') }
+    let(:config) { FactoryBot.build(:config, fields: [title_field, keyword_field]) }
+
+    it 'renders fields as a table' do
+      expect(rendered).to have_table('field_configs')
+    end
+
+    it 'displays the solr field name' do
+      expect(rendered).to have_selector 'td.name', text: 'title_tesi'
+    end
+
+    it 'displays the label' do
+      expect(rendered).to have_selector 'td.label', text: 'Keyword'
+    end
+
+    it 'displays whether the field is enabled' do
+      expect(rendered).to have_checked_field 'fields[1][enabled]', disabled: true
+    end
+
+    it 'displays whether the field is searchable' do
+      expect(rendered).to have_checked_field 'fields[1][searchable]', disabled: true
+    end
+
+    it 'displays whether the field is facetable' do
+      expect(rendered).to have_unchecked_field 'fields[1][facetable]', disabled: true
+    end
+
+    it 'displays whether the field is displayed in search results' do
+      expect(rendered).to have_checked_field 'fields[1][search_results]', disabled: true
+    end
+
+    it 'displays whether the field is displayed on the single item view' do
+      expect(rendered).to have_checked_field 'fields[1][item_view]', disabled: true
+    end
   end
 end


### PR DESCRIPTION
Update the configuration show (read-only) view to show field-level configuration in a human-friendly table view.