### PR TITLE
Add UI for managing Custom Domains

### DIFF
--- a/app/controllers/admin/custom_domains_controller.rb
+++ b/app/controllers/admin/custom_domains_controller.rb
@@ -1,0 +1,64 @@
+module Admin
+  # Manage custom domain names for the application
+  class CustomDomainsController < ApplicationController
+    # before_action :set_custom_domain, only: %i[show edit update destroy]
+    load_and_authorize_resource
+
+    # GET /admin/custom_domains or /admin/custom_domains.json
+    def index
+      @custom_domains = CustomDomain.all
+    end
+
+    # GET /admin/custom_domains/1 or /admin/custom_domains/1.json
+    def show; end
+
+    # GET /admin/custom_domains/new
+    def new
+      @custom_domain = CustomDomain.new
+    end
+
+    # GET /admin/custom_domains/1/edit
+    # Action Not Routable
+    # def edit; end
+
+    # POST /admin/custom_domains or /admin/custom_domains.json
+    def create
+      @custom_domain = CustomDomain.new(custom_domain_params)
+
+      respond_to do |format|
+        if @custom_domain.save
+          format.html { redirect_to custom_domains_url }
+          format.json { redirect_to custom_domains_url, format: :json }
+        else
+          format.html { render :new, status: :unprocessable_entity }
+          format.json { render json: @custom_domain.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    # PATCH/PUT /admin/custom_domains/1 or /admin/custom_domains/1.json
+    # Action Not Routable
+
+    # DELETE /admin/custom_domains/1 or /admin/custom_domains/1.json
+    def destroy
+      @custom_domain.destroy
+
+      respond_to do |format|
+        format.html { redirect_to custom_domains_url }
+        format.json { head :no_content }
+      end
+    end
+
+    private
+
+    # Use callbacks to share common setup or constraints between actions.
+    def set_custom_domain
+      @custom_domain = Admin::CustomDomain.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def custom_domain_params
+      params.require(:custom_domain).permit(:host)
+    end
+  end
+end

--- a/app/models/custom_domain.rb
+++ b/app/models/custom_domain.rb
@@ -1,0 +1,9 @@
+# Vanity Domains
+class CustomDomain < ApplicationRecord
+  validates :host, presence: true
+  validates :host, format: { with: Certificate::DOMAIN_PATTERN, message: 'must be a valid DNS hostname' },
+                   allow_blank: true
+  validate :host_can_be_resolved
+
+  def host_can_be_resolved; end
+end

--- a/app/views/admin/_sidebar.html.erb
+++ b/app/views/admin/_sidebar.html.erb
@@ -25,6 +25,11 @@
           <%= link_to t('t3.admin.configs'), configs_path, class: 'nav-link' + active_controller_class('configs') %>
         </li>
       <% end %>
+      <% if can? :read, CustomDomain %>
+        <li class='nav-item'>
+          <%= link_to t('t3.admin.custom_domains'), custom_domains_path, class: 'nav-link' + active_controller_class('custom_domains') %>
+        </li>
+      <% end %>
     </ul>
   </nav>
 <% end -%>

--- a/app/views/admin/custom_domains/_custom_domain.json.jbuilder
+++ b/app/views/admin/custom_domains/_custom_domain.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! custom_domain, :id, :host, :created_at, :updated_at
+json.url custom_domain_url(custom_domain, format: :json)

--- a/app/views/admin/custom_domains/_form.html.erb
+++ b/app/views/admin/custom_domains/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: custom_domain) do |form| %>
+  <% if custom_domain.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(custom_domain.errors.count, "error") %> prohibited this domain from being saved:</h2>
+
+      <ul>
+        <% custom_domain.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :host, style: "display: block" %>
+    <%= form.text_field :host %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/custom_domains/index.html.erb
+++ b/app/views/admin/custom_domains/index.html.erb
@@ -1,0 +1,24 @@
+<h1>Custom domains</h1>
+
+<div id='default_domain'>
+  <h2>Default Host</h2>
+  <p>default domain name and certificate info goes here...</p>
+</div>
+
+<div id="custom_domains">
+  <h2>Additional Domains</h2>
+  <table>
+    <tr>
+      <th class='host'>Host Name</th>
+      <th class='delete'></th>
+    </tr>
+    <% @custom_domains.each do |custom_domain| %>
+      <tr id='<%= dom_id custom_domain %>'>
+        <td class='host'><%= custom_domain.host -%></td>
+        <td class='delete'><%= button_to('Delete', custom_domain, method: :delete, id: dom_id(custom_domain, :delete), class: 'btn btn-danger btn-sm') -%></td>
+      </tr>
+    <% end %>
+  </table>
+</div>
+
+<%= link_to "New custom domain", new_custom_domain_path, id: 'new_domain', class: 'btn btn-primary btn-sm' %>

