### PR TITLE
Update the Config edit and show views to manage field details

### DIFF
--- a/app/controllers/configs_controller.rb
+++ b/app/controllers/configs_controller.rb
@@ -69,7 +69,11 @@ class ConfigsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def config_params
-    params.require(:config).permit(:setup_step, :solr_host, :solr_version, :solr_core, :fields)
+    params.require(:config).permit(:setup_step, :solr_host, :solr_version, :solr_core,
+                                   fields_attributes: %i[
+                                     solr_field_name enabled display_label
+                                     searchable facetable search_results item_view
+                                   ])
   end
 
   # Manage multi-step create state
@@ -79,8 +83,8 @@ class ConfigsController < ApplicationController
       @config.setup_step = 'core' if @config.verified?
     when 'core'
       @config.setup_step = 'fields' if @config.solr_core.present?
-    when 'fields'
-      @config.setup_step = 'fields' # just hang out at the last step ;)
+      @config.populate_fields
+    when 'fields' # just hang out at the last step ;)
     else
       @config.setup_step = 'host'
     end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -13,6 +13,13 @@ class Config < ApplicationRecord
     fields: [:fields]
   }
 
+  # Emulate #accepts_nested_attributes_for behavior
+  def fields_attributes=(attributes)
+    self.fields = attributes.map do |_i, field_params|
+      FieldConfig.new(field_params)
+    end
+  end
+
   def verified?
     solr_version.present?
   end
@@ -62,6 +69,8 @@ class Config < ApplicationRecord
   end
 
   def populate_fields
+    return unless fields.empty? && solr_host.present? && solr_core.present?
+
     self.fields = available_fields.map do |name, config|
       FieldConfig.new(solr_field_name: name, solr_suffix: config['dynamicBase'])
     end

--- a/app/views/configs/_fields_form.html.erb
+++ b/app/views/configs/_fields_form.html.erb
@@ -1,9 +1,36 @@
 <%= fields_for @config do |form| %>
   <div>
-    <%= form.label :fields -%><span style='display: inline-block; width: 1.5rem;'>&nbsp;</span>
-    <% if @config.setup_step == 'fields' %>
-      <%= form.text_field :fields -%>
-      <%= button_tag 'Save Fields', type: 'submit', id: 'update_fields' -%>
+    <% if @config.setup_step != 'host' && @config.setup_step != 'core' %>
+      <%= form.submit 'Update Fields', id: 'update_fields' -%>
+      <table id='field_configs'>
+        <thead>
+          <tr>
+            <td class='name'>Solr Field</td>
+            <td class='enabled'>Enabled</td>
+            <td class='label'>Label</td>
+            <td class='search'>Search</td>
+            <td class='facet'>Facet</td>
+            <td class='index'>List</td>
+            <td class='show'>Item</td>
+          </tr>
+        </thead>
+        <tbody>
+        <%= form.fields_for :fields do |field_form| %>
+            <tr id="<%= "fields_row_#{field_form.index}" -%>">
+              <td class='name'><%= field_form.object.solr_field_name -%>
+                <%= field_form.hidden_field :solr_field_name -%>
+                <%= field_form.hidden_field :solr_suffix -%></td>
+              <td class='enabled'><%= field_form.check_box :enabled -%></td>
+              <td class='label'><%= field_form.text_field :display_label -%></td>
+              <td class='search'><%= field_form.check_box :searchable -%></td>
+              <td class='facet'><%= field_form.check_box :facetable -%></td>
+              <td class='index'><%= field_form.check_box :search_results -%></td>
+              <td class='show'><%= field_form.check_box :item_view -%></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
     <% else %>
       <%= form.text_field :fields, disabled: true -%>
     <% end %>

--- a/spec/models/config_spec.rb
+++ b/spec/models/config_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Config, :aggregate_failures do
   end
 
   describe '#populate_fields' do
-    let(:config) { FactoryBot.build(:config, solr_core: 'tenejo') }
+    let(:config) { FactoryBot.build(:config, solr_host: 'http://localhost:8983', solr_core: 'tenejo', fields: []) }
 
     it 'has the same number of elements as the solr index' do
       config.populate_fields

--- a/spec/views/configs/_fields_form.html.erb_spec.rb
+++ b/spec/views/configs/_fields_form.html.erb_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe 'configs/_fields_form' do
       render
     end
 
-    it 'disables the field input' do
-      expect(rendered).to have_field 'config[fields]', disabled: true
-    end
-
     it 'does not have an update fields button' do
       expect(rendered).not_to have_button 'update_fields'
     end
@@ -20,10 +16,6 @@ RSpec.describe 'configs/_fields_form' do
     before do
       @config = Config.new(setup_step: 'fields')
       render
-    end
-
-    it 'disables the field input' do
-      expect(rendered).to have_field 'config[fields]'
     end
 
     it 'shows an update fields button' do

--- a/spec/views/configs/edit.html.erb_spec.rb
+++ b/spec/views/configs/edit.html.erb_spec.rb
@@ -7,12 +7,55 @@ RSpec.describe 'configs/edit' do
     allow(config).to receive(:solr_host_responsive)
     config.save!
     assign(:config, config)
+    render
   end
 
   it 'renders the edit config form', :aggregate_failures do
-    render
     assert_select 'form[action=?][method=?]', config_path(config), 'post'
     expect(rendered).to have_field('config[solr_host]', disabled: true)
     expect(rendered).to have_field('config[solr_core]', disabled: true)
+  end
+
+  context 'with multiple fields' do
+    let(:title_field) { FieldConfig.new(solr_field_name: 'title_tesi', solr_suffix: '*_tesi') }
+    let(:keyword_field) { FieldConfig.new(solr_field_name: 'keyword_ssim', solr_suffix: '*_ssim') }
+    let(:config) { FactoryBot.build(:config, fields: [title_field, keyword_field]) }
+
+    it 'renders fields as a table' do
+      expect(rendered).to have_table('field_configs')
+    end
+
+    it 'displays the solr field name as plain text' do
+      expect(rendered).to have_selector 'td.name', text: 'title_tesi'
+    end
+
+    it 'round-trips non-editable fields as hidden fields', :aggregate_failures do
+      expect(rendered).to have_field 'config_fields_attributes_1_solr_field_name', type: :hidden, with: 'keyword_ssim'
+      expect(rendered).to have_field 'config_fields_attributes_1_solr_suffix', type: :hidden, with: '*_ssim'
+    end
+
+    it 'displays the label' do
+      expect(rendered).to have_field 'config_fields_attributes_1_display_label', with: 'Keyword'
+    end
+
+    it 'displays whether the field is enabled' do
+      expect(rendered).to have_checked_field 'config_fields_attributes_1_enabled'
+    end
+
+    it 'displays whether the field is searchable' do
+      expect(rendered).to have_checked_field 'config_fields_attributes_1_searchable'
+    end
+
+    it 'displays whether the field is facetable' do
+      expect(rendered).to have_unchecked_field 'config_fields_attributes_1_facetable'
+    end
+
+    it 'displays whether the field is displayed in search results' do
+      expect(rendered).to have_checked_field 'config_fields_attributes_1_search_results'
+    end
+
+    it 'displays whether the field is displayed on the single item view' do
+      expect(rendered).to have_checked_field 'config_fields_attributes_1_item_view'
+    end
   end
 end


### PR DESCRIPTION
* Allow field-level changes when editing configuration data.
* Displays a field count summary on config index views.
* Displays field-level configuration data on the show view.