### PR TITLE
Refactor app to use a test client for certbot in dev and test

### DIFF
--- a/app/api/certbot/v2/client.rb
+++ b/app/api/certbot/v2/client.rb
@@ -112,29 +112,5 @@ module Certbot
         end
       end
     end
-
-    # Test class that makes no calls to external interfaces
-    # Accessor methods allow setting dummy values for all
-    # instance variables as required for testing
-    class TestClient < Client
-      attr_accessor :hosts, :not_after, :last_error, :valid
-
-      def initialize(domains: [], not_after: Time.current, last_error: nil, valid: true)
-        super()
-        @domains = domains
-        @not_after = not_after
-        @last_error = last_error
-        @valid = valid
-      end
-
-      private
-
-      def load_certificate; end
-
-      def update_hosts(new_hosts)
-        Rails.logger.warn("TEST CLIENT: would have called Certbot with: #{CERTBOT_UPDATE + new_hosts}")
-        @hosts = new_hosts
-      end
-    end
   end
 end

--- a/app/api/certbot/v2/test_client.rb
+++ b/app/api/certbot/v2/test_client.rb
@@ -1,0 +1,27 @@
+module Certbot
+  module V2
+    # Test class that makes no calls to external interfaces
+    # Accessor methods allow setting dummy values for all
+    # instance variables as required for testing
+    class TestClient < Client
+      attr_accessor :hosts, :not_after, :last_error, :valid
+
+      def initialize(domains: [], not_after: 1.day.from_now, last_error: nil, valid: true)
+        super()
+        @domains = [TestClient.default_host].concat(domains).uniq
+        @not_after = not_after
+        @last_error = last_error
+        @valid = valid
+      end
+
+      private
+
+      def load_certificate; end
+
+      def update_hosts(new_hosts)
+        Rails.logger.warn("TEST CLIENT: would have called Certbot with: #{CERTBOT_UPDATE + new_hosts}")
+        @hosts = new_hosts
+      end
+    end
+  end
+end

--- a/app/models/custom_domain.rb
+++ b/app/models/custom_domain.rb
@@ -5,7 +5,7 @@ class CustomDomain < ApplicationRecord
   before_save :update_certificate
 
   def certbot_client
-    @certbot_client ||= Certbot::V2::Client.new
+    @certbot_client ||= Rails.env.production? ? Certbot::V2::Client.new : Certbot::V2::TestClient.new
   end
 
   def update_certificate

--- a/spec/requests/admin/custom_domains_spec.rb
+++ b/spec/requests/admin/custom_domains_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe '/admin/custom_domains' do
   # adjust the attributes here as well.
   let(:valid_attributes) { { host: 'my-host.example.com' } }
   let(:invalid_attributes) { { host: 'not_a_valid_domain' } }
-  let(:test_cert) { Certbot::V2::TestClient.new(domains: ['my-host.example.com'], not_after: 10.minutes.from_now) }
 
   let(:super_admin)  { FactoryBot.create(:super_admin) }
   let(:regular_user) { FactoryBot.create(:user) }
@@ -15,7 +14,6 @@ RSpec.describe '/admin/custom_domains' do
     # Stub DNS requests to isolate external services
     allow(Resolv).to receive(:getaddress).and_return('10.10.0.1')
     login_as super_admin
-    allow(Certbot::V2::Client).to receive(:new).and_return(test_cert)
   end
 
   describe 'GET /index' do

--- a/spec/views/admin/custom_domains/index.html.erb_spec.rb
+++ b/spec/views/admin/custom_domains/index.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'admin/custom_domains/index' do
     expect(rendered).to have_selector('td.host', count: 3)
   end
 
-  it 'has links to delte each domain' do
+  it 'has links to delete each domain' do
     render
     expect(rendered).to have_button('delete_custom_domain_3')
   end

--- a/spec/views/admin/custom_domains/new.html.erb_spec.rb
+++ b/spec/views/admin/custom_domains/new.html.erb_spec.rb
@@ -23,10 +23,6 @@ RSpec.describe 'admin/custom_domains/new' do
   end
 
   describe 'shows errors for' do
-    before do
-      allow(Certbot::V2::Client).to receive(:new).and_return(Certbot::V2::TestClient.new)
-    end
-
     example ':format' do
       custom_domain.errors.add(:host, :format)
       render


### PR DESCRIPTION
**ISSUE**
Certbot is intended to run in production environments. Configuring Certbot to run successfully in a local development or test environment would be complicated and fragile.  It also requires sudo priveleges that block tests and development servers unless local sudoers is modified.

**SOLUTION**
Default to use the Certbot::V2::TestClient in development and test environments instead of Certbot::V2::Client, which is only used in production.