### PR TITLE
Refactor CustomDomain tests to use Certbot TestClient

### DIFF
--- a/app/api/certbot/v2/client.rb
+++ b/app/api/certbot/v2/client.rb
@@ -69,7 +69,7 @@ module Certbot
         response, status = Open3.capture2e(CERTBOT_UPDATE + new_hosts)
         Rails.logger.warn("Certbot returned: \n#{response}")
         @last_error = extract_errors(response, status)
-        load_certificate
+        load_certificate && @last_error.blank?
       end
 
       # call certbot to return a certificate summary
@@ -113,33 +113,27 @@ module Certbot
       end
     end
 
-    # Test class that makes no calls to external inerfaces
+    # Test class that makes no calls to external interfaces
     # Accessor methods allow setting dummy values for all
-    # instance variables
-    class TestClient
+    # instance variables as required for testing
+    class TestClient < Client
       attr_accessor :hosts, :not_after, :last_error, :valid
 
-      def initialize(hosts: [], not_after: Time.current, last_error: nil, valid: true)
-        @hosts = hosts
+      def initialize(domains: [], not_after: Time.current, last_error: nil, valid: true)
+        super()
+        @domains = domains
         @not_after = not_after
         @last_error = last_error
         @valid = valid
       end
 
-      def valid?
-        !!valid
-      end
+      private
 
-      def invalid?
-        !valid
-      end
+      def load_certificate; end
 
-      def add_host(host)
-        @hosts = hosts << host
-      end
-
-      def remove_host(host)
-        @hosts = hosts - [host]
+      def update_hosts(new_hosts)
+        Rails.logger.warn("TEST CLIENT: would have called Certbot with: #{CERTBOT_UPDATE + new_hosts}")
+        @hosts = new_hosts
       end
     end
   end

--- a/app/models/custom_domain.rb
+++ b/app/models/custom_domain.rb
@@ -4,32 +4,21 @@ class CustomDomain < ApplicationRecord
   validates :host, uniqueness: true
   validates :host, format: { with: Certificate::DOMAIN_PATTERN, message: 'must be a valid DNS hostname' },
                    allow_blank: true
-  validate :host_can_be_resolved
   validate :certbot_success
 
   before_save :update_certificate
-
-  def host_can_be_resolved; end
 
   def certbot_success
     if certbot_client.invalid?
       errors.add(:base, :certbot, message: 'could not initialize Certbot')
     elsif certbot_client.last_error.present?
       errors.add(:host, :certificate, message: "certificate update error text:\n#{certbot_client.last_error}")
-    else
-      # no certbot errors
-      return true
     end
-    false
-  end
-
-  def initialize(attributes = nil)
-    super
   end
 
   def update_certificate
-    certbot_client.add_host(host)
-    raise ActiveRecord::RecordInvalid unless certbot_success
+    success = certbot_client.add_host(host)
+    raise ActiveRecord::RecordInvalid unless success
   end
 
   def certbot_client

--- a/spec/models/custom_domain_spec.rb
+++ b/spec/models/custom_domain_spec.rb
@@ -2,21 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CustomDomain do
   let(:domain) { described_class.new }
-  let(:success) { Process.wait2(fork { Process.exit 0 })[1] }
-  let(:certbot_stdout) do
-    <<~STDOUT
-      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-      Found the following matching certs:
-        Certificate Name: t3.application
-          Serial Number: 12345678901234567890123456789012345
-          Key Type: ECDSA
-          Domains: t3.example.com
-          Expiry Date: 2023-11-12 19:15:08+00:00 (VALID: 89 days)
-          Certificate Path: /etc/letsencrypt/live/t3.application/fullchain.pem
-          Private Key Path: /etc/letsencrypt/live/t3.application/privkey.pem
-      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    STDOUT
-  end
+  let(:test_cert) { Certbot::V2::TestClient.new(domains: ['my-host.example.com'], not_after: 10.minutes.from_now) }
   let(:auth_failure) do
     <<~STDOUT
       Certbot failed to authenticate some domains (authenticator: apache). The Certificate Authority reported these problems:
@@ -25,17 +11,12 @@ RSpec.describe CustomDomain do
         Detail: 50.16.172.231: Invalid response from https://demo.tenejo.com/.well-known/acme-challenge/sxzTJOsdmDKfInk7chxPpYj_9HWjEkEbInNP5ZFKTcY: 404
 
       Hint: The Certificate Authority failed to verify the temporary Apache configuration changes made by Certbot. Ensure that the listed domains point to this Apache server and that it is accessible from the internet.
-
-      Some challenges have failed.
     STDOUT
   end
 
   before do
-    # stub certbot certificate returning a single domain
-    allow(Open3)
-      .to receive(:capture2e)
-      .with(Certbot::V2::Client::CERTBOT_READ)
-      .and_return([certbot_stdout, success])
+    # stub certbot api calls
+    allow(Certbot::V2::Client).to receive(:new).and_return(test_cert)
   end
 
   it 'has a host attribute' do
