### PR TITLE
Add validations and testing to Themes

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -18,6 +18,10 @@ class Theme < ApplicationRecord
 
   has_one_attached :main_logo
 
+  validates :label, presence: true
+  validates :header_color, :header_text_color, :background_color, :background_accent_color,
+            format: { with: /\A#[0-9a-f]{6}\z/i, message: "'%<value>s' is not in hex #RRGGBB format" }
+
   before_destroy :confirm_inactive
   after_save :refresh_current
 

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -1,6 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe Theme do
+  let(:theme) { described_class.new }
+
+  describe 'validation' do
+    it 'passes for class defaults' do
+      expect(theme).to be_valid
+    end
+
+    it 'requres a label' do
+      theme.label = nil
+      expect(theme).not_to be_valid
+    end
+
+    it 'requires colors to have hex #RRGGBB format' do
+      theme.header_color = 'white' # css color names are not valid
+      theme.validate
+      expect(theme.errors[:header_color]).to include "'white' is not in hex #RRGGBB format"
+    end
+
+    it 'does not accepts rgba color format' do
+      theme.header_text_color = '#8090ff80' # rgba values are not valid
+      expect(theme).not_to be_valid
+    end
+  end
+
   describe '.current' do
     context 'with no saved themes' do
       before do
@@ -90,13 +114,14 @@ RSpec.describe Theme do
     end
   end
 
-  describe '.main_logo' do
+  describe '#main_logo' do
     it 'is empty on new themes' do
-      expect(described_class.new.main_logo).not_to be_attached
+      expect(theme.main_logo).not_to be_attached
     end
 
-    it 'is a kind of ActiveStorage blob' do
-      expect(described_class.new.main_logo).not_to be_a ActiveStorage::Blob
+    it 'accepts ActiveStorage attachments' do
+      theme.main_logo.attach(fixture_file_upload('sample_logo.png'))
+      expect(theme.main_logo).to be_a ActiveStorage::Attached::One
     end
   end
 end

--- a/spec/requests/admin/themes_spec.rb
+++ b/spec/requests/admin/themes_spec.rb
@@ -17,11 +17,7 @@ RSpec.describe '/admin/themes' do
   # Theme. As you add validations to Theme, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) { { label: 'Test Theme' } }
-
-  let(:invalid_attributes) do
-    skip 'wait until the class requires some type of validation'
-  end
-
+  let(:invalid_attributes) { { label: nil, header_color: 'white' } }
   let(:super_admin) { FactoryBot.create(:super_admin) }
 
   before { login_as super_admin }

--- a/spec/views/admin/themes/edit.html.erb_spec.rb
+++ b/spec/views/admin/themes/edit.html.erb_spec.rb
@@ -1,16 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/themes/edit' do
-  let(:theme) do
-    Theme.create!(
-      label: 'MyString',
-      site_name: 'MyString',
-      header_color: 'MyString',
-      header_text_color: 'MyString',
-      background_color: 'MyString',
-      background_accent_color: 'MyString'
-    )
-  end
+  let(:theme) { FactoryBot.build(:theme) }
 
   before do
     assign(:theme, theme)


### PR DESCRIPTION
* Adds validation for Theme labels (must be present)
* Adds validation for Theme colors (must be in HTML #RRGGBB hex format)
* Adds request tests for invalid Theme values
* Fixes Theme logo attachment test
* Fixes vies spec broken by added validations