### PR TITLE
Set "provider" to "local" for database users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,11 @@ class User < ApplicationRecord
   # the account.
   self.string_display_key ||= :email
 
+  def initialize(attributes = nil)
+    super
+    self.provider ||= 'local'
+  end
+
   def self.from_omniauth(auth)
     provider = auth.provider
     uid = auth.uid

--- a/db/migrate/20230803213844_set_default_provider_on_users.rb
+++ b/db/migrate/20230803213844_set_default_provider_on_users.rb
@@ -1,0 +1,9 @@
+class SetDefaultProviderOnUsers < ActiveRecord::Migration[7.0]
+  def up
+    User.where(provider: nil).update_all(provider: 'local') # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def down
+    User.where(provider: 'local').update_all(provider: nil) # rubocop:disable Rails/SkipsModelValidations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_03_141429) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_03_213844) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe User do
   let(:guest) { FactoryBot.create(:guest) }
   let(:role) { FactoryBot.create(:role) }
 
+  it 'defaults provider to "local"' do
+    expect(described_class.new.provider).to eq 'local'
+  end
+
+  it 'does not change passed provider' do
+    expect(described_class.new(provider: 'imported').provider).to eq 'imported'
+  end
+
   describe '#roles' do
     it 'returns an empty array when initialized' do
       expect(user.roles).to be_empty
@@ -20,7 +28,6 @@ RSpec.describe User do
   describe '#role_name?' do
     it 'is true for users with the named role' do
       user.roles << role
-      user.save!
       expect(user.role_name?(role.name)).to be true
     end
 


### PR DESCRIPTION
We want to show the "account type" in the user index.  We can use the provider name, e.g. 'google', for OmniAuth accounts, but database accounts previously had the provider set to `nil`.

Rather than writing a helper that checks for nil every time we want to display the user's account type, i.e. nil => 'local', we chose to set the value once when the user is initialized.  Now we can just display the provider value directly.