### PR TITLE
Allow administrators to invite OAuth accounts

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -2,7 +2,7 @@ module Users
   # Authentication callback controller for third-party authenticaion
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     def google
-      user = User.from_omniauth(auth)
+      user = User.from_omniauth(auth, token)
 
       if user.persisted?
         sign_in_and_redirect user, event: :authentication
@@ -21,7 +21,11 @@ module Users
     private
 
     def auth
-      @auth ||= request.env['omniauth.auth']
+      request.env['omniauth.auth']
+    end
+
+    def token
+      request.env.dig('omniauth.params', 'invitation_token')
     end
   end
 end

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,0 +1,28 @@
+<h2><%= t "devise.invitations.edit.header" %></h2>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <p><%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider, invitation_token: params[:invitation_token]), params: {login_hint: resource.email}, data: { turbo: false } %></p>
+  <% end %>
+<% end %>
+
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :invitation_token, readonly: true %>
+
+  <% if f.object.class.require_password_on_accepting %>
+    <div class="field">
+      <%= f.label :password %><br />
+      <%= f.password_field :password %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation %><br />
+      <%= f.password_field :password_confirmation %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit t("devise.invitations.edit.submit_button") %>
+  </div>
+<% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,0 +1,16 @@
+<h2><%= t "devise.invitations.new.header" %></h2>
+
+<%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <% resource.class.invite_key_fields.each do |field| -%>
+    <div class="field">
+      <%= f.label field %><br />
+      <%= f.text_field field %>
+    </div>
+  <% end -%>
+
+  <div class="actions">
+    <%= f.submit t("devise.invitations.new.submit_button") %>
+  </div>
+<% end %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,0 +1,11 @@
+<p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
+
+<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
+
+<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token) %></p>
+
+<% if @resource.invitation_due_at %>
+  <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
+<% end %>
+
+<p><%= t("devise.mailer.invitation_instructions.ignore") %></p>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,0 +1,11 @@
+<%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %>
+
+<%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %>
+
+<%= accept_invitation_url(@resource, invitation_token: @token) %>
+
+<% if @resource.invitation_due_at %>
+  <%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>
+<% end %>
+
+<%= t("devise.mailer.invitation_instructions.ignore") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,12 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
   t3:
     header_links:
       status: 'Dashboard'
+
+  activerecord:
+    errors:
+      models:
+        user:
+          unauthorized_account: 'Unauthorized account'

--- a/spec/requests/users/omniauth_callback_spec.rb
+++ b/spec/requests/users/omniauth_callback_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe 'Users::OmniauthCallbacksController' do
   before do
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:google] = FactoryBot.build(:google_auth_hash)
+
+    # Stub user persistence
+    user = FactoryBot.build(:user)
+    allow(user).to receive(:persisted?).and_return(true)
+    allow(User).to receive(:find_by).and_return(user)
   end
 
   after do
@@ -19,7 +24,7 @@ RSpec.describe 'Users::OmniauthCallbacksController' do
     end
 
     it 'redirects to signin on failed authentication', :aggregate_failures do
-      # simulate failed login
+      # simulate failed authentication
       # see: https://github.com/omniauth/omniauth/wiki/Integration-Testing#mocking-failure
       OmniAuth.config.mock_auth[:google] = :invalid_credentials
 


### PR DESCRIPTION
**ISSUES**
The Devise Invitable module was not playing nicely with Google OAuth accounts because:
1. Invitable creates a user with the target email that caused an "Email already in use" error when User.from_omniauth was called
2. Google users with multiple identitites could confirm an account for any of their identities instead of only the one corresponding to the invited e-mail address
3. Google user could still self-register without administrator invitation because of the omniauth callback logic

**SOLUTION**
1. Update the User.from_omniauth method to check for an invitation token and update the invited user rather than attempting to create a new user with the omniauth information.
2. Send the desired email to google as a login_hint - see https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters
3. Remove create logic from the omniauth callback controller and rely on finding the user either by an invitation token for new users or their provider uid for existing users