### PR TITLE
Connect custom domain UI to certificates

### DIFF
--- a/app/api/certbot/v2/client.rb
+++ b/app/api/certbot/v2/client.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module Certbot
   module V2
     # Wrapper for interacting with Certbot v2.x to manage TLS certificates
@@ -32,6 +34,10 @@ module Certbot
         @valid
       end
 
+      def invalid?
+        !@valid
+      end
+
       # Return the list of subject alternate name domains listed in the certificate
       # NOTE: letsencrypt & certbot use the term 'domain', we're using host to fit more
       # naturally with other rails network classes
@@ -59,14 +65,14 @@ module Certbot
 
       # call certbot to update the list of domains (i.e. subject alternative names)
       def update_hosts(new_hosts)
-        response, status = Open3.capture2(CERTBOT_UPDATE, stdin_data: new_hosts)
+        response, status = Open3.capture2e(CERTBOT_UPDATE, stdin_data: new_hosts)
         @last_error = extract_errors(response, status)
         load_certificate
       end
 
       # call certbot to return a certificate summary
       def load_certificate
-        cert_summary, status = Open3.capture2(CERTBOT_READ)
+        cert_summary, status = Open3.capture2e(CERTBOT_READ)
 
         @domains = extract_domains(cert_summary)
         @not_after = extract_expiration(cert_summary)
@@ -94,12 +100,43 @@ module Certbot
       def extract_errors(raw, status)
         if status.success?
           # a partial renewal was successful, the new domain failed authentication
-          parsed = raw.match(/(?<failure>The Certificate Authority reported these problems(?:.+\n)+)/)
+          parsed =
+            raw.match(/(?<failure>The Certificate Authority reported these problems(?:.+\n)+(?:\nHint: (?:.+\n)+)*)/)
           parsed[:failure] if parsed
         else
           # certbot exited with a an unexpected status code, so just return the full text
           raw
         end
+      end
+    end
+
+    # Test class that makes no calls to external inerfaces
+    # Accessor methods allow setting dummy values for all
+    # instance variables
+    class TestClient
+      attr_accessor :hosts, :not_after, :last_error, :valid
+
+      def initialize(hosts: [], not_after: Time.current, last_error: nil, valid: true)
+        @hosts = hosts
+        @not_after = not_after
+        @last_error = last_error
+        @valid = valid
+      end
+
+      def valid?
+        !!valid
+      end
+
+      def invalid?
+        !valid
+      end
+
+      def add_host(host)
+        @hosts = hosts << host
+      end
+
+      def remove_host(host)
+        @hosts = hosts - [host]
       end
     end
   end

--- a/app/models/custom_domain.rb
+++ b/app/models/custom_domain.rb
@@ -1,9 +1,38 @@
 # Vanity Domains
 class CustomDomain < ApplicationRecord
   validates :host, presence: true
+  validates :host, uniqueness: true
   validates :host, format: { with: Certificate::DOMAIN_PATTERN, message: 'must be a valid DNS hostname' },
                    allow_blank: true
   validate :host_can_be_resolved
+  validate :certbot_success
+
+  before_save :update_certificate
 
   def host_can_be_resolved; end
+
+  def certbot_success
+    if certbot_client.invalid?
+      errors.add(:base, :certbot, message: 'could not initialize Certbot')
+    elsif certbot_client.last_error.present?
+      errors.add(:host, :certificate, message: "certificate update error text:\n#{certbot_client.last_error}")
+    else
+      # no certbot errors
+      return true
+    end
+    false
+  end
+
+  def initialize(attributes = nil)
+    super
+  end
+
+  def update_certificate
+    certbot_client.add_host(host)
+    raise ActiveRecord::RecordInvalid unless certbot_success
+  end
+
+  def certbot_client
+    @certbot_client ||= Certbot::V2::Client.new
+  end
 end

--- a/db/migrate/20230813190525_create_custom_domains.rb
+++ b/db/migrate/20230813190525_create_custom_domains.rb
@@ -1,8 +1,7 @@
 class CreateCustomDomains < ActiveRecord::Migration[7.0]
   def change
     create_table :custom_domains do |t|
-      t.string :host
-
+      t.string :host, index: { unique: true }
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,6 +69,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_13_190525) do
     t.string "host"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["host"], name: "index_custom_domains_on_host", unique: true
   end
 
   create_table "roles", force: :cascade do |t|

--- a/spec/models/custom_domain_spec.rb
+++ b/spec/models/custom_domain_spec.rb
@@ -2,8 +2,104 @@ require 'rails_helper'
 
 RSpec.describe CustomDomain do
   let(:domain) { described_class.new }
