### PR TITLE
Display default host information with CustomDomains

### DIFF
--- a/app/views/admin/custom_domains/index.html.erb
+++ b/app/views/admin/custom_domains/index.html.erb
@@ -2,11 +2,29 @@
 
 <div id='default_domain'>
   <h2>Default Host</h2>
-  <p>default domain name and certificate info goes here...</p>
+  <% default_host = Certbot::V2::Client.default_host %>
+  <table>
+    <tr>
+      <td class='label'>Default Host:</td>
+      <td class='value' id='default_host'><%= default_host %></td>
+    </tr>
+    <tr>
+      <td class='label'>URL:</td>
+      <td class='value'><%= link_to root_url(host: default_host) %></td>
+    </tr>
+    <tr>
+      <td class='label'>Cert Expires:</td>
+      <td class='value' id='not_valid_after'><%= CustomDomain.new.certbot_client.not_after %></td>
+    </tr>
+  </table>
 </div>
 
+<br>
 <div id="custom_domains">
   <h2>Additional Domains</h2>
+  <p>To access your site via a custom domain name, you need to add the host name in your institution's
+    dns with a CNAME pointing to the default host listed above.  Once you've updated your DNS, add the domain as
+    a new custom domain usig the button below.</p>
   <table>
     <tr>
       <th class='host'>Host Name</th>

--- a/spec/api/certbot/v2/client_spec.rb
+++ b/spec/api/certbot/v2/client_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe Certbot::V2::Client do
 
   describe '.default_host' do
     it 'returns the hostname configured on the server' do
+      described_class.instance_variable_set(:@default_host, nil)
       allow(described_class).to receive(:`).with('hostname -f').and_return("fqdn.example.com\n")
 
       expect(described_class.default_host).to eq 'fqdn.example.com'

--- a/spec/views/admin/custom_domains/index.html.erb_spec.rb
+++ b/spec/views/admin/custom_domains/index.html.erb_spec.rb
@@ -21,14 +21,12 @@ RSpec.describe 'admin/custom_domains/index' do
   end
 
   it 'displays the default domain' do
-    pending 'certificate implementation'
     render
-    expect(rendered).to have_selector('default_domain', text: 't3.curationexperts.com')
+    expect(rendered).to have_selector('#default_host')
   end
 
   it 'displays the certificate expiration' do
-    pending 'certificate implementation'
     render
-    expect(rendered).to have_selector('not_valid_after', text: '3 days from now')
+    expect(rendered).to have_selector('#not_valid_after')
   end
 end


### PR DESCRIPTION
This commit adds host and certificate expiration information to the Custom Domain index view.

It also updates the Cerbot client spec to reset any memoized hostname.  Depending on the randomized order of tests, other tests might memoize the local system's hostname before running the Certbot Client spec.

**BEFORE**
<img width="1122" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/0221af78-11e9-4979-a93d-c14687cdf857">

**AFTER**
<img width="1097" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/3367de00-c532-4f14-bee8-7250f523ad82">