--- a/app/views/admin/custom_domains/index.json.jbuilder
+++ b/app/views/admin/custom_domains/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @custom_domains, partial: 'admin/custom_domains/custom_domain', as: :custom_domain

--- a/app/views/admin/custom_domains/new.html.erb
+++ b/app/views/admin/custom_domains/new.html.erb
@@ -1,0 +1,30 @@
+<h1>Add Custom Hostname</h1>
+
+<%= form_with(model: @custom_domain) do |form| %>
+  <% if @custom_domain.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(@custom_domain.errors.count, "error") %> prohibited this domain from being saved:</h2>
+
+      <ul>
+        <% @custom_domain.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :host, style: "display: block" %>
+    <%= form.text_field :host, autofocus: true %>
+  </div>
+
+  <div>
+    <%= form.submit 'Add new host' %>
+  </div>
+<% end %>
+
+<br>
+
+<div>
+  <%= link_to "Back to custom domains", custom_domains_path %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
       patch 'activate', on: :member
     end
     resources :configs
+    resources :custom_domains, except: %i[edit update show]
   end
 
   # When app is firt booted and no Solr config exists, use this as the application root

--- a/db/migrate/20230813190525_create_custom_domains.rb
+++ b/db/migrate/20230813190525_create_custom_domains.rb
@@ -1,0 +1,9 @@
+class CreateCustomDomains < ActiveRecord::Migration[7.0]
+  def change
+    create_table :custom_domains do |t|
+      t.string :host
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_03_213844) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_13_190525) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,6 +61,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_03_213844) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "solr_version"
+    t.string "custom_domain"
+    t.datetime "certificate_expiration"
+  end
+
+  create_table "custom_domains", force: :cascade do |t|
+    t.string "host"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "roles", force: :cascade do |t|

--- a/spec/factories/custom_domains.rb
+++ b/spec/factories/custom_domains.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :custom_domain, class: 'CustomDomain' do
+    host { Faker::Internet.domain_name(subdomain: true) }
+  end
+end

--- a/spec/models/custom_domain_spec.rb
+++ b/spec/models/custom_domain_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe CustomDomain do
+  let(:domain) { described_class.new }
+
+  it 'has a host attribute' do
+    expect(domain).to respond_to(:host=)
+  end
+end

--- a/spec/requests/admin/custom_domains_spec.rb
+++ b/spec/requests/admin/custom_domains_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+
+RSpec.describe '/admin/custom_domains' do
+  # This should return the minimal set of attributes required to create a valid
+  # CustomDomain. As you add validations to CustomDomain, be sure to
+  # adjust the attributes here as well.
+  let(:valid_attributes) { { host: 'my-host.example.com' } }
+  let(:invalid_attributes) { { host: 'not_a_valid_domain' } }
+
+  let(:super_admin)  { FactoryBot.create(:super_admin) }
+  let(:regular_user) { FactoryBot.create(:user) }
+
+  before do
+    # Stub DNS requests to isolate external services
+    allow(Resolv).to receive(:getaddress).and_return('10.10.0.1')
+    login_as super_admin
+  end
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      CustomDomain.create! valid_attributes
+      get custom_domains_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'does not respond' do
+      custom_domain = CustomDomain.create! valid_attributes
+      expect { get custom_domain_url(custom_domain) }.to raise_exception(ActionController::RoutingError)
+    end
+  end
+
+  describe 'GET /new' do
+    it 'renders a successful response' do
+      get new_custom_domain_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'does not respond' do
+      custom_domain = CustomDomain.create! valid_attributes
+      expect { get edit_custom_domain_url(custom_domain) }.to raise_exception(NoMethodError)
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new CustomDomain' do
+        expect do
+          post custom_domains_url, params: { custom_domain: valid_attributes }
+        end.to change(CustomDomain, :count).by(1)
+      end
+
+      it 'redirects to the created custom_domain' do
+        post custom_domains_url, params: { custom_domain: valid_attributes }
+        expect(response).to redirect_to(custom_domains_url)
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new CustomDomain' do
+        expect do
+          post custom_domains_url, params: { custom_domain: invalid_attributes }
+        end.not_to change(CustomDomain, :count)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        post custom_domains_url, params: { custom_domain: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do
+      let(:new_attributes) { { host: 'new-domain.example.com' } }
+
+      it 'updates the requested custom_domain' do
+        custom_domain = CustomDomain.create! valid_attributes
+        expect do
+          patch custom_domain_url(custom_domain), params: { custom_domain: new_attributes }
+        end.to raise_exception(ActionController::RoutingError)
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested custom_domain' do
+      custom_domain = CustomDomain.create! valid_attributes
+      expect do
+        delete custom_domain_url(custom_domain)
+      end.to change(CustomDomain, :count).by(-1)
+    end
+
+    it 'redirects to the custom_domains list' do
+      custom_domain = CustomDomain.create! valid_attributes
+      delete custom_domain_url(custom_domain)
+      expect(response).to redirect_to(custom_domains_url)
+    end
+  end
+
+  describe 'resctricts access' do
+    example 'for guest users' do
+      logout
+      get custom_domains_url
+      expect(response).to be_not_found
+    end
+
+    example 'for non-admin users' do
+      login_as regular_user
+      get custom_domains_url
+      expect(response).to be_unauthorized
+    end
+  end
+end

--- a/spec/routing/admin/custom_domains_routing_spec.rb
+++ b/spec/routing/admin/custom_domains_routing_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Admin::CustomDomainsController do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: '/admin/custom_domains').to route_to('admin/custom_domains#index')
+    end
+
+    it 'routes to #new' do
+      expect(get: '/admin/custom_domains/new').to route_to('admin/custom_domains#new')
+    end
+
+    it 'routes to #create' do
+      expect(post: '/admin/custom_domains').to route_to('admin/custom_domains#create')
+    end
+
+    it 'routes to #destroy' do
+      expect(delete: '/admin/custom_domains/1').to route_to('admin/custom_domains#destroy', id: '1')
+    end
+
+    it 'does not route to #show' do
+      expect(get: '/admin/custom_domains/1').not_to be_routable
+    end
+
+    it 'routes to #edit' do
+      expect(get: '/admin/custom_domains/1/edit').not_to be_routable
+    end
+
+    it 'routes to #update via PUT' do
+      expect(put: '/admin/custom_domains/1').not_to be_routable
+    end
+
+    it 'routes to #update via PATCH' do
+      expect(patch: '/admin/custom_domains/1').not_to be_routable
+    end
+  end
+end

