### PR TITLE
Allow administrator to assign roles to user

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -26,7 +26,7 @@ module Admin
 
       respond_to do |format|
         if @user.save
-          format.html { redirect_to user_url(@user), notice: 'User was successfully created.' }
+          format.html { redirect_to user_url(@user) }
           format.json { render :show, status: :created, location: @user }
         else
           format.html { render :new, status: :unprocessable_entity }
@@ -39,7 +39,7 @@ module Admin
     def update
       respond_to do |format|
         if @user.update(user_params)
-          format.html { redirect_to user_url(@user), notice: 'User was successfully updated.' }
+          format.html { redirect_to user_url(@user) }
           format.json { render :show, status: :ok, location: @user }
         else
           format.html { render :edit, status: :unprocessable_entity }
@@ -69,6 +69,7 @@ module Admin
     def user_params
       params.fetch(:user, {})
       params.require(:user).permit(:email, :display_name, :password)
+      params.require(:user).permit(:email, :display_name, :password, role_ids: [])
     end
   end
 end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: user) do |form| %>
   <% if user.errors.any? %>
-    <div style="color: red">
+    <div class='user_errors card'>
       <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>
 
       <ul>
@@ -21,9 +21,18 @@
     <%= form.text_field :display_name %>
   </div>
 
-  <div>
+  <% if action_name == 'new' %>
     <%= form.label :password, style: "display: block" %>
     <%= form.password_field :password %>
+  <% end %>
+
+  <div>
+    <%= form.label 'role_ids[]', 'Roles', style: "display: block" %>
+    <%= collection_check_boxes(:user, :role_ids, Role.all, :id, :name) do |b| %>
+      <%= b.check_box %>
+      <%= b.label %>
+      <br>
+    <% end %>
   </div>
 
   <div>

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -86,6 +86,17 @@ RSpec.describe '/admin/users' do
         user.reload
         expect(response).to redirect_to(user_url(user))
       end
+
+      it 'can update role associations', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+        system_role = Role.find_by(name: 'System Manager')
+        user_role = Role.find_by(name: 'User Manager')
+        super_role = Role.find_by(name: 'Super Admin')
+
+        expect(super_admin.roles).to contain_exactly(super_role)
+        patch user_url(super_admin), params: { user: { role_ids: ['', user_role.id.to_s, system_role.id.to_s] } }
+        super_admin.reload
+        expect(super_admin.roles).to contain_exactly(user_role, system_role)
+      end
     end
 
     context 'with invalid parameters' do

--- a/spec/views/admin/users/edit.html.erb_spec.rb
+++ b/spec/views/admin/users/edit.html.erb_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/users/edit' do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.build(:user) }
 
   before do
     assign(:user, user)
   end
 
   it 'renders new user form' do
+    user.save!
     render
     expect(rendered).to have_selector("form[@action='#{user_path(user)}']")
   end
@@ -22,8 +23,31 @@ RSpec.describe 'admin/users/edit' do
     expect(rendered).to have_field(id: 'user_display_name')
   end
 
+  it 'does not have a password field' do
+    render
+    expect(rendered).not_to have_field(id: 'user_password')
+  end
+
   it 'has a submit button' do
     render
     expect(rendered).to have_button(type: 'submit')
+  end
+
+  describe 'role checkbox' do
+    let(:user) { FactoryBot.build(:super_admin) }
+
+    it 'is checked for assigned roles' do
+      # the super_admin factory should assign at least one role to the user
+      role_id = "user_role_ids_#{user.roles.first.id}"
+      render
+      expect(rendered).to have_checked_field(role_id)
+    end
+
+    it 'is unchecked for unassigned roles' do
+      # create a new role that can't be assigned to any user yet
+      role_id = "user_role_ids_#{FactoryBot.create(:role).id}"
+      render
+      expect(rendered).to have_unchecked_field(role_id)
+    end
   end
 end

--- a/spec/views/admin/users/new.html.erb_spec.rb
+++ b/spec/views/admin/users/new.html.erb_spec.rb
@@ -21,8 +21,15 @@ RSpec.describe 'admin/users/new' do
   end
 
   it 'accepts a password' do
+    allow(view).to receive(:action_name).and_return('new')
     render
     expect(rendered).to have_field(id: 'user_password')
+  end
+
+  it 'has checkboxes for available roles' do
+    role_id = "user_role_ids_#{Role.last.id}"
+    render
+    expect(rendered).to have_unchecked_field(role_id)
   end
 
   it 'has a submit button' do


### PR DESCRIPTION
This change adds checkboxes for available roles to the user creation and edit forms.

An administrator with the permission to
manage users can select or de-select which roles should be assigned to a user.

<img width="743" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/61d27a70-075d-4251-ac7b-79d07a68c6d3">
