### PR TITLE
Refactor dynamic field configuration

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -241,22 +241,6 @@ class CatalogController < ApplicationController
     # config.autocomplete_suggester = 'mySuggester'
   end
 
-  def self.update_config # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
-    configure_blacklight do |config|
-      config.connection_config[:url] = [Config.current.solr_host, Config.current.solr_core].join('/solr/')
-      config.facet_fields = {}
-      config.index_fields = {}
-      config.show_fields = {}
-      Config.current.enabled_fields.each do |f|
-        config.add_facet_field f.solr_field_name, label: f.display_label if f.facetable
-        config.add_index_field f.solr_field_name, label: f.display_label if f.search_results
-        config.add_show_field f.solr_field_name, label: f.display_label if f.item_view
-        config.index.title_field = f.solr_field_name if f.display_label.match(/^Title/)
-      end
-    end
-  end
-
-  # Add dynaically configured fields first, so they appear ahead of any statically
-  # configured fields
-  update_config
+  # Apply any dynamic field configurations from the current configuration record
+  Config.current.update_catalog_controller
 end

--- a/spec/models/config_spec.rb
+++ b/spec/models/config_spec.rb
@@ -188,50 +188,9 @@ RSpec.describe Config, :aggregate_failures do
     end
   end
 
-  context 'with scope-like methods for fields' do
-    before do
-      config.fields = []
-      # NOTE: facetable defaults to `false` so we're turning it on explicity so the
-      # facet test looks like the others
-      5.times { |i| config.fields.push(FieldConfig.new(solr_field_name: "field#{i}", facetable: true)) }
-    end
-
-    describe '#search_fields' do
-      it 'returns fields that should be searched, in order' do
-        config.fields[3].enabled = false
-        config.fields[0].searchable = false
-        expect(config.search_fields.map(&:solr_field_name)).to eq ['field1', 'field2', 'field4']
-      end
-    end
-
-    describe '#facet_fields' do
-      it 'returns fields that should be faceted, in order' do
-        config.fields[1].enabled = false
-        config.fields[2].facetable = false
-        expect(config.facet_fields.map(&:solr_field_name)).to eq ['field0', 'field3', 'field4']
-      end
-    end
-
-    describe '#index_fields' do
-      it 'returns fields that should appear in search results, in order' do
-        config.fields[2].enabled = false
-        config.fields[4].search_results = false
-        expect(config.index_fields.map(&:solr_field_name)).to eq ['field0', 'field1', 'field3']
-      end
-    end
-
-    describe '#show_fields' do
-      it 'returns fields that should appear in the single item view, in order' do
-        config.fields[4].enabled = false
-        config.fields[0].item_view = false
-        expect(config.show_fields.map(&:solr_field_name)).to eq ['field1', 'field2', 'field3']
-      end
-    end
-  end
-
   it 'updates the catalog controller on saves' do
-    allow(CatalogController).to receive(:update_config)
+    allow(config).to receive(:update_catalog_controller)
     config.save!
-    expect(CatalogController).to have_received(:update_config)
+    expect(config).to have_received(:update_catalog_controller)
   end
 end


### PR DESCRIPTION
This commit moves the dynamic mapping of catalog fields from the CatalogController to the Config class. This reduces complexity in the CatalogController and moves the mapping into the persistence object where it fits better. (e.g. no more obsessive calls to `Config.current...`)

A group of Config methods that have become obsolete through the evolution of the `update_catalog_controller` have also been removed in this change.