--- a/spec/views/admin/_sidebar.html.erb_spec.rb
+++ b/spec/views/admin/_sidebar.html.erb_spec.rb
@@ -67,4 +67,18 @@ RSpec.describe 'admin/_sidebar' do
       expect(rendered).not_to have_link(href: configs_path)
     end
   end
+
+  describe 'domains link' do
+    it 'renders for authorized users' do
+      allow(view.controller.current_ability).to receive(:can?).with(:read, CustomDomain).and_return(true)
+      render
+      expect(rendered).to have_link(href: custom_domains_path)
+    end
+
+    it 'is hidden from unauthorized users' do
+      allow(view.controller.current_ability).to receive(:can?).with(:read, CustomDomain).and_return(false)
+      render
+      expect(rendered).not_to have_link(href: custom_domains_path)
+    end
+  end
 end

--- a/spec/views/admin/custom_domains/index.html.erb_spec.rb
+++ b/spec/views/admin/custom_domains/index.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/custom_domains/index' do
+  let(:domains) { (1..3).collect { |i| FactoryBot.build(:custom_domain, id: i) } }
+
+  before { assign(:custom_domains, domains) }
+
+  it 'renders a list of domains' do
+    render
+    expect(rendered).to have_selector('td.host', count: 3)
+  end
+
+  it 'has links to delte each domain' do
+    render
+    expect(rendered).to have_button('delete_custom_domain_3')
+  end
+
+  it 'has a link to add a domain' do
+    render
+    expect(rendered).to have_link('new_domain')
+  end
+
+  it 'displays the default domain' do
+    pending 'certificate implementation'
+    render
+    expect(rendered).to have_selector('default_domain', text: 't3.curationexperts.com')
+  end
+
+  it 'displays the certificate expiration' do
+    pending 'certificate implementation'
+    render
+    expect(rendered).to have_selector('not_valid_after', text: '3 days from now')
+  end
+end

--- a/spec/views/admin/custom_domains/new.html.erb_spec.rb
+++ b/spec/views/admin/custom_domains/new.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/custom_domains/new' do
+  before do
+    assign(:custom_domain, CustomDomain.new)
+  end
+
+  it 'renders new domain form' do
+    render
+    expect(rendered).to have_selector("form[@action='#{custom_domains_path}']")
+  end
+
+  it 'accepts a domain name' do
+    render
+    expect(rendered).to have_field(id: 'custom_domain_host')
+  end
+
+  it 'has a submit button' do
+    render
+    expect(rendered).to have_button(type: 'submit')
+  end
+end


### PR DESCRIPTION
Custom Domains are 'vanity' URLs that allow an insitution to access the repository via a brand-friendly domain name instead of the default DNS name provided by DCE.