### PR TITLE
Redirect admins to the dashboard after login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,4 +18,13 @@ class ApplicationController < ActionController::Base
       format.js   { render nothing: true, status: :not_found }
     end
   end
+
+  def after_sign_in_path_for(resource)
+    stored_location_for(resource) ||
+      if can? :read, :dashboard
+        status_url
+      else
+        super
+      end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,4 +82,8 @@ RSpec.configure do |config|
   config.before(:each, type: :component) do
     @request = vc_test_controller.request
   end
+
+  config.before(:each, type: :system) do
+    driven_by(:rack_test)
+  end
 end

--- a/spec/system/post_login_redirect_spec.rb
+++ b/spec/system/post_login_redirect_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Login' do
+  let(:user)  { FactoryBot.create(:user,        password: 'password') }
+  let(:admin) { FactoryBot.create(:super_admin, password: 'password') }
+
+  # Stub out Solr service
+  before do
+    solr_response = { responseHeader: { status: 0, QTime: 60, params: { rows: '10', wt: 'json' } },
+                      response: { numFound: 0, start: 0, maxScore: 0.0, numFoundExact: true, docs: [] },
+                      facet_counts: { facet_fields: { active_fedora_model_ssi: [], subject_ssim: [] },
+                                      facet_queries: {}, facet_ranges: {}, facet_intervals: {} } }
+    solr_client = instance_double RSolr::Client
+    allow(RSolr).to receive(:connect).and_return(solr_client)
+    allow(solr_client).to receive(:get).and_return solr_response
+    allow(solr_client).to receive(:send_and_receive).and_return solr_response
+  end
+
+  it 'redirects administrators to the status page' do
+    visit new_user_session_path
+    fill_in 'user_email', with: admin.email
+    fill_in 'user_password', with: 'password'
+    click_on 'Log in'
+    expect(page).to have_current_path status_path
+  end
+
+  it 'redirects regular users to root' do
+    visit new_user_session_path
+    fill_in 'user_email', with: user.email
+    fill_in 'user_password', with: 'password'
+    click_on 'Log in'
+    expect(page).to have_current_path root_path
+  end
+end


### PR DESCRIPTION
**STORY**
As an administrator, I want to go directly to the dashboard after logging in, so that I don't have to always click the dashboard link.

**DETAILS**
This change updates the Devise `.after_sign_in_path_for(resource)` method to check for admin users and redirect them to the dashboard instead of the Devise default.

Normal users are still sent to the root_path, which is the Blacklight Catalog index page.