### PR TITLE
Remove dead code from `solr_host_responsive`

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -94,7 +94,7 @@ class Config < ApplicationRecord
     return false unless solr_host_looks_valid
 
     if fetch_solr_version.nil?
-      errors.add(:solr_host, 'did not return a valid Solr version') unless check_solr_version
+      errors.add(:solr_host, 'did not return a valid Solr version')
       return false
     end
 


### PR DESCRIPTION
We accidentally left an unassigned variable after our refactor, the resulting code effectively evaluates to:
`... unless nil`
So the line is always executed and we can remove the condition.