+  let(:success) { Process.wait2(fork { Process.exit 0 })[1] }
+  let(:certbot_stdout) do
+    <<~STDOUT
+      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      Found the following matching certs:
+        Certificate Name: t3.application
+          Serial Number: 12345678901234567890123456789012345
+          Key Type: ECDSA
+          Domains: t3.example.com
+          Expiry Date: 2023-11-12 19:15:08+00:00 (VALID: 89 days)
+          Certificate Path: /etc/letsencrypt/live/t3.application/fullchain.pem
+          Private Key Path: /etc/letsencrypt/live/t3.application/privkey.pem
+      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    STDOUT
+  end
+  let(:auth_failure) do
+    <<~STDOUT
+      Certbot failed to authenticate some domains (authenticator: apache). The Certificate Authority reported these problems:
+        Domain: demo.tenejo.com
+        Type:   unauthorized
+        Detail: 50.16.172.231: Invalid response from https://demo.tenejo.com/.well-known/acme-challenge/sxzTJOsdmDKfInk7chxPpYj_9HWjEkEbInNP5ZFKTcY: 404
+
+      Hint: The Certificate Authority failed to verify the temporary Apache configuration changes made by Certbot. Ensure that the listed domains point to this Apache server and that it is accessible from the internet.
+
+      Some challenges have failed.
+    STDOUT
+  end
+
+  before do
+    # stub certbot certificate returning a single domain
+    allow(Open3)
+      .to receive(:capture2e)
+      .with(Certbot::V2::Client::CERTBOT_READ)
+      .and_return([certbot_stdout, success])
+  end
 
   it 'has a host attribute' do
     expect(domain).to respond_to(:host=)
+  end
+
+  describe 'validation' do
+    example 'checks host presence' do
+      d1 = described_class.new(host: nil)
+      d1.valid?
+      expect(d1.errors.where(:host, :blank)).to be_present
+    end
+
+    example 'checks host uniqueness' do
+      # Add the name to the table without calling other model logic
+      described_class.insert({ host: 't3.example.com' })
+      d1 = described_class.new(host: 't3.example.com')
+      d1.valid?
+      expect(d1.errors.where(:host, :taken)).to be_present
+    end
+
+    example 'checks certbot setup' do
+      # stub certbot returning a partial update error
+      allow(Open3).to receive(:capture2e).with(Certbot::V2::Client::CERTBOT_READ).and_return(['error', success])
+      d1 = described_class.new(host: 'demo.tenejo.com')
+      d1.valid?
+      expect(d1.errors.where(:base, :certbot)).to be_present
+    end
+
+    example 'checks certbot errors' do
+      # stub certbot returning a partial update error
+      allow(Open3).to receive(:capture2e).with(Certbot::V2::Client::CERTBOT_UPDATE,
+                                               anything).and_return([auth_failure, success])
+      d1 = described_class.new(host: 'demo.tenejo.com')
+      d1.save
+      expect(d1.errors.where(:host, :certificate)).to be_present
+    end
+  end
+
+  describe '#save' do
+    before do
+      # stub certbot returning a partial update error
+      allow(Open3).to receive(:capture2e).with(Certbot::V2::Client::CERTBOT_UPDATE,
+                                               anything).and_return([auth_failure, success])
+    end
+
+    it 'calls certbot with the hostname' do
+      # stub out calls to certbot #add_host
+      allow(domain.certbot_client).to receive(:add_host)
+      domain.host = 'demo.tenejo.com'
+      domain.save
+      expect(domain.certbot_client).to have_received(:add_host).with('demo.tenejo.com')
+    end
+
+    it 'returns false on certbot failures', :aggregate_failures do
+      domain.host = 'demo.tenejo.com'
+      expect(domain.save).to be false
+      expect(domain.errors).not_to be_nil
+    end
+
+    it 'returns the error on certbot failure' do
+      domain.host = 'demo.tenejo.com'
+      domain.save
+      expect(domain.errors.where(:host, :certificate)).not_to be_nil
+    end
   end
 end

--- a/spec/requests/admin/custom_domains_spec.rb
+++ b/spec/requests/admin/custom_domains_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe '/admin/custom_domains' do
     # Stub DNS requests to isolate external services
     allow(Resolv).to receive(:getaddress).and_return('10.10.0.1')
     login_as super_admin
+    allow(Certbot::V2::Client).to receive(:new).and_return(Certbot::V2::TestClient.new)
   end
 
   describe 'GET /index' do


### PR DESCRIPTION
This commit connects the Custom Domain UI to the certificate so that changes to custom domains are sent to certbot to update the application's security certificate.