### PR TITLE
Disable user self-registration

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -75,7 +75,7 @@ module Admin
 
     # Use callbacks to share common setup or constraints between actions.
     def set_user
-      @user = User.find(params[:id])
+      @user = User.find_by(id: params[:id]) || current_user
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :invitable, :database_authenticatable, :registerable,
+  devise :invitable, :database_authenticatable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: [:google]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
     end
     resources :configs
     resources :custom_domains, except: %i[edit update show]
+    get 'profile', to: 'users#edit', as: :edit_user_registration
   end
 
   # When app is firt booted and no Solr config exists, use this as the application root


### PR DESCRIPTION
**ISSUE**
Users should not be able to create accounts on their own without being invitied by an administrator.

**SOLUTION**
Remove the Devise Registerable module from the user model.  This removes the "Sign Up" link from the login screen and removes Devise funcitonality to allow users to edit and delete their own account.

Because Blacklight inlcudes a link to the edit_user_registration route, we need to supply a definition for this helper.  For the time being, we've added a user profile route that allows a user to edit their own record.