### PR TITLE
Provide detailed error instructions for CustomDomain host errors

### DIFF
--- a/app/models/custom_domain.rb
+++ b/app/models/custom_domain.rb
@@ -22,6 +22,8 @@ class CustomDomain < ApplicationRecord
   # e.g. an improperly formatted host can never be resolved
   # and an unresolvable host can never be authenticated by certbot
   #
+  # Error priority: (:base) :certbot, (:host) :format, :taken, :unresolvable, :certificate
+  #
   # @return boolean True if domain passes all validations
   def domain_setup_ok?
     certbot_ok? && format_valid? && host_unique? && host_resolvable? && certificate_ok?

--- a/app/views/admin/custom_domains/_error_instructions.html.erb
+++ b/app/views/admin/custom_domains/_error_instructions.html.erb
@@ -1,0 +1,51 @@
+<% if @custom_domain.errors.any? %>
+  <% other_errors = @custom_domain.errors.select{|e| e.attribute != :host}  %>
+  <div class='errors'>
+    <h2><%= pluralize(other_errors.count, "error") %> prohibited this domain from being saved:</h2>
+
+    <ul>
+      <% other_errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+
+    <%# Potential hsot errors :format, :taken, :unresolvable, :certificate %>
+    <% if @custom_domain.errors.where(:host, :format).present? %>
+      <div id='format'>
+        <p>The name you have supplied is incorrectly formatted.  Please check that you've entered the name
+        correctly.  Domain names have a host name followed by a period followed by zero or more sub-domain
+        names each separated by a period, followed by a a domain name and a top-level domain (e.g. .com, .org.
+          or .edu)</p>
+
+        <p>Examples:<br>
+        <pre>
+    my-host.subdomain.domain.org
+    digital.libary.university.edu
+        </pre></p>
+      </div>
+
+    <% elsif @custom_domain.errors.where(:host, :taken).present? %>
+      <div id='taken'>
+        <p>The name you have supplied is already being used.)</p>
+      </div>
+
+    <% elsif @custom_domain.errors.where(:host, :unresolvable).present? %>
+      <div id='unresolvable'>
+        <p>The name you have supplied cannot be resolved using DNS.  Please make sure that you have added the
+          name as a CNAME entry pointing to <%= Certbot::V2::TestClient.default_host %> in your DNS zone.)</p>
+        <p>Examples:<br>
+        <pre>
+    <%= @custom_domain.host.split('.').first %> CNAME <%= Certbot::V2::TestClient.default_host %>
+        </pre></p>
+      </div>
+
+    <% elsif @custom_domain.errors.where(:host, :certificate).present? %>
+      <div id='certificate'>
+        <p>Certbot was unable to register your domain with Let's Encrypt.  The certbot error message was:<br>
+        <pre>
+<%= @custom_domain.certbot_client.last_error %>
+        </pre></p>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/custom_domains/new.html.erb
+++ b/app/views/admin/custom_domains/new.html.erb
@@ -1,18 +1,8 @@
 <h1>Add Custom Hostname</h1>
 
+<%= render 'error_instructions' %>
+
 <%= form_with(model: @custom_domain) do |form| %>
-  <% if @custom_domain.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(@custom_domain.errors.count, "error") %> prohibited this domain from being saved:</h2>
-
-      <ul>
-        <% @custom_domain.errors.each do |error| %>
-          <li><%= simple_format(error.full_message, wrapper_tag: 'div') %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
   <div>
     <%= form.label :host, style: "display: block" %>
     <%= form.text_field :host, autofocus: true %>

--- a/spec/views/admin/custom_domains/new.html.erb_spec.rb
+++ b/spec/views/admin/custom_domains/new.html.erb_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/custom_domains/new' do
+  let(:custom_domain) { CustomDomain.new }
+
   before do
-    assign(:custom_domain, CustomDomain.new)
+    assign(:custom_domain, custom_domain)
   end
 
   it 'renders new domain form' do
@@ -18,5 +20,37 @@ RSpec.describe 'admin/custom_domains/new' do
   it 'has a submit button' do
     render
     expect(rendered).to have_button(type: 'submit')
+  end
+
+  describe 'shows errors for' do
+    before do
+      allow(Certbot::V2::Client).to receive(:new).and_return(Certbot::V2::TestClient.new)
+    end
+
+    example ':format' do
+      custom_domain.errors.add(:host, :format)
+      render
+      expect(rendered).to have_selector('div#format')
+    end
+
+    example ':taken' do
+      custom_domain.errors.add(:host, :taken)
+      render
+      expect(rendered).to have_selector('div#taken')
+    end
+
+    example ':unresolvable' do
+      custom_domain.host = 'test.example.com'
+      custom_domain.errors.add(:host, :unresolvable)
+      render
+      expect(rendered).to have_selector('div#unresolvable')
+    end
+
+    example ':certificate' do
+      custom_domain.certbot_client.last_error = 'Something unexpected happened'
+      custom_domain.errors.add(:host, :certificate)
+      render
+      expect(rendered).to have_selector('div#certificate')
+    end
   end
 end


### PR DESCRIPTION
**ISSUE**
When a custom domain setup error occurs, we want to provide the admiistrator with enough information to correct the error.  Since admins may not be familiar with setting up TLS certificates, a basic Rails error message may not be sufficient to let them know what has gone wrong.

**SOLUTION**
Suppress the default error messages for :host errors and provide more detailed setup instructions based on the error type.

**NOTE**
Curently the prioritized list of errors is:

* :certbot      - There was a problem with the Certbot installation
* :format       - The domain name is missing or improperly formatted
* :taken        - The domain name is already in use by the application
* :unresolvable - The domain name can not be resolved via DNS
* :certificate  - Certbot encountered an error when trying to add the domain