### PR TITLE
Display most recent login info on user dashboard

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -1,0 +1,19 @@
+# Various helpers for User dashboard views
+module UserHelper
+  # Human friendly formatter for login dates
+  def last_login(user)
+    timestamp = user.current_sign_in_at
+    duration(timestamp)
+  end
+
+  # Human friendly formatter for Time-compatible values
+  def duration(timestamp)
+    return tag.span('never', class: 'login_timestamp empty') unless timestamp
+
+    suffix = timestamp < Time.now.utc ? ' ago' : ' from now'
+    duration_text = time_ago_in_words(timestamp) + suffix
+    tag.span(duration_text, class: 'login_timestamp', datetime: timestamp.iso8601)
+  rescue StandardError
+    tag.span('n/a', class: 'login_timestamp empty')
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :invitable, :database_authenticatable,
+  devise :invitable, :database_authenticatable, :trackable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: [:google]
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -3,18 +3,20 @@
 <div id="users">
   <table>
     <tr>
-      <th class='email'>E-Mail</th>
-      <th class='provider'>Type</th>
-      <th class='password'>Password</th>
       <th class='display_name'>Display Name</th>
+      <th class='email'>E-Mail</th>
+      <th class='last_login'>Last Login</th>
+      <th class='provider'>Type</th>
+      <th class='pw_reset'>Password</th>
       <th class='roles'>Roles</th>
     </tr>
     <% @users.each do |user| %>
       <tr id='<%= dom_id user %>'>
-        <td class='email'><%= link_to user.email, user -%></td>
-        <td class='provider'><%= user.provider -%></td>
-        <td class='password'><%= link_to('Send Reset', user_password_reset_path(user), id: dom_id(user, :password_reset), data: { turbo_method: "post" }) if user.local? -%></td>
         <td class='display_name'><%= user.display_name -%></td>
+        <td class='email'><%= link_to user.email, user -%></td>
+        <td class='last_login'><%= last_login(user) -%></td>
+        <td class='provider'><%= user.provider -%></td>
+        <td class='pw_reset'><%= link_to('Send Reset', user_password_reset_path(user), id: dom_id(user, :password_reset), data: { turbo_method: "post" }) if user.local? -%></td>
         <td class='roles'><%= user.roles.map(&:name).join(', ') -%></td>
       </tr>
     <% end %>

--- a/db/migrate/20230901145428_add_devise_trackable_to_users.rb
+++ b/db/migrate/20230901145428_add_devise_trackable_to_users.rb
@@ -1,0 +1,17 @@
+class AddDeviseTrackableToUsers < ActiveRecord::Migration[7.0]
+  def up
+    change_table :users, bulk: true do |t|
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
+    end
+  end
+
+  def down
+    change_table :users, bulk: true do |t|
+      t.remove :sign_in_count, :current_sign_in_at, :last_sign_in_at, :current_sign_in_ip, :last_sign_in_ip
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_13_190525) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_01_145428) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -130,6 +130,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_13_190525) do
     t.string "invited_by_type"
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe UserHelper do
+  let(:user) { FactoryBot.build(:user) }
+
+  # Human friendly formatter for login dates
+  # returns a <span> element with time span from timestamps
+  # the span has the 'login_timestamp' class
+  describe '#last_login(user)' do
+    it 'returns a span element' do
+      user.current_sign_in_at = 3.hours.ago
+      expect(last_login(user)).to match(%r{\A<span.*</span>\z})
+    end
+
+    it 'returns "ago" for past dates' do
+      user.current_sign_in_at = 3.hours.ago
+      expect(last_login(user)).to match(%r{ago</span>\z})
+    end
+
+    it 'returns "from now" for future dates' do
+      user.current_sign_in_at = 3.hours.from_now
+      expect(last_login(user)).to match(%r{from now</span>\z})
+    end
+
+    it 'returns a duration' do
+      user.current_sign_in_at = (6.hours + 50.minutes).ago
+      expect(last_login(user)).to match(%r{about 7 hours ago</span>\z})
+    end
+
+    it 'returns "never" for nil values' do
+      user.current_sign_in_at = nil
+      expect(last_login(user)).to eq '<span class="login_timestamp empty">never</span>'
+    end
+  end
+
+  describe '#duration(timestamp)' do
+    it 'returns "n/a" for non-time values' do
+      timestamp = 'random value or class'
+      expect(duration(timestamp)).to eq '<span class="login_timestamp empty">n/a</span>'
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe User do
     end
   end
 
+  describe '#current_sign_in_at' do
+    it 'is nil for new users' do
+      expect(described_class.new.current_sign_in_at).to be_nil
+    end
+
+    it 'can be set' do
+      expect(user).to respond_to(:current_sign_in_at=)
+    end
+  end
+
   describe '#password_reset' do
     let(:local_user) { FactoryBot.create(:user, provider: 'local') }
 

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -31,4 +31,12 @@ RSpec.describe 'Login' do
     click_on 'Log in'
     expect(page).to have_current_path root_path
   end
+
+  it 'sets current_sign_in_at', :aggregate_failures do
+    visit new_user_session_path
+    fill_in 'user_email', with: user.email
+    fill_in 'user_password', with: 'password'
+    click_on 'Log in'
+    expect(user.reload.current_sign_in_at).to be_within(1.second).of(Time.now.utc)
+  end
 end

--- a/spec/views/admin/users/index.html.erb_spec.rb
+++ b/spec/views/admin/users/index.html.erb_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe 'admin/users/index' do
     expect(rendered).to have_selector('td.display_name', text: users[0].display_name)
   end
 
+  it 'displays the last login for users' do
+    users[2].current_sign_in_at = (12.days + 4.hours).ago
+    render
+    expect(rendered).to have_selector('span.login_timestamp', text: '12 days ago')
+  end
+
   describe 'password reset links' do
     example 'for database users' do
       render


### PR DESCRIPTION
**STORY**
As an administrator, I would like to know when accounts were last used, so that I can identify potentially inactive accounts that should be deactivated.

**SOLUTION**
Add a column to the user listing in the dashboard that shows how long ago a user last logged in.

**ADDED**
<img width="1076" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/e151616a-6e51-4a83-bb88-6c27f3ffb264">
