### PR TITLE
Add Certificate model to encapsulate low-level TLS management

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -1,0 +1,58 @@
+# Wrapper to look up and read HTTPS (TLS) certificates
+class Certificate
+  DOMAIN_PATTERN = /(?<fqdn>(?:[a-z][a-z0-9-]{0,61}[a-z0-9]+\.)+[a-z0-9]{2,6})/i
+
+  include ActiveModel::API
+
+  attr_accessor :host, :x509cert
+
+  validates :host, presence: true
+  validates :host, format: { with: DOMAIN_PATTERN, message: 'must be a valid DNS hostname' }, allow_blank: true
+  validate :host_can_be_resolved
+  validates_each :x509cert do |rec, attr, val|
+    rec.errors.add(attr, :missing_certificate, message: "certificate not returned by #{rec.host}") if val == :error
+  end
+
+  delegate :subject, :not_after, to: :@x509cert
+
+  def initialize(attributes = nil)
+    super
+    @x509cert = fetch_cert(host)
+  end
+
+  # return the value of the CN portion of the subject as a domain string
+  def subject_cn
+    x509cert.subject.to_a.find { |e| e[0] = 'CN' }[1]
+  end
+
+  private
+
+  def fetch_cert(host)
+    return :error unless valid?
+
+    DefaultSession.fetch(host)
+  end
+
+  def host_can_be_resolved
+    return unless host&.match? DOMAIN_PATTERN
+    return if Resolv.getaddress(host).present?
+  rescue Resolv::ResolvError
+    errors.add(:host, :unresolvable, message: 'can not be resolved via DNS')
+  end
+
+  # Encapsulates Net::HTTP calls
+  # so that we can stub external dependencies in tests
+  class DefaultSession
+    def self.fetch(host)
+      http = Net::HTTP.new(host, 443)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      cert = nil
+      http.start { |h| cert = h.peer_cert }
+      cert || :error
+    rescue StandardError => e
+      Rails.logger.error(e)
+      :error
+    end
+  end
+end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe Certificate, :aggregate_failures do
+  let(:test_cert) do
+    OpenSSL::X509::Certificate.new.tap do |cert|
+      cert.version = 2
+      cert.serial = 1
+      cert.subject = OpenSSL::X509::Name.new([['CN', 'test.example.com'], ['O', 'example.com']])
+      cert.not_before = Time.current
+      cert.not_after = 5.minutes.from_now
+      ef = OpenSSL::X509::ExtensionFactory.new
+      ef.subject_certificate = cert
+      ef.issuer_certificate = cert
+      cert.add_extension(ef.create_extension('subjectAltName', 'DNS:host.example.com,DNS:text.example.com'))
+    end
+  end
+
+  # Convenience method to stub out remote calls for an
+  # HTTP-only host interaction
+  def stub_http_only_host
+    allow(Resolv).to receive(:getaddress).and_return('127.0.0.1')
+    http = Net::HTTP.new(host: 'host.example.com')
+    allow(http).to receive(:start).and_return(nil)
+    allow(Net::HTTP).to receive(:new).and_return(http)
+  end
+
+  # This one test makes live connections over the public internet
+  # to ensure our logic and syntax are valid. The remaining tests
+  # stub out all internet calls
+  it 'returns the certificate for a host' do
+    cert = described_class.new(host: 'status.circleci.com')
+    expect(cert).to be_valid
+    expect(cert.not_after).to be > Time.current
+  end
+
+  it 'requires a host' do
+    cert = described_class.new(host: nil)
+    expect(cert).not_to be_valid
+    expect(cert.errors.where(:host, :blank)).to be_present
+  end
+
+  it 'errors on invalid host names' do
+    cert = described_class.new(host: 'not_a_valid_hostname')
+    expect(cert).not_to be_valid
+    expect(cert.errors.where(:host, :invalid)).to be_present
+  end
+
+  it 'errors on unresolvable hosts' do
+    # stub Resolve call to simulate name resolution failure
+    allow(Resolv).to receive(:getaddress).and_raise(Resolv::ResolvError)
+    cert = described_class.new(host: 'my-machine.local')
+    expect(cert).not_to be_valid
+    expect(cert.errors.where(:host, :unresolvable)).to be_present
+  end
+
+  it 'errors on hosts without TLS certificates' do
+    stub_http_only_host
+
+    cert = described_class.new(host: 'host.example.com')
+    expect(cert).not_to be_valid
+    expect(cert.errors.where(:x509cert, :missing_certificate)).to be_present
+  end
+
+  it 'errors on NET::HTTP exceptions' do
+    # stub the resolution call for a non-live host
+    allow(Resolv).to receive(:getaddress).and_return('127.0.0.1')
+    allow(Net::HTTP).to receive(:start).and_raise(Net::HTTPError)
+
+    cert = described_class.new(host: 'host.example.com')
+    expect(cert).not_to be_valid
+    expect(cert.errors.where(:x509cert, :missing_certificate)).to be_present
+  end
+
+  describe 'with an x509 response' do
+    # Stub out host resolution and certificate calls so that we can
+    # run in isolation from external dependencies
+    before do
+      allow(Resolv).to receive(:getaddress).and_return('127.0.0.1')
+      allow(Certificate::DefaultSession).to receive(:fetch).and_return(test_cert)
+    end
+
+    example 'delegates #not_after' do
+      cert = described_class.new(host: 'host.example.com')
+      expect(cert.not_after).to be > Time.current
+    end
+
+    it 'delegates #subject' do
+      cert = described_class.new(host: 'host.example.com')
+      expect(cert.subject.to_s).to match 'test'
+    end
+
+    it 'extracts #subject_cn' do
+      cert = described_class.new(host: 'host.example.com')
+      expect(cert.subject_cn).to eq 'test.example.com'
+    end
+  end
+end


### PR DESCRIPTION
We want a handful of convience methods to interact with our custom domain settings and corresponding TLS certificates.  This new `Certificate` class lets us interact with X509 certificate data while hiding many of the lower-level library calls.