### PR TITLE
Add methods to support dynamic configuration of the Catalog controller

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,10 @@ AllCops:
 Rails/I18nLocaleTexts:
   Enabled: false
 
+Rails/SkipsModelValidations:
+  Exclude:
+    - 'spec/**/*'
+
 RSpec/FactoryBot/SyntaxMethods:
   Enabled: false
 
@@ -24,6 +28,9 @@ Style/FrozenStringLiteralComment:
 
 Style/HashSyntax:
   EnforcedShorthandSyntax: never
+
+Style/SymbolProc:
+  AllowedPatterns: ['map', 'select']
 
 Style/WordArray:
   Enabled: false

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -20,6 +20,30 @@ class Config < ApplicationRecord
     end
   end
 
+  def self.current
+    Config.order('updated_at').last
+  end
+
+  def enabled_fields
+    fields.select { |f| f.enabled }
+  end
+
+  def search_fields
+    enabled_fields.select { |f| f.searchable }
+  end
+
+  def facet_fields
+    enabled_fields.select { |f| f.facetable }
+  end
+
+  def index_fields
+    enabled_fields.select { |f| f.search_results }
+  end
+
+  def show_fields
+    enabled_fields.select { |f| f.item_view }
+  end
+
   def verified?
     solr_version.present?
   end

--- a/spec/models/config_spec.rb
+++ b/spec/models/config_spec.rb
@@ -177,4 +177,55 @@ RSpec.describe Config, :aggregate_failures do
       expect(resource_type.display_label).to eq 'Resource Type'
     end
   end
+
+  describe '.current' do
+    it 'returns the most recently modified Conifg' do
+      earliest_config = FactoryBot.create(:config, solr_core: 'first')
+      latest_config = FactoryBot.create(:config, solr_core: 'second')
+      expect(described_class.current).to eq latest_config
+      earliest_config.touch
+      expect(described_class.current).to eq earliest_config
+    end
+  end
+
+  context 'with scope-like methods for fields' do
+    before do
+      config.fields = []
+      # NOTE: facetable defaults to `false` so we're turning it on explicity so the
+      # facet test looks like the others
+      5.times { |i| config.fields.push(FieldConfig.new(solr_field_name: "field#{i}", facetable: true)) }
+    end
+
+    describe '#search_fields' do
+      it 'returns fields that should be searched, in order' do
+        config.fields[3].enabled = false
+        config.fields[0].searchable = false
+        expect(config.search_fields.map(&:solr_field_name)).to eq ['field1', 'field2', 'field4']
+      end
+    end
+
+    describe '#facet_fields' do
+      it 'returns fields that should be faceted, in order' do
+        config.fields[1].enabled = false
+        config.fields[2].facetable = false
+        expect(config.facet_fields.map(&:solr_field_name)).to eq ['field0', 'field3', 'field4']
+      end
+    end
+
+    describe '#index_fields' do
+      it 'returns fields that should appear in search results, in order' do
+        config.fields[2].enabled = false
+        config.fields[4].search_results = false
+        expect(config.index_fields.map(&:solr_field_name)).to eq ['field0', 'field1', 'field3']
+      end
+    end
+
+    describe '#show_fields' do
+      it 'returns fields that should appear in the single item view, in order' do
+        config.fields[4].enabled = false
+        config.fields[0].item_view = false
+        expect(config.show_fields.map(&:solr_field_name)).to eq ['field1', 'field2', 'field3']
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Config.current - return the active configuration data
* Config#search_fields - returns a list of fields that should be searched
* Config#facet_fields - returns a list of fields that should be faceted
* Config#index_fields - returns a list of fields to show in search results
* Config#show_fields - returns a list of fields to show in item views