### PR TITLE
Allow User Managers to send password reset instructions

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   # Manage Users
   class UsersController < ApplicationController
-    before_action :set_user, only: %i[show edit update destroy]
+    before_action :set_user, only: %i[show edit update destroy password_reset]
     load_and_authorize_resource
 
     # GET /admin/users or /admin/users.json
@@ -58,6 +58,19 @@ module Admin
       end
     end
 
+    # POST /admin/users/1/password_reset
+    def password_reset
+      respond_to do |format|
+        if @user.password_reset
+          format.html { redirect_to users_url, notice: password_reset_successfully }
+          format.json { render :show, status: :ok, location: @user }
+        else
+          format.html { redirect_to users_url, alert: password_reset_failed, status: :unprocessable_entity }
+          format.json { render json: @user.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
     private
 
     # Use callbacks to share common setup or constraints between actions.
@@ -70,6 +83,16 @@ module Admin
       params.fetch(:user, {})
       params.require(:user).permit(:email, :display_name, :password)
       params.require(:user).permit(:email, :display_name, :password, role_ids: [])
+    end
+
+    # Successfuly reset password message
+    def password_reset_successfully
+      "Password reset e-mail sent to #{@user.email}"
+    end
+
+    # Password reset failure message
+    def password_reset_failed
+      @user.errors.full_messages.join("\n")
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,8 +37,8 @@ class User < ApplicationRecord
       .find_or_create_by!(provider: provider, uid: uid)
   end
 
-  def self.dummy_password
-    Devise.friendly_token(20)
+  def local?
+    provider == 'local'
   end
 
   def role_name?(name)
@@ -47,5 +47,18 @@ class User < ApplicationRecord
 
   def role_names
     @role_names ||= roles.map(&:name)
+  end
+
+  def password_reset
+    if local?
+      send_reset_password_instructions
+    else # Can't reset OmniAuth account passwords
+      errors.add(:base, :remote_password_reset, message: "User must change their password via #{provider.titlecase}.")
+    end
+    errors.empty?
+  end
+
+  def self.dummy_password
+    Devise.friendly_token(20)
   end
 end

--- a/app/views/admin/users/_admin_user.json.jbuilder
+++ b/app/views/admin/users/_admin_user.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! admin_user, :id, :created_at, :updated_at
-json.url admin_user_url(admin_user, format: :json)

--- a/app/views/admin/users/_user.json.jbuilder
+++ b/app/views/admin/users/_user.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! user, :id, :created_at, :updated_at
+json.url user_url(user, format: :json)

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -3,13 +3,17 @@
 <div id="users">
   <table>
     <tr>
-      <th>E-Mail</th>
-      <th>Display Name</th>
-      <th>Roles</th>
+      <th class='email'>E-Mail</th>
+      <th class='provider'>Type</th>
+      <th class='password'>Password</th>
+      <th class='display_name'>Display Name</th>
+      <th class='roles'>Roles</th>
     </tr>
     <% @users.each do |user| %>
       <tr id='<%= dom_id user %>'>
         <td class='email'><%= link_to user.email, user -%></td>
+        <td class='provider'><%= user.provider -%></td>
+        <td class='password'><%= link_to('Send Reset', user_password_reset_path(user), id: dom_id(user, :password_reset), data: { turbo_method: "post" }) if user.local? -%></td>
         <td class='display_name'><%= user.display_name -%></td>
         <td class='roles'><%= user.roles.map(&:name).join(', ') -%></td>
       </tr>

--- a/app/views/admin/users/index.json.jbuilder
+++ b/app/views/admin/users/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @admin_users, partial: 'admin_users/admin_user', as: :admin_user
+json.array! @users, partial: 'user', as: :user

--- a/app/views/admin/users/show.json.jbuilder
+++ b/app/views/admin/users/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'admin_users/admin_user', admin_user: @admin_user
+json.partial! 'user', user: @user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
 
   scope path: '/admin', module: :admin do
     get :status, to: 'status#index'
+    post 'users/:id/password_reset', to: 'users#password_reset', as: :user_password_reset
     resources :users
     resources :roles
     resources :themes do

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -41,6 +41,22 @@ RSpec.describe '/admin/users' do
     end
   end
 
+  describe 'POST /password/reset', :aggregate_failures do
+    it 'sends reset instructions to the user' do
+      post user_password_reset_path(regular_user)
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.subject).to eq I18n.t('devise.mailer.reset_password_instructions.subject')
+      expect(regular_user.reload.reset_password_token).not_to be_nil
+    end
+
+    it 'does not send to OAuth accounts' do
+      regular_user.provider = 'omni_auth_provider'
+      regular_user.save!
+      post user_password_reset_path(regular_user), headers: { accept: 'application/json' }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
   describe 'POST /create' do
     context 'with valid parameters' do
       it 'creates a new User' do

--- a/spec/routing/admin/users_routing_spec.rb
+++ b/spec/routing/admin/users_routing_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Admin::UsersController do
       expect(get: '/admin/users/1/edit').to route_to('admin/users#edit', id: '1')
     end
 
+    it 'routes to #password_reset' do
+      expect(post: '/admin/users/1/password_reset').to route_to('admin/users#password_reset', id: '1')
+    end
+
     it 'routes to #create' do
       expect(post: '/admin/users').to route_to('admin/users#create')
     end

--- a/spec/views/admin/users/index.html.erb_spec.rb
+++ b/spec/views/admin/users/index.html.erb_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/users/index' do
-  let(:users) { (1..3).collect { FactoryBot.build(:user) } }
+  let(:users) { (0..3).collect { |i| FactoryBot.build(:user, id: i) } }
 
   before { assign(:users, users) }
 
   it 'renders a list of users' do
     render
-    expect(rendered).to have_selector('tr', count: 4) # users +1 for header row
+    expect(rendered).to have_selector('td.email', count: 4) # four users total
   end
 
   it 'links to the user object' do
@@ -18,6 +18,19 @@ RSpec.describe 'admin/users/index' do
   it 'displays the display_name for each user' do
     render
     expect(rendered).to have_selector('td.display_name', text: users[0].display_name)
+  end
+
+  describe 'password reset links' do
+    example 'for database users' do
+      render
+      expect(rendered).to have_link(id: :password_reset_user_1, href: user_password_reset_path(users[1]))
+    end
+
+    example 'not for other providers' do
+      users[2].provider = 'google'
+      render
+      expect(rendered).not_to have_link(id: :password_reset_user_2)
+    end
   end
 
   it 'has a link to invite new users' do


### PR DESCRIPTION
We want a method to allow authorized users (i.e User Managers and Super Admins) to trigger a new password for repository users.

The current changes allow the user manager to send a password reset link to a specified user via e-mail.  The existing password remains valid until the user changes it via the link.

OmniAuth users must reset their passwords directly via their provider.

This commit includes the following:
* A password update method on the user class
* A new route & controller method to handle user password reset requests
* Updates to the admin dashboard user index to show reset links
* Updates to the JSON views for users to fix previously broken code