### PR TITLE
Add a wrapper for interacting with certbot

### DIFF
--- a/app/api/certbot/v2/client.rb
+++ b/app/api/certbot/v2/client.rb
@@ -1,0 +1,106 @@
+module Certbot
+  module V2
+    # Wrapper for interacting with Certbot v2.x to manage TLS certificates
+    #
+    # This code makes a number of assumptions about interations with certbot:
+    # 1) There will be an existing certificate setup on the server
+    # 2) That certificate will always have the name 't3.application'
+    # 3) That certificate will have the fully qualified host name as it's CN
+    # 4) We are only interested in modifying domains listed at Subject Alternate Names
+    # 5) We only add or remove domains one at at time (this may seem inefficient,but it
+    #      maps directly to our current UX pattern)
+    class Client
+      # NOTE: The current implementation assumes the server uses a single previously issued
+      # certificate with the certbot name 't3.application'
+      CERTBOT_READ =
+        'sudo certbot certificates --cert-name t3.application'.freeze
+      CERTBOT_UPDATE =
+        'sudo certbot certonly --apache -n --cert-name t3.application --allow-subset-of-names --domains '.freeze
+
+      attr_reader :not_after, :last_error
+
+      def self.default_host
+        @default_host ||= `hostname -f`.chomp
+      end
+
+      def initialize
+        load_certificate
+        @last_error = nil
+      end
+
+      def valid?
+        @valid
+      end
+
+      # Return the list of subject alternate name domains listed in the certificate
+      # NOTE: letsencrypt & certbot use the term 'domain', we're using host to fit more
+      # naturally with other rails network classes
+      def hosts
+        @domains
+      end
+
+      # add a single hostname to the website certificate
+      def add_host(domain)
+        return unless domain && valid?
+
+        new_hosts = (@domains << domain).join(',')
+        update_hosts(new_hosts)
+      end
+
+      # remove a single hostname from the website certificate
+      def remove_host(domain)
+        return unless @domains.include?(domain) && valid?
+
+        new_hosts = (@domains - [domain]).join(',')
+        update_hosts(new_hosts)
+      end
+
+      private
+
+      # call certbot to update the list of domains (i.e. subject alternative names)
+      def update_hosts(new_hosts)
+        response, status = Open3.capture2(CERTBOT_UPDATE, stdin_data: new_hosts)
+        @last_error = extract_errors(response, status)
+        load_certificate
+      end
+
+      # call certbot to return a certificate summary
+      def load_certificate
+        cert_summary, status = Open3.capture2(CERTBOT_READ)
+
+        @domains = extract_domains(cert_summary)
+        @not_after = extract_expiration(cert_summary)
+        @valid = not_after.present? && status.success?
+      end
+
+      # Extract domains from "certbot certificates" output
+      def extract_domains(raw)
+        parsed = raw.match(/Domains: (?<domains>[0-9a-z\-\. ]+)\n/)
+        if parsed
+          parsed[:domains]&.split
+        else
+          []
+        end
+      end
+
+      # Extract expiration "certbot certificates" output
+      def extract_expiration(raw)
+        parsed = raw.match(/Expiry Date: (?<date>[0-9\- :+]+[0-9])\s+\(VALID/)
+        Time.zone.parse(parsed[:date]) if parsed
+      end
+
+      # Extract errors if there was a partial update or outright failure
+      # returns the error text or nil if there were no errors or failures
+      def extract_errors(raw, status)
+        if status.success?
+          # a partial renewal was successful, the new domain failed authentication
+          parsed = raw.match(/(?<failure>The Certificate Authority reported these problems(?:.+\n)+)/)
+          parsed[:failure] if parsed
+        else
+          # certbot exited with a an unexpected status code, so just return the full text
+          raw
+        end
+      end
+    end
+  end
+end

--- a/spec/api/certbot/v2/client_spec.rb
+++ b/spec/api/certbot/v2/client_spec.rb
@@ -1,0 +1,282 @@
+require 'rails_helper'
+
+RSpec.describe Certbot::V2::Client do
+  let(:certbot_captures) do
+    {
+      certificates2:
+        <<~STDOUT,
+          Saving debug log to /var/log/letsencrypt/letsencrypt.log
+
+          - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+          Found the following matching certs:
+            Certificate Name: t3.application
+              Serial Number: 12345678901234567890123456789012345
+              Key Type: ECDSA
+              Domains: t3-dev.example.com t3.university.edu
+              Expiry Date: 2023-11-12 19:15:08+00:00 (VALID: 89 days)
+              Certificate Path: /etc/letsencrypt/live/t3.application/fullchain.pem
+              Private Key Path: /etc/letsencrypt/live/t3.application/privkey.pem
+          - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        STDOUT
+      certificates3:
+        <<~STDOUT,
+          Saving debug log to /var/log/letsencrypt/letsencrypt.log
+
+          - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+          Found the following matching certs:
+            Certificate Name: t3.application
+              Serial Number: 54321098765432109876543210987654321
+              Key Type: ECDSA
+              Domains: t3-dev.example.com t3.university.edu t3.example.com
+              Expiry Date: 2023-11-12 19:46:32+00:00 (VALID: 89 days)
+              Certificate Path: /etc/letsencrypt/live/t3.application/fullchain.pem
+              Private Key Path: /etc/letsencrypt/live/t3.application/privkey.pem
+          - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        STDOUT
+      update_success:
+        <<~STDOUT,
+          Saving debug log to /var/log/letsencrypt/letsencrypt.log
+          Renewing an existing certificate for t3-dev.example.com and 2 more domains
+
+          Successfully received certificate.
+          Certificate is saved at: /etc/letsencrypt/live/t3.application/fullchain.pem
+          Key is saved at:         /etc/letsencrypt/live/t3.application/privkey.pem
+          This certificate expires on 2023-11-13.
+          These files will be updated when the certificate renews.
+          Certbot has set up a scheduled task to automatically renew this certificate in the background.
+
+          - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+          If you like Certbot, please consider supporting our work by:
+           * Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
+           * Donating to EFF:                    https://eff.org/donate-le
+          - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        STDOUT
+      update_partial:
+        <<~STDOUT,
+          Saving debug log to /var/log/letsencrypt/letsencrypt.log
+          Renewing an existing certificate for 3-dev.example.com and 2 more domains
+
+          Certbot failed to authenticate some domains (authenticator: apache). The Certificate Authority reported these problems:
+            Domain: 3-dev.example.com
+            Type:   dns
+            Detail: DNS problem: NXDOMAIN looking up A for 3-dev.example.com - check that a DNS record exists for this domain; DNS problem: NXDOMAIN looking up AAAA for 3-dev.example.com - check that a DNS record exists for this domain
+
+          Hint: The Certificate Authority failed to verify the temporary Apache configuration changes made by Certbot. Ensure that the listed domains point to this Apache server and that it is accessible from the internet.
+
+          Unable to obtain a certificate with every requested domain. Retrying without: 3-dev.example.com
+
+          Successfully received certificate.
+          Certificate is saved at: /etc/letsencrypt/live/t3.application/fullchain.pem
+          Key is saved at:         /etc/letsencrypt/live/t3.application/privkey.pem
+          This certificate expires on 2023-11-13.
+          These files will be updated when the certificate renews.
+          Certbot has set up a scheduled task to automatically renew this certificate in the background.
+
+          - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+          If you like Certbot, please consider supporting our work by:
+           * Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
+           * Donating to EFF:                    https://eff.org/donate-le
+          - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        STDOUT
+      update_error:
+        <<~STDOUT,
+          Saving debug log to /var/log/letsencrypt/letsencrypt.log
+          Renewing an existing certificate for t3-dev.example.com and 4 more domains
+          An unexpected error occurred:
+          Error creating new order :: Cannot issue for "foo-tenejo-com": Domain name needs at least one dot
+          Ask for help or search for solutions at https://community.letsencrypt.org. See the logfile /var/log/letsencrypt/letsencrypt.log or re-run Certbot with -v for more details.
+        STDOUT
+      unexpected: 'Not what we were expecting...'
+    }
+  end
+
+  let(:status_failed) { Process.wait2(fork { Process.exit 5 })[1] }
+  let(:status_successful) { Process.wait2(fork { Process.exit 0 })[1] }
+  let(:status) { status_successful }
+  let(:certbot_stdout) { certbot_captures[:certificates2] }
+
+  before do
+    # stub certbot certinfo calls
+    allow(Open3).to receive(:capture2).with(Certbot::V2::Client::CERTBOT_READ).and_return([certbot_stdout, status])
+  end
+
+  describe '.default_host' do
+    it 'returns the hostname configured on the server' do
+      allow(described_class).to receive(:`).with('hostname -f').and_return("fqdn.example.com\n")
+
+      expect(described_class.default_host).to eq 'fqdn.example.com'
+    end
+  end
+
+  describe '.new' do
+    it 'returns a client for the defualt certificate' do
+      expect(described_class.new).to be_a described_class
+    end
+
+    it 'returns a valid client' do
+      expect(described_class.new).to be_valid
+    end
+
+    context 'when certbot gives an unexpected response' do
+      let(:certbot_stdout) { certbot_captures[:unexpected] }
+
+      it 'returns a non-valid client' do
+        expect(described_class.new).not_to be_valid
+      end
+    end
+
+    context 'when certbot exits with an error code' do
+      let(:status) { status_failed }
+
+      it 'returns a non-valid client' do
+        expect(described_class.new).not_to be_valid
+      end
+    end
+  end
+
+  describe '#hosts' do
+    it 'returns the list of subject alternate names in the certificate' do
+      cert_client = described_class.new
+      expect(cert_client.hosts).to contain_exactly('t3-dev.example.com', 't3.university.edu')
+    end
+  end
+
+  describe '#not_after' do
+    it 'returns the expiration date for the certificate' do
+      cert_client = described_class.new
+      expect(cert_client.not_after).to eq Time.zone.parse('2023-11-12 19:15:08+00:00')
+    end
+  end
+
+  describe '#add_host' do
+    before do
+      # stub certbot certificate returning 2 domains, then 3 domains
+      allow(Open3)
+        .to receive(:capture2)
+        .with(Certbot::V2::Client::CERTBOT_READ)
+        .and_return(
+          [certbot_captures[:certificates2], status_successful],
+          [certbot_captures[:certificates3], status_successful]
+        )
+    end
+
+    context 'when certbot certonly returns without error' do
+      before do
+        # stub a successful call to 'certbot certonly'
+        allow(Open3).to receive(:capture2).with(Certbot::V2::Client::CERTBOT_UPDATE,
+                                                anything).and_return([certbot_captures[:update_success], status])
+      end
+
+      it 'updates the domains on the certificate' do
+        cert_client = described_class.new
+        initial_domains = cert_client.hosts.dup
+
+        cert_client.add_host('t3.example.com')
+        difference = cert_client.hosts - initial_domains
+        expect(difference).to eq ['t3.example.com']
+      end
+
+      it 'calls certbot update' do
+        cert_client = described_class.new
+        cert_client.add_host('t3.example.com')
+        expect(Open3).to have_received(:capture2).with(Certbot::V2::Client::CERTBOT_UPDATE, anything).once
+      end
+
+      it 'does nothing when the host is nil' do
+        cert_client = described_class.new
+        cert_client.add_host(nil)
+        expect(Open3).not_to have_received(:capture2).with(Certbot::V2::Client::CERTBOT_UPDATE, anything)
+      end
+    end
+
+    context 'when certbot returns an error' do
+      before do
+        # stub certbot exiting with error (invalid domain name)
+        allow(Open3)
+          .to receive(:capture2)
+          .with(Certbot::V2::Client::CERTBOT_UPDATE,
+                { stdin_data: 't3-dev.example.com,t3.university.edu,foo-tenejo-com' })
+          .and_return([certbot_captures[:update_error], status_failed])
+      end
+
+      it 'passes the error message' do
+        cert_client = described_class.new
+        cert_client.add_host('foo-tenejo-com')
+        expect(cert_client.last_error).to include 'Error creating new order'
+      end
+    end
+
+    context 'when certbot can not verify the domain' do
+      before do
+        # stub certbot unable to verify one of three domains (host validation failure)
+        allow(Open3)
+          .to receive(:capture2)
+          .with(Certbot::V2::Client::CERTBOT_UPDATE, anything)
+          .and_return([certbot_captures[:update_partial], status_successful])
+      end
+
+      it 'passes the failure reason' do
+        cert_client = described_class.new
+        cert_client.add_host('3-dev.example.com')
+        expect(cert_client.last_error).to include 'check that a DNS record exists for this domain'
+      end
+    end
+  end
+
+  describe '#remove_host' do
+    before do
+      # stub certbot certificate returning 3 domains, then 2 domains
+      allow(Open3)
+        .to receive(:capture2)
+        .with(Certbot::V2::Client::CERTBOT_READ)
+        .and_return(
+          [certbot_captures[:certificates3], status_successful],
+          [certbot_captures[:certificates2], status_successful]
+        )
+    end
+
+    context 'when certbot certonly returns without error' do
+      before do
+        allow(Open3).to receive(:capture2).with(Certbot::V2::Client::CERTBOT_UPDATE,
+                                                anything).and_return([certbot_captures[:update_success], status])
+      end
+
+      it 'updates the domains' do
+        cert_client = described_class.new
+        initial_domains = cert_client.hosts.dup
+
+        cert_client.remove_host('t3.example.com')
+        difference = initial_domains - cert_client.hosts
+        expect(difference).to eq ['t3.example.com']
+      end
+
+      it 'calls certbot update' do
+        cert_client = described_class.new
+        cert_client.remove_host('t3.university.edu')
+        expect(Open3).to have_received(:capture2).with(Certbot::V2::Client::CERTBOT_UPDATE, anything).once
+      end
+
+      it 'does nothing when the host is not in the existing certificate' do
+        cert_client = described_class.new
+        cert_client.remove_host('my-host.example.com')
+        expect(Open3).not_to have_received(:capture2).with(Certbot::V2::Client::CERTBOT_UPDATE, anything)
+      end
+    end
+
+    context 'when certbot gives an unexpected response' do
+      before do
+        # stub a certbot non-zero exit and error message
+        allow(Open3)
+          .to receive(:capture2)
+          .with(Certbot::V2::Client::CERTBOT_UPDATE, anything)
+          .and_return([certbot_captures[:update_error], status_failed])
+      end
+
+      it 'passes the error message' do
+        cert_client = described_class.new
+        cert_client.remove_host('t3.university.edu')
+        expect(cert_client.last_error).to include 'Error creating new order'
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to be able to update the TLS certificate for the application website so the repository owner can access the site via a custom domain name.

This code provides a wrapper for the certbot command line interface to LetsEncrypt.  It makes a large number of simplifying assumptions about certificate interactions based on our required user flow.

This wrapper does not attempt to provide a general purpose interface to the LetsEncrypt service and only provides access to a very limited set of certbot features.

Unsing the wrapper, the application can
* Read the current certificate info including domains and expiration
* Add or Remove a single domain to the certificate at a time