### PR TITLE
Update the site certificate when custom domains are removed

### DIFF
--- a/app/models/custom_domain.rb
+++ b/app/models/custom_domain.rb
@@ -2,18 +2,25 @@
 class CustomDomain < ApplicationRecord
   validate :domain_setup_ok?
 
-  before_save :update_certificate
+  before_save :add_host_to_certificate
+  before_destroy :remove_host_from_certificate
 
   def certbot_client
     @certbot_client ||= Rails.env.production? ? Certbot::V2::Client.new : Certbot::V2::TestClient.new
   end
 
-  def update_certificate
+  private
+
+  # Update the primary certificate to refelect newly added domains
+  def add_host_to_certificate
     certbot_client.add_host(host)
     raise ActiveRecord::RecordInvalid unless valid?
   end
 
-  private
+  # Update the primary certificate to reflect newly removed domains
+  def remove_host_from_certificate
+    certbot_client.remove_host(host)
+  end
 
   # Checks whether a certificate can be generated for the domain
   #

--- a/spec/models/custom_domain_spec.rb
+++ b/spec/models/custom_domain_spec.rb
@@ -88,4 +88,13 @@ RSpec.describe CustomDomain do
       end
     end
   end
+
+  describe '#destroy' do
+    it 'calls certbot with the hostname' do
+      allow(domain.certbot_client).to receive(:remove_host)
+      domain.host = 'demo.tenejo.com'
+      domain.destroy
+      expect(domain.certbot_client).to have_received(:remove_host).with('demo.tenejo.com')
+    end
+  end
 end


### PR DESCRIPTION
**ISSUE**
Custom domains could be added to the site certificate, but deleting a CustomDomain did not remove the hostname from the certificate.

**SOLUTION**
Add a before_destroy callback on the model which removes the CustomDomain hostname from the security certificate.