### PR TITLE
Remove webdriver gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,5 +100,4 @@ group :test do
   gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'simplecov_json_formatter'
-  gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -423,10 +423,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -481,7 +477,6 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  webdrivers
 
 RUBY VERSION
    ruby 3.2.1p31


### PR DESCRIPTION
**ISSUE**
Chrome has changed it's release and distribution process for chromedriver causing the webdriver gem to fail with an error when trying to load chromedriver for versions > 114.x.y.

EXAMPLE
>  Failure/Error: raise VersionError, msg
>
>  Webdrivers::VersionError:
>    Unable to find latest point release version for 115.0.5790. You appear to be using a non-production version of Chrome. Plea

**RESOULUTION**
The webdriver gem is no longer require when using recent versions of selenium-webdriver.