### PR TITLE
Create System Roles on startup

### DIFF
--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -51,10 +51,14 @@ module Admin
     # DELETE /roles/1 or /roles/1.json
     def destroy
       @role.destroy
-
       respond_to do |format|
         format.html { redirect_to roles_url, notice: 'Role was successfully destroyed.' }
         format.json { head :no_content }
+      end
+    rescue ActiveRecord::ReadOnlyRecord
+      respond_to do |format|
+        format.html { redirect_to @role, alert: 'System Roles cannot be deleted.', status: :unprocessable_entity }
+        format.json { render json: 'System Roles cannot be deleted.', status: :unprocessable_entity }
       end
     end
 

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,8 +1,27 @@
 # Allows users to be grouped into roles
 # for access and authorizaion purposes
 class Role < ApplicationRecord
+  SYSTEM_ROLES = ['Super Admin', 'User Manager', 'Brand Manager', 'System Manager'].freeze
   validates :name, presence: true
   validates :name, uniqueness: true
 
   has_and_belongs_to_many :users
+
+  def delete
+    raise ActiveRecord::ReadOnlyRecord, 'Can not delete system Roles' if system?
+
+    super
+  end
+
+  def self.system_roles
+    @system_roles || SYSTEM_ROLES.map { |name| Role.find_by(name: name) }
+  end
+
+  def system?
+    @system ||= self.class.system_roles.include?(self)
+  end
+
+  def readonly?
+    system? || super
+  end
 end

--- a/config/initializers/default_records.rb
+++ b/config/initializers/default_records.rb
@@ -1,7 +1,14 @@
 # Re-initialize default records (using database seeds)
 Rails.application.config.after_initialize do
   if ActiveRecord::Base.connection.table_exists? 'roles'
-    Role.create_with(description: 'Full administrative privleges').find_or_create_by(name: 'Super Admin')
+    Role.create_with(description: 'Full administrative privleges')
+        .find_or_create_by(name: 'Super Admin')
+    Role.create_with(description: 'Manages users and roles')
+        .find_or_create_by(name: 'User Manager')
+    Role.create_with(description: 'Manages visual styling and infomrational content')
+        .find_or_create_by(name: 'Brand Manager')
+    Role.create_with(description: 'Manages system configuration and defaults')
+        .find_or_create_by(name: 'System Manager')
   end
 rescue ActiveRecord::NoDatabaseError
   # database doesn't exist, don't try to do this yet

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -28,4 +28,35 @@ RSpec.describe Role do
     role = FactoryBot.create(:role)
     expect(role.users).to be_empty
   end
+
+  describe '.system_roles' do
+    it 'returns a list of persistent (system) roles' do
+      expect(described_class.system_roles.map(&:class).uniq).to eq [described_class]
+    end
+
+    it 'includes the expected roles' do
+      expect(described_class.system_roles.map(&:name))
+        .to contain_exactly('Super Admin', 'User Manager', 'Brand Manager', 'System Manager')
+    end
+  end
+
+  describe 'a system role' do
+    let(:system_role) { described_class.system_roles.first }
+
+    it 'raises an error on deltion' do
+      expect { system_role.delete }.to raise_error(ActiveRecord::ReadOnlyRecord, /system Role/)
+    end
+
+    it 'cannot be destroyed' do
+      expect { system_role.destroy }.to raise_error(ActiveRecord::ReadOnlyRecord, /marked as readonly/)
+    end
+
+    it 'returns readonly? true' do
+      expect(system_role.readonly?).to be true
+    end
+
+    it 'returns system? true' do
+      expect(system_role.system?).to be true
+    end
+  end
 end

--- a/spec/requests/admin/roles_spec.rb
+++ b/spec/requests/admin/roles_spec.rb
@@ -110,6 +110,14 @@ RSpec.describe '/adim/roles' do
       delete role_url(role)
       expect(response).to redirect_to(roles_url)
     end
+
+    describe 'system roles' do
+      it 'cannot be deleted' do
+        role = Role.system_roles.first
+        delete role_url(role)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 
   describe 'resctricts access' do

--- a/spec/requests/admin/themes_spec.rb
+++ b/spec/requests/admin/themes_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe '/admin/themes' do
 
   describe 'DELETE /destroy' do
     it 'destroys the requested theme' do
+      Theme.current # ensure we have a current theme included in the initial count
       theme = Theme.create! valid_attributes
       expect do
         delete theme_url(theme)

--- a/spec/system/default_roles_spec.rb
+++ b/spec/system/default_roles_spec.rb
@@ -1,7 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe 'Default roles' do
-  it 'include "Super Admin"' do
+  example 'include "Super Admin"' do
     expect(Role.where(name: 'Super Admin')).to be_present
+  end
+
+  example 'include "User Manager"' do
+    expect(Role.where(name: 'User Manager')).to be_present
+  end
+
+  example 'include "System Manager"' do
+    expect(Role.where(name: 'System Manager')).to be_present
+  end
+
+  example 'include "Brand Manager"' do
+    expect(Role.where(name: 'Brand Manager')).to be_present
   end
 end


### PR DESCRIPTION
This change adds an initilizer that will create records for each system role at initialization if one does not already exist.

This change also prevents the deletion of system roles.