### PR TITLE
Update application to use encrypted credentials

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -41,7 +41,7 @@ append :linked_dirs,
        'storage'
 
 # Files shared across deployments
-append :linked_files, 'config/secrets.yml'
+append :linked_files, 'config/master.key'
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
This change ensures that a private master.key file is persisted in the config directory across deployments made via Capistrano.

Rather than maintaining a separate secret_key_base in screts.yml, the value is now included in the encrypted credentials file.

The master.key value is stored outside the repository in a password management application and manually distrubuted to environments that require it.