### PR TITLE
Allow User Managers to invite new users via e-mail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,16 +6,19 @@ ruby '3.2.1'
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.0.4', '>= 7.0.4.3'
 
-# Blacklight search and discovery engine using Devise for user auth
+# Blacklight search and discovery engine
 gem 'blacklight', '~> 8.0'
 gem 'bootstrap', '5.3.0.alpha3'
+gem 'rsolr', '>= 1.0', '< 3'
+gem 'sassc-rails', '~> 2.1'
+
+# Use Devise + OmniAuth for user authentication
 gem 'devise'
 gem 'devise-guests', '~> 0.8'
+gem 'devise_invitable', '~> 2.0'
 gem 'omniauth'
 gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection'
-gem 'rsolr', '>= 1.0', '< 3'
-gem 'sassc-rails', '~> 2.1'
 
 # Implement user authorization within the app
 gem 'cancancan'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,9 @@ GEM
       warden (~> 1.2.3)
     devise-guests (0.8.1)
       devise
+    devise_invitable (2.0.8)
+      actionmailer (>= 5.0)
+      devise (>= 4.6)
     diff-lcs (1.5.0)
     docile (1.4.0)
     domain_name (0.5.20190701)
@@ -485,6 +488,7 @@ DEPENDENCIES
   debug
   devise
   devise-guests (~> 0.8)
+  devise_invitable (~> 2.0)
   factory_bot_rails
   faker
   importmap-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,14 +7,14 @@ class ApplicationController < ActionController::Base
   rescue_from CanCan::AccessDenied do |_exception|
     respond_to do |format|
       if current_user
-        message = 'You are not authorized to access the requested item'
+        file = Rails.public_path.join('422.html')
         status = :unauthorized
       else
-        message = 'The page cannot be found'
+        file = Rails.public_path.join('404.html')
         status = :not_found
       end
       format.json { render nothing: true, status: :not_found }
-      format.html { redirect_to main_app.root_url, alert: message, status: status }
+      format.html { render file: file, status: status }
       format.js   { render nothing: true, status: :not_found }
     end
   end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,0 +1,18 @@
+module Users
+  # Subclass with restrictions on which users can invite others
+  class InvitationsController < Devise::InvitationsController
+    def authenticate_inviter!
+      return unless cannot? :create, User
+
+      render file: Rails.public_path.join('422.html'), status: :unprocessable_entity
+    end
+
+    def current_inviter
+      current_user
+    end
+
+    def after_invite_path_for(_inviter, _invitee)
+      users_path
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :invitable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: [:google]
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -17,4 +17,4 @@
   </table>
 </div>
 
-<%= link_to "New User", new_user_path %>
+<%= link_to "Invite New User", new_user_invitation_path, id: 'invite_user', class: 'btn btn-primary' %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -26,7 +26,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'systems@curationexperts.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -137,6 +137,55 @@ Devise.setup do |config|
 
   # Send a notification email when the user's password is changed.
   # config.send_password_change_notification = false
+
+  # ==> Configuration for :invitable
+  # The period the generated invitation token is valid.
+  # After this period, the invited resource won't be able to accept the invitation.
+  # When invite_for is 0 (the default), the invitation won't expire.
+  config.invite_for = 1.week
+
+  # Number of invitations users can send.
+  # - If invitation_limit is nil, there is no limit for invitations, users can
+  # send unlimited invitations, invitation_limit column is not used.
+  # - If invitation_limit is 0, users can't send invitations by default.
+  # - If invitation_limit n > 0, users can send n invitations.
+  # You can change invitation_limit column for some users so they can send more
+  # or less invitations, even with global invitation_limit = 0
+  # Default: nil
+  # config.invitation_limit = 5
+
+  # The key to be used to check existing users when sending an invitation
+  # and the regexp used to test it when validate_on_invite is not set.
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/ }
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/, username: nil }
+
+  # Ensure that invited record is valid.
+  # The invitation won't be sent if this check fails.
+  # Default: false
+  # config.validate_on_invite = true
+
+  # Resend invitation if user with invited status is invited again
+  # Default: true
+  # config.resend_invitation = false
+
+  # The class name of the inviting model. If this is nil,
+  # the #invited_by association is declared to be polymorphic.
+  # Default: nil
+  # config.invited_by_class_name = 'User'
+
+  # The foreign key to the inviting model (if invited_by_class_name is set)
+  # Default: :invited_by_id
+  # config.invited_by_foreign_key = :invited_by_id
+
+  # The column name used for counter_cache column. If this is nil,
+  # the #invited_by association is declared without counter_cache.
+  # Default: nil
+  # config.invited_by_counter_cache = :invitations_count
+
+  # Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite.
+  # Default: true
+  # config.allow_insecure_sign_in_after_accept = false
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -1,0 +1,31 @@
+en:
+  devise:
+    failure:
+      invited: "You have a pending invitation, accept it to finish creating your account."
+    invitations:
+      send_instructions: "An invitation email has been sent to %{email}."
+      invitation_token_invalid: "The invitation token provided is not valid!"
+      updated: "Your password was set successfully. You are now signed in."
+      updated_not_active: "Your password was set successfully."
+      no_invitations_remaining: "No invitations remaining"
+      invitation_removed: "Your invitation was removed."
+      new:
+        header: "Send invitation"
+        submit_button: "Send an invitation"
+      edit:
+        header: "Set your password"
+        submit_button: "Set my password"
+    mailer:
+      invitation_instructions:
+        subject: "Invitation instructions"
+        hello: "Hello %{email}"
+        someone_invited_you: "Someone has invited you to %{url}, you can accept it through the link below."
+        accept: "Accept invitation"
+        accept_until: "This invitation will be due in %{due_date}."
+        ignore: "If you don't want to accept the invitation, please ignore this email. Your account won't be created until you access the link above and set your password."
+  time:
+    formats:
+      devise:
+        mailer:
+          invitation_instructions:
+            accept_until_format: "%B %d, %Y %I:%M %p"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,8 @@ Rails.application.routes.draw do
     concerns :searchable
   end
 
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks',
+                                    invitations: 'users/invitations' }
 
   concern :exportable, Blacklight::Routes::Exportable.new
 

