### PR TITLE
Add basic dashboard status page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,10 @@ Metrics/AbcSize:
   Exclude:
     - 'db/**/*'
 
+Metrics/BlockLength:
+  Exclude:
+    - 'config/routes.rb'
+
 Metrics/MethodLength:
   Exclude:
     - 'db/**/*'

--- a/app/controllers/admin/status_controller.rb
+++ b/app/controllers/admin/status_controller.rb
@@ -1,0 +1,8 @@
+module Admin
+  # Primary status landing page for administrative users
+  class StatusController < ApplicationController
+    def index
+      authorize! :read, :dashboard
+    end
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -72,9 +72,9 @@ class CatalogController < ApplicationController
     config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
     config.add_show_tools_partial(:citation)
 
+    config.add_nav_action(:dashoard, partial: 'blacklight/nav/status')
     config.add_nav_action(:bookmark, partial: 'blacklight/nav/bookmark', if: :render_bookmarks_control?)
     config.add_nav_action(:search_history, partial: 'blacklight/nav/search_history')
-    config.add_nav_action(:configs, partial: 'blacklight/nav/configs')
 
     # solr field configuration for document/show views
     # config.show.title_field = 'title_tsim'

--- a/app/views/admin/status/index.html.erb
+++ b/app/views/admin/status/index.html.erb
@@ -1,0 +1,6 @@
+<h1>System Status</h1>
+
+<h2>&nbsp;</h2>
+<h3>Solr Status: <%= Config&.current&.solr_version&.present? ? "connected" : "down" -%></h3>
+<h3>Solr Version: <%= Config.current.solr_version -%></h3>
+<h3>Users: <%= User.count -%></h3>

--- a/app/views/blacklight/nav/_configs.html.erb
+++ b/app/views/blacklight/nav/_configs.html.erb
@@ -1,3 +1,0 @@
-<%= link_to configs_path, id:'configs_nav', class: 'nav-link' do %>
-  <%= t('blacklight.header_links.configs') %>
-<% end %>

--- a/app/views/blacklight/nav/_status.html.erb
+++ b/app/views/blacklight/nav/_status.html.erb
@@ -1,0 +1,5 @@
+<% if controller.current_ability.can? :read, :dashboard -%>
+  <%= link_to status_path, id:'dashboard_nav', class: 'nav-link' do -%>
+    <%= t('t3.header_links.status') -%>
+  <% end -%>
+<% end -%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,6 @@
 
 en:
   hello: "Hello world"
+  t3:
+    header_links:
+      status: 'Dashboard'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'devise'
+require 'capybara/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -66,8 +67,8 @@ RSpec.configure do |config|
   # Add devise authentication support for tests
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
-  config.include Devise::Test::IntegrationHelpers, type: :feature
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::IntegrationHelpers, type: :system
 end
 
 # Speed up Devise user creation

--- a/spec/requests/admin/status_spec.rb
+++ b/spec/requests/admin/status_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin::Statuses' do
+  let(:stubbed_ability) { Ability.new(nil) }
+
+  before do
+    allow(Ability).to receive(:new).and_return(stubbed_ability)
+  end
+
+  describe 'GET /index for users with read dashboard ability' do
+    it 'returns http success' do
+      allow(stubbed_ability).to receive(:can?).with(:read, :dashboard).and_return(true)
+      get '/admin/status'
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  context 'with non-priveleged users' do
+    it 'returns http not_found' do
+      allow(stubbed_ability).to receive(:can?).with(:read, :dashboard).and_return(false)
+      get '/admin/status'
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/views/admin/status/index.html.erb_spec.rb
+++ b/spec/views/admin/status/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe 'status/index.html.erb' do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/blacklight/nav/_status.html.erb_spec.rb
+++ b/spec/views/blacklight/nav/_status.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'blacklight/nav/_status' do
+  example 'no link for users without read dashboard ability' do
+    allow(view.controller.current_ability).to receive(:can?).with(:read, :dashboard).and_return(false)
+    render
+    expect(rendered).not_to have_link(href: status_path)
+  end
+
+  it 'shows link for users with read dashboard ability' do
+    allow(view.controller.current_ability).to receive(:can?).with(:read, :dashboard).and_return(true)
+    render
+    expect(rendered).to have_link(href: status_path)
+  end
+end


### PR DESCRIPTION
This change adds
* A restricted admin status page (with very basic stats for now)
* A dashboard link in the header that displays only for admins

<img width="1087" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/d39d88fa-aacf-40aa-adab-5df9ec183103">
