### PR TITLE
Remove obsolete Config management links

### DIFF
--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -38,7 +38,4 @@
 
 <div>
   <%= link_to "Edit this config", edit_config_path(@config) %> |
-  <%= link_to "Back to configs", config_path %>
-
-  <%= button_to "Destroy this config", @config, method: :delete %>
 </div>


### PR DESCRIPTION
We no longer allow multiple Config objects, so there's no longer a need for an index link or to delete an inactive config.