### PR TITLE
Update solr host and core dynamically

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -240,6 +240,7 @@ class CatalogController < ApplicationController
 
   def self.update_config # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
     configure_blacklight do |config|
+      config.connection_config[:url] = [Config.current.solr_host, Config.current.solr_core].join('/solr/')
       config.facet_fields = {}
       config.index_fields = {}
       config.show_fields = {}


### PR DESCRIPTION
ISSUE
If an admin creates a new active config with a different Solr host or core while the application is currently running, we need to re- set those values in the current blacklight controller.

FIX
Add code to reset the host and core whenever we update the active Blacklight configuration.