### PR TITLE
Fix for admins not redirecting to dashboard on login

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -12,12 +12,6 @@ module Users
       end
     end
 
-    protected
-
-    def after_sign_in_path_for(resource_or_scope)
-      stored_location_for(resource_or_scope) || root_path
-    end
-
     private
 
     def auth


### PR DESCRIPTION
**ISSUE**
Administrators logging in with Google (OmniAuth) accounts were not being redirected to the dashboard on login.

**SOLUTION**
Remove the custom `after_sign_in_path_for` method in the OnmiauthCallbacksController that was preventing the newer version of this method in the ApplicationController from being called.

I.E. all controller should call this method
https://github.com/curationexperts/t3/blob/c1126fd294578c21b6d3db82a9948216741d2553/app/controllers/application_controller.rb#L22-L29

Now both OmniAuth and Database users call the same method.