### PR TITLE
Display the user account state

### DIFF
--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -10,10 +10,31 @@ module UserHelper
   def duration(timestamp)
     return tag.span('never', class: 'login_timestamp empty') unless timestamp
 
-    suffix = timestamp < Time.now.utc ? ' ago' : ' from now'
+    suffix = timestamp.future? ? ' from now' : ' ago'
     duration_text = time_ago_in_words(timestamp) + suffix
     tag.span(duration_text, class: 'login_timestamp', datetime: timestamp.iso8601)
   rescue StandardError
     tag.span('n/a', class: 'login_timestamp empty')
+  end
+
+  # User account status:
+  #   invited  - invitation e-mail sent to user, but not accepted
+  #   active   - invitation accepted and user has logged in
+  #   inactive - user has not logged in for over a year
+  #   unknown  - any other state
+  def status_badge(user) # rubocop:disable Metrics/MethodLength
+    return unless user.is_a?(User)
+
+    state = if user.invited_to_sign_up?
+              :invited
+            elsif user.sign_in_count.positive? && user.current_sign_in_at >= 1.year.ago
+              :active
+            elsif user.sign_in_count.positive? && user.current_sign_in_at < 1.year.ago
+              :inactive
+            else
+              :unknown
+            end
+
+    tag.span(state, class: "user_state #{state}")
   end
 end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -5,6 +5,7 @@
     <tr>
       <th class='display_name'>Display Name</th>
       <th class='email'>E-Mail</th>
+      <th class='status'>Status</th>
       <th class='last_login'>Last Login</th>
       <th class='provider'>Type</th>
       <th class='pw_reset'>Password</th>
@@ -14,6 +15,7 @@
       <tr id='<%= dom_id user %>'>
         <td class='display_name'><%= user.display_name -%></td>
         <td class='email'><%= link_to user.email, user -%></td>
+        <td class='status'><%= status_badge(user) -%></td>
         <td class='last_login'><%= last_login(user) -%></td>
         <td class='provider'><%= user.provider -%></td>
         <td class='pw_reset'><%= link_to('Send Reset', user_password_reset_path(user), id: dom_id(user, :password_reset), data: { turbo_method: "post" }) if user.local? -%></td>

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UserHelper do
   # Human friendly formatter for login dates
   # returns a <span> element with time span from timestamps
   # the span has the 'login_timestamp' class
-  describe '#last_login(user)' do
+  describe '#last_login' do
     it 'returns a span element' do
       user.current_sign_in_at = 3.hours.ago
       expect(last_login(user)).to match(%r{\A<span.*</span>\z})
@@ -33,10 +33,42 @@ RSpec.describe UserHelper do
     end
   end
 
-  describe '#duration(timestamp)' do
+  describe '#duration' do
     it 'returns "n/a" for non-time values' do
       timestamp = 'random value or class'
       expect(duration(timestamp)).to eq '<span class="login_timestamp empty">n/a</span>'
+    end
+  end
+
+  describe '#status_badge' do
+    it 'returns a span element' do
+      expect(status_badge(user)).to match(%r{\A<span.*</span>\z})
+    end
+
+    it 'returns "invited" for invited users' do
+      user = User.invite!(email: 'new_user@example.com')
+      expect(status_badge(user)).to match(/invited/)
+    end
+
+    it 'returns "active" for users who have logged in at least once' do
+      user.sign_in_count = 1
+      user.current_sign_in_at = 2.months.ago
+      expect(status_badge(user)).to match(/active/)
+    end
+
+    it 'returns "inactive" for users who not logged in for over a year' do
+      user.sign_in_count = 150
+      user.current_sign_in_at = (1.year + 1.week).ago
+      expect(status_badge(user)).to match(/inactive/)
+    end
+
+    it 'returns "unknown" if all else fails' do
+      # i.e. user object has never been persisted
+      expect(status_badge(user)).to match(/unknown/)
+    end
+
+    it 'returns nothing if called with non-user object' do
+      expect(status_badge(Object.new)).to be_nil
     end
   end
 end

--- a/spec/views/admin/users/index.html.erb_spec.rb
+++ b/spec/views/admin/users/index.html.erb_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe 'admin/users/index' do
     expect(rendered).to have_selector('span.login_timestamp', text: '12 days ago')
   end
 
+  it 'displays the user state' do
+    render
+    expect(rendered).to have_selector('span.user_state', text: 'unknown')
+  end
+
   describe 'password reset links' do
     example 'for database users' do
       render


### PR DESCRIPTION
Show what part of the user-lifecycle a user is in.  Adds a column to the user list in the dashboard.  Currently shows:

  * invited  - invitation e-mail sent to user, but not accepted
  * active   - invitation accepted and user has logged in
  * inactive - user has not logged in for over a year
  * unknown  - any other state

**AFTER**
<img width="1123" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/a8375122-92b1-454e-91d5-71867bb2bf5e">