--- a/db/migrate/20230803141429_add_devise_invitable_to_users.rb
+++ b/db/migrate/20230803141429_add_devise_invitable_to_users.rb
@@ -1,0 +1,23 @@
+class AddDeviseInvitableToUsers < ActiveRecord::Migration[7.0]
+  def up
+    change_table :users, bulk: true do |t|
+      t.string     :invitation_token
+      t.datetime   :invitation_created_at
+      t.datetime   :invitation_sent_at
+      t.datetime   :invitation_accepted_at
+      t.integer    :invitation_limit
+      t.references :invited_by, polymorphic: true
+      t.integer    :invitations_count, default: 0
+      t.index      :invitation_token, unique: true # for invitable
+      t.index      :invited_by_id
+    end
+  end
+
+  def down
+    change_table :users, bulk: true do |t|
+      t.remove_references :invited_by, polymorphic: true
+      t.remove :invitations_count, :invitation_limit, :invitation_sent_at, :invitation_accepted_at, :invitation_token,
+               :invitation_created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_25_165617) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_03_141429) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -113,7 +113,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_165617) do
     t.string "uid"
     t.string "provider"
     t.string "display_name"
+    t.string "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.string "invited_by_type"
+    t.bigint "invited_by_id"
+    t.integer "invitations_count", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
+    t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by"
     t.index ["provider"], name: "index_users_on_provider"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid"], name: "index_users_on_uid"

--- a/spec/requests/users/invitations_spec.rb
+++ b/spec/requests/users/invitations_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Users::InvitationsController' do
+  let(:super_admin)  { FactoryBot.create(:super_admin) }
+  let(:regular_user) { FactoryBot.create(:user) }
+
+  before { login_as super_admin }
+
+  describe 'POST users/invitations' do
+    it 'creates a new user' do
+      expect do
+        post user_invitation_path, params: { user: { email: 'invitee@example.org' } }
+      end.to change(User, :count).by(1)
+    end
+
+    it 'sends an invitation e-mail', :aggregate_failures do
+      post user_invitation_path, params: { user: { email: 'invitee@example.org' } }
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.to).to eq(['invitee@example.org'])
+      expect(mail.subject).to eq('Invitation instructions')
+    end
+
+    it 'redirects to admin/users' do
+      post user_invitation_path, params: { user: { email: 'invitee@example.org' } }
+      expect(response).to redirect_to users_path
+    end
+  end
+
+  it 'restricts unauthorized users' do
+    login_as regular_user # who does not have user management abilities
+    post user_invitation_path, params: { user: { email: 'invitee@example.org' } }
+    expect(response).to be_unprocessable
+  end
+end

--- a/spec/views/admin/users/index.html.erb_spec.rb
+++ b/spec/views/admin/users/index.html.erb_spec.rb
@@ -19,4 +19,9 @@ RSpec.describe 'admin/users/index' do
     render
     expect(rendered).to have_selector('td.display_name', text: users[0].display_name)
   end
+
+  it 'has a link to invite new users' do
+    render
+    expect(rendered).to have_link(:invite_user, href: new_user_invitation_path)
+  end
 end


### PR DESCRIPTION
This change adds the [devise_invitable](https://github.com/scambra/devise_invitable) gem to generate user invitations and send them via e-mail.

The current implementation allows new local (database) users to be invited.  OminAuth (Google) users can not be sucessfully invited with the current code.