### PR TITLE
Update certbot call signature

### DIFF
--- a/app/api/certbot/v2/client.rb
+++ b/app/api/certbot/v2/client.rb
@@ -66,7 +66,7 @@ module Certbot
       # call certbot to update the list of domains (i.e. subject alternative names)
       def update_hosts(new_hosts)
         Rails.logger.warn("Calling Certbot with: #{CERTBOT_UPDATE + new_hosts}")
-        response, status = Open3.capture2e(CERTBOT_UPDATE, stdin_data: new_hosts)
+        response, status = Open3.capture2e(CERTBOT_UPDATE + new_hosts)
         Rails.logger.warn("Certbot returned: \n#{response}")
         @last_error = extract_errors(response, status)
         load_certificate

--- a/spec/api/certbot/v2/client_spec.rb
+++ b/spec/api/certbot/v2/client_spec.rb
@@ -164,8 +164,9 @@ RSpec.describe Certbot::V2::Client do
     context 'when certbot certonly returns without error' do
       before do
         # stub a successful call to 'certbot certonly'
-        allow(Open3).to receive(:capture2e).with(Certbot::V2::Client::CERTBOT_UPDATE,
-                                                 anything).and_return([certbot_captures[:update_success], status])
+        allow(Open3).to receive(:capture2e)
+          .with(a_string_matching(Certbot::V2::Client::CERTBOT_UPDATE))
+          .and_return([certbot_captures[:update_success], status])
       end
 
       it 'updates the domains on the certificate' do
@@ -180,13 +181,15 @@ RSpec.describe Certbot::V2::Client do
       it 'calls certbot update' do
         cert_client = described_class.new
         cert_client.add_host('t3.example.com')
-        expect(Open3).to have_received(:capture2e).with(Certbot::V2::Client::CERTBOT_UPDATE, anything).once
+        expect(Open3).to have_received(:capture2e)
+          .with(a_string_matching(Certbot::V2::Client::CERTBOT_UPDATE)).once
       end
 
       it 'does nothing when the host is nil' do
         cert_client = described_class.new
         cert_client.add_host(nil)
-        expect(Open3).not_to have_received(:capture2e).with(Certbot::V2::Client::CERTBOT_UPDATE, anything)
+        expect(Open3).not_to have_received(:capture2e)
+          .with(a_string_matching(Certbot::V2::Client::CERTBOT_UPDATE))
       end
     end
 
@@ -195,8 +198,7 @@ RSpec.describe Certbot::V2::Client do
         # stub certbot exiting with error (invalid domain name)
         allow(Open3)
           .to receive(:capture2e)
-          .with(Certbot::V2::Client::CERTBOT_UPDATE,
-                { stdin_data: 't3-dev.example.com,t3.university.edu,foo-tenejo-com' })
+          .with(a_string_matching(Certbot::V2::Client::CERTBOT_UPDATE))
           .and_return([certbot_captures[:update_error], status_failed])
       end
 
@@ -212,7 +214,7 @@ RSpec.describe Certbot::V2::Client do
         # stub certbot unable to verify one of three domains (host validation failure)
         allow(Open3)
           .to receive(:capture2e)
-          .with(Certbot::V2::Client::CERTBOT_UPDATE, anything)
+          .with(a_string_matching(Certbot::V2::Client::CERTBOT_UPDATE))
           .and_return([certbot_captures[:update_partial], status_successful])
       end
 
@@ -238,8 +240,9 @@ RSpec.describe Certbot::V2::Client do
 
     context 'when certbot certonly returns without error' do
       before do
-        allow(Open3).to receive(:capture2e).with(Certbot::V2::Client::CERTBOT_UPDATE,
-                                                 anything).and_return([certbot_captures[:update_success], status])
+        allow(Open3).to receive(:capture2e)
+          .with(a_string_matching(Certbot::V2::Client::CERTBOT_UPDATE))
+          .and_return([certbot_captures[:update_success], status])
       end
 
       it 'updates the domains' do
@@ -254,13 +257,15 @@ RSpec.describe Certbot::V2::Client do
       it 'calls certbot update' do
         cert_client = described_class.new
         cert_client.remove_host('t3.university.edu')
-        expect(Open3).to have_received(:capture2e).with(Certbot::V2::Client::CERTBOT_UPDATE, anything).once
+        expect(Open3).to have_received(:capture2e)
+          .with(a_string_matching(Certbot::V2::Client::CERTBOT_UPDATE)).once
       end
 
       it 'does nothing when the host is not in the existing certificate' do
         cert_client = described_class.new
         cert_client.remove_host('my-host.example.com')
-        expect(Open3).not_to have_received(:capture2e).with(Certbot::V2::Client::CERTBOT_UPDATE, anything)
+        expect(Open3).not_to have_received(:capture2e)
+          .with(a_string_matching(Certbot::V2::Client::CERTBOT_UPDATE))
       end
     end
 
@@ -269,7 +274,7 @@ RSpec.describe Certbot::V2::Client do
         # stub a certbot non-zero exit and error message
         allow(Open3)
           .to receive(:capture2e)
-          .with(Certbot::V2::Client::CERTBOT_UPDATE, anything)
+          .with(a_string_matching(Certbot::V2::Client::CERTBOT_UPDATE))
           .and_return([certbot_captures[:update_error], status_failed])
       end
 

--- a/spec/models/custom_domain_spec.rb
+++ b/spec/models/custom_domain_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe CustomDomain do
 
     example 'checks certbot errors' do
       # stub certbot returning a partial update error
-      allow(Open3).to receive(:capture2e).with(Certbot::V2::Client::CERTBOT_UPDATE,
-                                               anything).and_return([auth_failure, success])
+      allow(Open3).to receive(:capture2e)
+        .with(a_string_matching(Certbot::V2::Client::CERTBOT_UPDATE)).and_return([auth_failure, success])
       d1 = described_class.new(host: 'demo.tenejo.com')
       d1.save
       expect(d1.errors.where(:host, :certificate)).to be_present
@@ -78,8 +78,9 @@ RSpec.describe CustomDomain do
   describe '#save' do
     before do
       # stub certbot returning a partial update error
-      allow(Open3).to receive(:capture2e).with(Certbot::V2::Client::CERTBOT_UPDATE,
-                                               anything).and_return([auth_failure, success])
+      allow(Open3).to receive(:capture2e)
+        .with(a_string_matching(Certbot::V2::Client::CERTBOT_UPDATE))
+        .and_return([auth_failure, success])
     end
 
     it 'calls certbot with the hostname' do


### PR DESCRIPTION
**ISSUE**
Calling Open3 with `stdin` data still causes sudo to prompt for a password.

**SOLUTION**
Send the domains to certbot as part of the command line.