### PR TITLE
Fix host url display on custom domains page

### DIFF
--- a/app/views/admin/custom_domains/index.html.erb
+++ b/app/views/admin/custom_domains/index.html.erb
@@ -10,7 +10,7 @@
     </tr>
     <tr>
       <td class='label'>URL:</td>
-      <td class='value'><%= link_to root_url(host: default_host) %></td>
+      <td class='value'><%= link_to root_url, root_url %></td>
     </tr>
     <tr>
       <td class='label'>Cert Expires:</td>


### PR DESCRIPTION
**ISSUE**
Only the hostname portion of the default URL is displaying on the Custom Domains index view.  We want the full domain to display so the URL is actually resolvable

**FIX**
Supply the url to the link helper twice, as both the link reference and the display text to be used for the link.