### PR TITLE
Remove dead code from the Custom Domain controller

### DIFF
--- a/app/controllers/admin/custom_domains_controller.rb
+++ b/app/controllers/admin/custom_domains_controller.rb
@@ -1,16 +1,12 @@
 module Admin
   # Manage custom domain names for the application
   class CustomDomainsController < ApplicationController
-    # before_action :set_custom_domain, only: %i[show edit update destroy]
     load_and_authorize_resource
 
     # GET /admin/custom_domains or /admin/custom_domains.json
     def index
       @custom_domains = CustomDomain.all
     end
-
-    # GET /admin/custom_domains/1 or /admin/custom_domains/1.json
-    def show; end
 
     # GET /admin/custom_domains/new
     def new
@@ -50,11 +46,6 @@ module Admin
     end
 
     private
-
-    # Use callbacks to share common setup or constraints between actions.
-    def set_custom_domain
-      @custom_domain = Admin::CustomDomain.find(params[:id])
-    end
 
     # Only allow a list of trusted parameters through.
     def custom_domain_params


### PR DESCRIPTION
We do not provide a way to view individual domains, all the relevant information is available on the index view.  So there is no route to a show action.

The cancancan load_and_authorize_resource handles setting the domain for singular actions, so we also do not need the set_custom_domain method.