### PR TITLE
Refactor to add test coverage and remove dead code

### DIFF
--- a/app/components/t3/search_bar_component.rb
+++ b/app/components/t3/search_bar_component.rb
@@ -44,17 +44,6 @@ module T3
       @autocomplete_path
     end
 
-    def autofocus
-      if @autofocus.nil?
-        blacklight_config.enable_search_bar_autofocus &&
-          controller.is_a?(Blacklight::Catalog) &&
-          controller.action_name == 'index' &&
-          !controller.has_search_parameters?
-      else
-        @autofocus
-      end
-    end
-
     def search_fields
       @search_fields ||= blacklight_config.search_fields.values
                                           .select { |field_def| helpers.should_render_field?(field_def) }

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -51,14 +51,10 @@ module Admin
 
     # PATCH /themes/1/activate or /themes/1/activate.json
     def activate
+      @theme.activate! # always succeeds and returns itself
       respond_to do |format|
-        if @theme.activate!
-          format.html { redirect_to theme_url(@theme) }
-          format.json { render :show, status: :ok, location: @theme }
-        else
-          format.html { render :edit, status: :unprocessable_entity }
-          format.json { render json: @theme.errors, status: :unprocessable_entity }
-        end
+        format.html { redirect_to theme_url(@theme) }
+        format.json { render :show, status: :ok, location: @theme }
       end
     end
 

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -94,6 +94,21 @@ RSpec.describe '/admin/configs' do
       end
     end
 
+    context 'with valid host and core' do
+      let(:step_attributes) do
+        { setup_step: 'core', solr_host: 'http://localhost:8983', solr_verison: '9.2.1', solr_core: 'tenejo' }
+      end
+
+      it 'saves the new config' do
+        expect { post configs_url, params: { config: step_attributes } }.to change(Config, :count).by(1)
+      end
+
+      it 'redirects to the newly created config' do
+        post configs_url, params: { config: step_attributes }
+        expect(response).to redirect_to Config.last
+      end
+    end
+
     context 'with valid parameters' do
       it 'creates a new Config' do
         expect do

--- a/spec/requests/admin/themes_spec.rb
+++ b/spec/requests/admin/themes_spec.rb
@@ -153,14 +153,11 @@ RSpec.describe '/admin/themes' do
   end
 
   describe 'PATCH /activate' do
-    let(:theme) { Theme.create! valid_attributes }
-    let(:patched) { Theme.new valid_attributes }
-
-    it 'calls #activate! on the theme' do
-      allow(Theme).to receive(:find).and_return(patched)
-      allow(patched).to receive(:activate!)
-      patch activate_theme_url(theme)
-      expect(patched).to have_received(:activate!)
+    it 'updates the current theme' do
+      old_theme = FactoryBot.create(:theme)
+      old_theme.activate!
+      new_theme = FactoryBot.create(:theme)
+      expect { patch activate_theme_url(new_theme) }.to change(Theme, :current).from(old_theme).to(new_theme)
     end
   end
 


### PR DESCRIPTION
* Adds tests for multi-step Config setup form
* Removes failure path for Theme#activate that can never be reached
* Removes SearchBarComponent#autofocus method that is no longer called
* Refactors Theme#activate test for fuller code coverage