### PR TITLE
Display the admin sidebar when inviting users

### DIFF
--- a/app/helpers/custom_layout_helper.rb
+++ b/app/helpers/custom_layout_helper.rb
@@ -6,7 +6,7 @@ module CustomLayoutHelper
   # Convenience function for rendering dashboard views
   # True whenever our controller sits under the Admin:: namespace
   def show_dashboard?
-    controller.class.module_parent_name == 'Admin'
+    ['Admin', 'Users'].include? controller.class.module_parent_name
   end
 
   ##

--- a/spec/helpers/custom_layout_helper_spec.rb
+++ b/spec/helpers/custom_layout_helper_spec.rb
@@ -19,7 +19,14 @@ RSpec.describe CustomLayoutHelper do
       expect(helper.show_dashboard?).to be true
     end
 
-    it 'returns false for non-Admin views' do
+    it 'returns true for User views' do
+      # Devise controllers are all under the 'User' namespace
+      # and should be displayed wih the dashboard sidebar
+      allow(controller.class).to receive(:module_parent_name).and_return('Users')
+      expect(helper.show_dashboard?).to be true
+    end
+
+    it 'returns false for other views' do
       allow(controller.class).to receive(:module_parent_name).and_return('Blacklight')
       expect(helper.show_dashboard?).to be false
     end


### PR DESCRIPTION
**ISSUE**
The user invitation view did not display the dashboard sidebar.

**SOLUTION**
Update the layout helper to recognize the namespace used by Devise (i.e. User) as well as any under the Admin namespace.