### PR TITLE
Refactor CustomDomain validations

### DIFF
--- a/app/models/custom_domain.rb
+++ b/app/models/custom_domain.rb
@@ -1,38 +1,66 @@
 # Vanity Domains
 class CustomDomain < ApplicationRecord
-  validates :host, presence: true
-  validates :host, uniqueness: true
-  validate :validate_domain_resolvable
-  validate :validate_certbot_success
+  validate :domain_setup_ok?
 
   before_save :update_certificate
+
+  def certbot_client
+    @certbot_client ||= Certbot::V2::Client.new
+  end
 
   def update_certificate
     success = certbot_client.add_host(host)
     raise ActiveRecord::RecordInvalid unless success
   end
 
-  def certbot_client
-    @certbot_client ||= Certbot::V2::Client.new
+  private
+
+  # Checks whether a certificate can be generated for the domain
+  #
+  # Adds a single error to the model representing the first failed process stage
+  # because it would be redundant to add errors for successive stages
+  # e.g. an improperly formatted host can never be resolved
+  # and an unresolvable host can never be authenticated by certbot
+  #
+  # @return boolean True if domain passes all validations
+  def domain_setup_ok?
+    certbot_ok? && format_valid? && host_unique? && host_resolvable? && certificate_ok?
   end
 
-  def validate_domain_resolvable
-    return unless host
+  def certbot_ok?
+    return true if certbot_client.valid?
 
-    if host =~ Certificate::DOMAIN_PATTERN
-      Resolv.getaddress(host)
-    else
-      errors.add(:host, :format, message: 'must be a valid DNS hostname')
-    end
+    errors.add(:base, :certbot, message: 'could not initialize Certbot')
+    false
+  end
+
+  def format_valid?
+    return true if host =~ Certificate::DOMAIN_PATTERN
+
+    errors.add(:host, :format, message: 'must be a valid DNS hostname')
+    false
+  end
+
+  def host_unique?
+    return true if CustomDomain.where(host: host).none?
+
+    errors.add(:host, :taken, message: 'has already been taken')
+    false
+  end
+
+  def host_resolvable?
+    return true if Resolv.getaddress(host)
+
+  # Resolv.getaddress raises an error on failures instead of returning a value
   rescue Resolv::ResolvError
     errors.add(:host, :unresolvable, message: 'can not be resolved via DNS')
+    false
   end
 
-  def validate_certbot_success
-    if certbot_client.invalid?
-      errors.add(:base, :certbot, message: 'could not initialize Certbot')
-    elsif certbot_client.last_error.present?
-      errors.add(:host, :certificate, message: "certificate update error text:\n#{certbot_client.last_error}")
-    end
+  def certificate_ok?
+    return true if certbot_client.last_error.blank?
+
+    errors.add(:host, :certificate, message: "certificate update error text:\n#{certbot_client.last_error}")
+    false
   end
 end

--- a/spec/models/custom_domain_spec.rb
+++ b/spec/models/custom_domain_spec.rb
@@ -25,12 +25,6 @@ RSpec.describe CustomDomain do
   end
 
   describe 'validation' do
-    example 'checks host presence' do
-      d1 = described_class.new(host: nil)
-      d1.valid?
-      expect(d1.errors.where(:host, :blank)).to be_present
-    end
-
     example 'checks host uniqueness' do
       # Add the name to the table without calling other model logic
       described_class.insert({ host: 't3.example.com' })


### PR DESCRIPTION
We want the validations to only return the single most relevant issue - i.e. an incorrectly formatted domain can never be resolved or authorized by certbot, so there's no point in listing the higher level errors.

This commit consolidates all the :host vailidations into a single method that returns only the lowest-level :host error.

This commit also eliminates the presence test since it is covered by the format test - i.e. a blank domain will fail the format test.