### PR TITLE
Add a method to extract subject alternative names from certificates

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -25,6 +25,14 @@ class Certificate
     x509cert.subject.to_a.find { |e| e[0] = 'CN' }[1]
   end
 
+  # return the value of any subject alternate names
+  def subject_alt_names
+    @subject_alt_names ||=
+      x509cert.extensions.find { |e| e.oid == 'subjectAltName' }.value.scan(DOMAIN_PATTERN).flatten
+    # Alternate implementation
+    # x509cert.extensions.find { |e| e.oid == 'subjectAltName' }.value.split(', ').map { |h| h.sub('DNS:', '') }
+  end
+
   private
 
   def fetch_cert(host)

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -93,5 +93,10 @@ RSpec.describe Certificate, :aggregate_failures do
       cert = described_class.new(host: 'host.example.com')
       expect(cert.subject_cn).to eq 'test.example.com'
     end
+
+    it 'extracts #subject_alt_names' do
+      cert = described_class.new(host: 'host.example.com')
+      expect(cert.subject_alt_names).to eq ['host.example.com', 'text.example.com']
+    end
   end
 end


### PR DESCRIPTION
In console tests, reading the alternate hostnames from a certificate retrieved over HTTPS is much faster than using Certbot to extract the same information via the command line.

As a result, we implementing a  method that returns all of the host names (subject alternative names) a certificate includes.