### PR TITLE
Allow admins to set display name and roles for invited users

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,6 +1,11 @@
 module Users
-  # Subclass with restrictions on which users can invite others
+  # Subclass of devise_invitable invitations controller that
+  # - Restricts which users can invite others
+  # - Allows additional parameters when creating invited users
+  # - Redirects to the user dashboard after issuing an invite
   class InvitationsController < Devise::InvitationsController
+    before_action :configure_permitted_parameters
+
     def authenticate_inviter!
       return unless cannot? :create, User
 
@@ -13,6 +18,12 @@ module Users
 
     def after_invite_path_for(_inviter, _invitee)
       users_path
+    end
+
+    protected
+
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:invite, keys: [:display_name, { role_ids: [] }])
     end
   end
 end

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -10,6 +10,17 @@
     </div>
   <% end -%>
 
+  <div class="field">
+    <%= f.label :display_name %><br />
+    <%= f.text_field :display_name %>
+  </div>
+
+  <div class="field">
+    <%= f.label :role_ids %><br />
+    <%= collection_select(:user, :role_ids, Role.all, :id, :name, {prompt: 'None'}, {multiple: true}) %>
+  </div>
+
+  <br />
   <div class="actions">
     <%= f.submit t("devise.invitations.new.submit_button") %>
   </div>

--- a/spec/requests/users/invitations_spec.rb
+++ b/spec/requests/users/invitations_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe 'Users::InvitationsController' do
       end.to change(User, :count).by(1)
     end
 
+    it 'can set display name' do
+      post user_invitation_path, params: { user: { email: 'invitee@example.org', display_name: 'Last, First' } }
+      expect(User.last.display_name).to eq 'Last, First'
+    end
+
+    it 'can set user roles' do
+      post user_invitation_path,
+           params: { user: { email: 'invitee@example.org', role_ids: [Role.last.id, Role.second.id] } }
+      expect(Role.second.users).to include User.last
+    end
+
     it 'sends an invitation e-mail', :aggregate_failures do
       post user_invitation_path, params: { user: { email: 'invitee@example.org' } }
       mail = ActionMailer::Base.deliveries.last

--- a/spec/views/devise/invitations/new.html.erb_spec.rb
+++ b/spec/views/devise/invitations/new.html.erb_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'devise/invitations/new' do
+  # The view depends on controller methods defined in Devise::InvitationsController
+  # There are a number of ways to inject these, this seemed cleanest
+  # For additonal background see:
+  # https://github.com/rspec/rspec-mocks/pull/1104/files
+  # https://stackoverflow.com/questions/14426746/testing-devise-views-with-rspec
+  # https://github.com/rspec/rspec-rails/issues/1219
+  before do
+    without_partial_double_verification do
+      # Stub DeviseController .resource methods
+      allow(view).to receive(:resource).and_return(User.new)
+      allow(view).to receive(:resource_name).and_return(:user)
+    end
+  end
+
+  it 'renders new user form' do
+    render
+    expect(rendered).to have_selector("form[@action='#{user_invitation_path}']")
+  end
+
+  it 'accepts an e-mail' do
+    render
+    expect(rendered).to have_field(id: 'user_email')
+  end
+
+  it 'accepts a display name' do
+    render
+    expect(rendered).to have_field(id: 'user_display_name')
+  end
+
+  it 'has an option to select an initial role' do
+    render
+    expect(rendered).to have_select(id: 'user_role_ids')
+  end
+
+  it 'has a submit button' do
+    render
+    expect(rendered).to have_button(type: 'submit')
+  end
+end


### PR DESCRIPTION
**STORY**
As an administrator, I would like a one-step process to set a user's display name and roles when I invite them, so that I don't have to remember to edit the user after inviting them.

**SOLUTION**
Add optional fields to the invitation view to set the display name and roles.  These can also be left blank and modified later by editing the user.

**REFERENCE**
See https://github.com/scambra/devise_invitable/tree/v2.0.8#strong-parameters