### PR TITLE
Fix bug not displaying certificate errors on new host setup

### DIFF
--- a/app/api/certbot/v2/client.rb
+++ b/app/api/certbot/v2/client.rb
@@ -69,7 +69,7 @@ module Certbot
         response, status = Open3.capture2e(CERTBOT_UPDATE + new_hosts)
         Rails.logger.warn("Certbot returned: \n#{response}")
         @last_error = extract_errors(response, status)
-        load_certificate && @last_error.blank?
+        load_certificate && last_error.blank?
       end
 
       # call certbot to return a certificate summary

--- a/app/api/certbot/v2/test_client.rb
+++ b/app/api/certbot/v2/test_client.rb
@@ -4,7 +4,7 @@ module Certbot
     # Accessor methods allow setting dummy values for all
     # instance variables as required for testing
     class TestClient < Client
-      attr_accessor :hosts, :not_after, :last_error, :valid
+      attr_accessor :domains, :not_after, :last_error, :valid
 
       def initialize(domains: [], not_after: 1.day.from_now, last_error: nil, valid: true)
         super()
@@ -16,11 +16,14 @@ module Certbot
 
       private
 
-      def load_certificate; end
-
       def update_hosts(new_hosts)
         Rails.logger.warn("TEST CLIENT: would have called Certbot with: #{CERTBOT_UPDATE + new_hosts}")
-        @hosts = new_hosts
+        @domains = new_hosts
+        load_certificate && last_error.blank?
+      end
+
+      def load_certificate
+        valid?
       end
     end
   end

--- a/app/models/custom_domain.rb
+++ b/app/models/custom_domain.rb
@@ -9,8 +9,8 @@ class CustomDomain < ApplicationRecord
   end
 
   def update_certificate
-    success = certbot_client.add_host(host)
-    raise ActiveRecord::RecordInvalid unless success
+    certbot_client.add_host(host)
+    raise ActiveRecord::RecordInvalid unless valid?
   end
 
   private

--- a/app/views/admin/custom_domains/_error_instructions.html.erb
+++ b/app/views/admin/custom_domains/_error_instructions.html.erb
@@ -25,7 +25,7 @@
 
     <% elsif @custom_domain.errors.where(:host, :taken).present? %>
       <div id='taken'>
-        <p>The name you have supplied is already being used.)</p>
+        <p>The name you have supplied is already being used.</p>
       </div>
 
     <% elsif @custom_domain.errors.where(:host, :unresolvable).present? %>

--- a/spec/models/custom_domain_spec.rb
+++ b/spec/models/custom_domain_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe CustomDomain do
         Detail: 50.16.172.231: Invalid response from https://demo.tenejo.com/.well-known/acme-challenge/sxzTJOsdmDKfInk7chxPpYj_9HWjEkEbInNP5ZFKTcY: 404
 
       Hint: The Certificate Authority failed to verify the temporary Apache configuration changes made by Certbot. Ensure that the listed domains point to this Apache server and that it is accessible from the internet.
+
+      Unable to obtain a certificate with every requested domain. Retrying without: demo.tenejo.com
     STDOUT
   end
 
@@ -79,8 +81,8 @@ RSpec.describe CustomDomain do
 
       it 'adds an error to the domain object' do
         domain.host = 'demo.tenejo.com'
-        # simulate certbot returning a partial update error
-        domain.certbot_client.last_error = auth_failure
+        # simulate domain passing initial validation on save, then failing after certbot update_hosts
+        allow(domain.certbot_client).to receive(:last_error).and_return(nil, auth_failure)
         domain.save
         expect(domain.errors.where(:host, :certificate)).to be_present
       end


### PR DESCRIPTION
**ISSUE**
When certbot encountered an authentication failure for a domain, the new host form was displaying, but no error message was shown.

**DIAGNOSIS**
The error was occuring after the domain was validated, so domain.save failed, but there were no validation errors.

**FIX**
Update the update_certificate method to re-validate after certbot calls.

Also updates the `Certbot::V2::TestClient` implementation to more closely follow the production `Certbot::V2::Client` implementation.