@@ -58,8 +39,8 @@ RSpec.describe CustomDomain do
     end
 
     example 'checks certbot setup' do
-      # stub certbot returning a partial update error
-      allow(Open3).to receive(:capture2e).with(Certbot::V2::Client::CERTBOT_READ).and_return(['error', success])
+      # stub certbot failing to read a local certificate
+      test_cert.valid = false
       d1 = described_class.new(host: 'demo.tenejo.com')
       d1.valid?
       expect(d1.errors.where(:base, :certbot)).to be_present
@@ -67,8 +48,7 @@ RSpec.describe CustomDomain do
 
     example 'checks certbot errors' do
       # stub certbot returning a partial update error
-      allow(Open3).to receive(:capture2e)
-        .with(a_string_matching(Certbot::V2::Client::CERTBOT_UPDATE)).and_return([auth_failure, success])
+      test_cert.last_error = auth_failure
       d1 = described_class.new(host: 'demo.tenejo.com')
       d1.save
       expect(d1.errors.where(:host, :certificate)).to be_present
@@ -76,31 +56,30 @@ RSpec.describe CustomDomain do
   end
 
   describe '#save' do
-    before do
-      # stub certbot returning a partial update error
-      allow(Open3).to receive(:capture2e)
-        .with(a_string_matching(Certbot::V2::Client::CERTBOT_UPDATE))
-        .and_return([auth_failure, success])
-    end
-
     it 'calls certbot with the hostname' do
-      # stub out calls to certbot #add_host
       allow(domain.certbot_client).to receive(:add_host)
       domain.host = 'demo.tenejo.com'
       domain.save
       expect(domain.certbot_client).to have_received(:add_host).with('demo.tenejo.com')
     end
 
-    it 'returns false on certbot failures', :aggregate_failures do
-      domain.host = 'demo.tenejo.com'
-      expect(domain.save).to be false
-      expect(domain.errors).not_to be_nil
-    end
+    context 'with certbot failures' do
+      before do
+        # stub certbot returning a partial update error
+        test_cert.last_error = auth_failure
+      end
 
-    it 'returns the error on certbot failure' do
-      domain.host = 'demo.tenejo.com'
-      domain.save
-      expect(domain.errors.where(:host, :certificate)).not_to be_nil
+      it 'returns false', :aggregate_failures do
+        domain.host = 'demo.tenejo.com'
+        expect(domain.save).to be false
+        expect(domain.errors).not_to be_nil
+      end
+
+      it 'adds an error to the domain object' do
+        domain.host = 'demo.tenejo.com'
+        domain.save
+        expect(domain.errors.where(:host, :certificate)).to be_present
+      end
     end
   end
 end

--- a/spec/requests/admin/custom_domains_spec.rb
+++ b/spec/requests/admin/custom_domains_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe '/admin/custom_domains' do
   # adjust the attributes here as well.
   let(:valid_attributes) { { host: 'my-host.example.com' } }
   let(:invalid_attributes) { { host: 'not_a_valid_domain' } }
+  let(:test_cert) { Certbot::V2::TestClient.new(domains: ['my-host.example.com'], not_after: 10.minutes.from_now) }
 
   let(:super_admin)  { FactoryBot.create(:super_admin) }
   let(:regular_user) { FactoryBot.create(:user) }
@@ -14,7 +15,7 @@ RSpec.describe '/admin/custom_domains' do
     # Stub DNS requests to isolate external services
     allow(Resolv).to receive(:getaddress).and_return('10.10.0.1')
     login_as super_admin
-    allow(Certbot::V2::Client).to receive(:new).and_return(Certbot::V2::TestClient.new)
+    allow(Certbot::V2::Client).to receive(:new).and_return(test_cert)
   end
 
   describe 'GET /index' do
@@ -76,12 +77,10 @@ RSpec.describe '/admin/custom_domains' do
 
   describe 'PATCH /update' do
     context 'with valid parameters' do
-      let(:new_attributes) { { host: 'new-domain.example.com' } }
-
       it 'updates the requested custom_domain' do
         custom_domain = CustomDomain.create! valid_attributes
         expect do
-          patch custom_domain_url(custom_domain), params: { custom_domain: new_attributes }
+          patch custom_domain_url(custom_domain), params: { custom_domain: { host: 'invalid-domain.example.com' } }
         end.to raise_exception(ActionController::RoutingError)
       end
     end


### PR DESCRIPTION
**ISSUE**
The code previously stubbed out low-level system calls to Open3 to simulate behavior in the Certbot::V2::Client that triggered various behaviors in the CustomDomain model.  This requires the tests to have knowlege of the underlying implementation in a different class.  This makes the tests somewhat fragile and difficult to interpret.

**FIX**
This change leverages the Certbot::V2::TestClient to directly set the return values that we want to test in the CustomDomain model. This decouples the CustomDomain tests from the Certbot implementation and hopefully clarifies the specific return values and object states that drive behavior in the CustomDomain class.