### PR TITLE
Read hostname from system

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_deliveries = true
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: 't3-dev.curationexperts.com', protocol: 'https' }
+  config.action_mailer.default_url_options = { host: `hostname -f`, protocol: 'https' }
 
   config.action_mailer.delivery_method = :ses
   # Set a default AWS region so ActionMailer knows where to look for SES


### PR DESCRIPTION
**ISSUE**
As a simplifying assumption in early-stage development, we hardcoded the server hostname "t3-dev.curationexperts.com" into the mailer configuration.  We now want to run multiple environemnts and the static hostname is incorrect on other servers.

**FIX**
In the initializer, read the fully qualified name configured on the system instead of using a hardcoded value.