### PR TITLE
Allow administrators to deactivate users

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -50,10 +50,10 @@ module Admin
 
     # DELETE /admin/users/1 or /admin/users/1.json
     def destroy
-      @user.destroy
+      @user.deactivate
 
       respond_to do |format|
-        format.html { redirect_to users_url, notice: 'User was successfully destroyed.' }
+        format.html { redirect_to users_url, notice: 'User was successfully deactivated.' }
         format.json { head :no_content }
       end
     end

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -17,24 +17,30 @@ module UserHelper
     tag.span('n/a', class: 'login_timestamp empty')
   end
 
-  # User account status:
-  #   invited  - invitation e-mail sent to user, but not accepted
-  #   active   - invitation accepted and user has logged in
-  #   inactive - user has not logged in for over a year
-  #   unknown  - any other state
-  def status_badge(user) # rubocop:disable Metrics/MethodLength
+  def status_badge(user)
     return unless user.is_a?(User)
 
-    state = if user.invited_to_sign_up?
-              :invited
-            elsif user.sign_in_count.positive? && user.current_sign_in_at >= 1.year.ago
-              :active
-            elsif user.sign_in_count.positive? && user.current_sign_in_at < 1.year.ago
-              :inactive
-            else
-              :unknown
-            end
-
+    state = account_state(user)
     tag.span(state, class: "user_state #{state}")
+  end
+
+  # User account status:
+  #   invited     - invitation e-mail sent to user, but not accepted
+  #   active      - invitation accepted and user has logged in
+  #   inactive    - user has not logged in for over a year
+  #   deactivated - user has been administratively deactivated
+  #   unknown     - any other state
+  def account_state(user) # rubocop:disable Metrics/MethodLength
+    if user.sign_in_count.positive? && user.current_sign_in_at >= 1.year.ago
+      :active
+    elsif user.deactivated_at?
+      :deactivated
+    elsif user.invited_to_sign_up?
+      :invited
+    elsif user.sign_in_count.positive? && user.current_sign_in_at < 1.year.ago
+      :inactive
+    else
+      :unknown
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,19 @@ class User < ApplicationRecord
     self.provider ||= 'local'
   end
 
+  # Deactivate the user and clear any outstanding invitations
+  # Deactivation should be persisted even if the user is invalid,
+  # so we user update_attribute to skip validations before save
+  def deactivate
+    self.invitation_token = nil
+    update_attribute(:deactivated_at, Time.now.utc) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  # do not permit deactivated users to login
+  def active_for_authentication?
+    super && !deactivated_at
+  end
+
   def local?
     provider == 'local'
   end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -10,6 +10,7 @@
       <th class='provider'>Type</th>
       <th class='pw_reset'>Password</th>
       <th class='roles'>Roles</th>
+      <th class='deactivate'>Deactivate</th>
     </tr>
     <% @users.each do |user| %>
       <tr id='<%= dom_id user %>'>
@@ -20,6 +21,7 @@
         <td class='provider'><%= user.provider -%></td>
         <td class='pw_reset'><%= link_to('Send Reset', user_password_reset_path(user), id: dom_id(user, :password_reset), data: { turbo_method: "post" }) if user.local? -%></td>
         <td class='roles'><%= user.roles.map(&:name).join(', ') -%></td>
+        <td class='deactivate'><%= button_to('Deactivate', user, method: :delete, id: dom_id(user, :delete), class: 'btn btn-danger btn-sm') if user.active_for_authentication? -%></td>
       </tr>
     <% end %>
   </table>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -2,6 +2,12 @@
 
 <div id="<%= dom_id @user %>">
   <p>
+    <strong>Status:</strong>
+    <span class='user_status'><%= status_badge(@user) %></span>
+  </p>
+
+
+  <p>
     <strong>E-Mail:</strong>
     <span class='user_email'><%= @user.email %></span>
   </p>
@@ -26,5 +32,5 @@
   <%= link_to "Edit this user", edit_user_path(@user) %> |
   <%= link_to "Back to users", users_path %>
 
-  <%= button_to "Destroy this user", @user, method: :delete %>
+  <%= button_to("Deactivate this user", @user, method: :delete, class: 'btn btn-danger btn-sm') if @user.active_for_authentication? %>
 </div>

--- a/db/migrate/20230902161139_add_deactivation_time_to_users.rb
+++ b/db/migrate/20230902161139_add_deactivation_time_to_users.rb
@@ -1,0 +1,5 @@
+class AddDeactivationTimeToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :deactivated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_01_145428) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_02_161139) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -135,6 +135,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_01_145428) do
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
+    t.datetime "deactivated_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe UserHelper do
       expect(status_badge(user)).to match(/invited/)
     end
 
+    it 'returns "deactivated" for deactivated users' do
+      user.deactivated_at = 2.months.ago
+      expect(status_badge(user)).to match(/deactivated/)
+    end
+
     it 'returns "active" for users who have logged in at least once' do
       user.sign_in_count = 1
       user.current_sign_in_at = 2.months.ago

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,6 +11,19 @@ RSpec.describe User do
     expect(described_class.new(provider: 'imported').provider).to eq 'imported'
   end
 
+  describe '#deactivate' do
+    it 'marks the user as deactivated' do
+      user.deactivate
+      expect(user.deactivated_at?).to be true
+    end
+
+    it 'disables authentication', :aggregate_failures do
+      expect(user.active_for_authentication?).to be true
+      user.deactivate
+      expect(user.active_for_authentication?).to be false
+    end
+  end
+
   describe '#local?' do
     let(:local_user) { FactoryBot.create(:user, provider: 'local') }
     let(:remote_user) { FactoryBot.create(:user, provider: 'google') }

--- a/spec/views/admin/users/index.html.erb_spec.rb
+++ b/spec/views/admin/users/index.html.erb_spec.rb
@@ -44,6 +44,22 @@ RSpec.describe 'admin/users/index' do
     end
   end
 
+  describe 'deactivation links' do
+    example 'appear for active users', :aggregate_failures do
+      render
+      within "form[@action='#{user_path(users[1])}']" do
+        expect(rendered).to have_selector('#delete_user_1')
+        expect(rendered).to have_input('_method', value: 'delete')
+      end
+    end
+
+    example 'are not provided for inactive users' do
+      users[2].deactivated_at = 1.week.ago
+      render
+      expect(rendered).not_to have_selector('#delete_user_2')
+    end
+  end
+
   it 'has a link to invite new users' do
     render
     expect(rendered).to have_link(:invite_user, href: new_user_invitation_path)

--- a/spec/views/admin/users/show.html.erb_spec.rb
+++ b/spec/views/admin/users/show.html.erb_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe 'admin/users/show' do
     expect(rendered).to have_selector('.user_display_name', text: user.display_name)
   end
 
+  it 'displays the user status' do
+    render
+    expect(rendered).to have_selector('.user_status', text: 'unknown')
+  end
+
   it 'displays any associated roles' do
     render
     expect(rendered).to have_selector('.user_roles', text: user.roles.first)


### PR DESCRIPTION
Instead of deleting users from the database, allow administrators to deactivate an account to prevent the user from logging in, while retaining user data.  We want to keep user references intact so that we can audit objects and actions even after the user had been disabled in the system.

This change:
* Allows user records to be marked as deativated
* Adds UI functionality to allow authorized users to deactivate other users
* Adds 'deactivated' to the possible user states displayed in the user dashboard
* Adds the user account status to the User show view