### PR TITLE
Add logging for Certbot calls

### DIFF
--- a/app/api/certbot/v2/client.rb
+++ b/app/api/certbot/v2/client.rb
@@ -65,13 +65,16 @@ module Certbot
 
       # call certbot to update the list of domains (i.e. subject alternative names)
       def update_hosts(new_hosts)
+        Rails.logger.warn("Calling Certbot with: #{CERTBOT_UPDATE + new_hosts}")
         response, status = Open3.capture2e(CERTBOT_UPDATE, stdin_data: new_hosts)
+        Rails.logger.warn("Certbot returned: \n#{response}")
         @last_error = extract_errors(response, status)
         load_certificate
       end
 
       # call certbot to return a certificate summary
       def load_certificate
+        Rails.logger.info("Calling Certbot with: #{CERTBOT_READ}")
         cert_summary, status = Open3.capture2e(CERTBOT_READ)
 
         @domains = extract_domains(cert_summary)


### PR DESCRIPTION
For debugging purposes (info), we want to be able to see read-only calls to Certbot.

For auditing purposes (warn), we want to log all calls to Certbot that might make modifications to a certificate.

This information helps us implement the least-privelege necessary to allow the rails user (deploy) to update certificates.