### PR TITLE
Add basic UI and model for Blueprints

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,5 +1,6 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
+# version: 8.11.1
 collection:
   dir: solr/conf/
   name: blacklight-core

--- a/app/controllers/admin/blueprints_controller.rb
+++ b/app/controllers/admin/blueprints_controller.rb
@@ -1,0 +1,73 @@
+module Admin
+  # Manage user roles and authorizations
+  class BlueprintsController < ApplicationController
+    before_action :set_blueprint, only: %i[show edit update destroy]
+    load_and_authorize_resource
+
+    # GET /blueprints or /blueprints.json
+    def index
+      @blueprints = Blueprint.all
+    end
+
+    # GET /blueprints/1 or /blueprints/1.json
+    def show; end
+
+    # GET /blueprints/new
+    def new
+      @blueprint = Blueprint.new
+    end
+
+    # GET /blueprints/1/edit
+    def edit; end
+
+    # POST /blueprints or /blueprints.json
+    def create
+      @blueprint = Blueprint.new(blueprint_params)
+
+      respond_to do |format|
+        if @blueprint.save
+          format.html { redirect_to blueprint_url(@blueprint), notice: 'Blueprint was successfully created.' }
+          format.json { render :show, status: :created, location: @blueprint }
+        else
+          format.html { render :new, status: :unprocessable_entity }
+          format.json { render json: @blueprint.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    # PATCH/PUT /blueprints/1 or /blueprints/1.json
+    def update
+      respond_to do |format|
+        if @blueprint.update(blueprint_params)
+          format.html { redirect_to blueprint_url(@blueprint), notice: 'Blueprint was successfully updated.' }
+          format.json { render :show, status: :ok, location: @blueprint }
+        else
+          format.html { render :edit, status: :unprocessable_entity }
+          format.json { render json: @blueprint.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    # DELETE /blueprints/1 or /blueprints/1.json
+    def destroy
+      @blueprint.destroy
+
+      respond_to do |format|
+        format.html { redirect_to blueprints_url, notice: 'Blueprint was successfully destroyed.' }
+        format.json { head :no_content }
+      end
+    end
+
+    private
+
+    # Use callbacks to share common setup or constraints between actions.
+    def set_blueprint
+      @blueprint = Blueprint.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def blueprint_params
+      params.require(:blueprint).permit(:name)
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,7 +9,8 @@ class Ability
     User => 'User Manager',
     Role => 'User Manager',
     Theme => 'Brand Manager',
-    Config => 'System Manager'
+    Config => 'System Manager',
+    Blueprint => 'System Manager'
   }.freeze
 
   def initialize(user)

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -1,0 +1,6 @@
+# Object model definitions
+class Blueprint < ApplicationRecord
+  validates :name, presence: true
+  validates :name, uniqueness: true
+  validates :name, format: { with: /\A([\w _-])+\z/, message: 'can not contain special characters' }
+end

--- a/app/views/admin/_sidebar.html.erb
+++ b/app/views/admin/_sidebar.html.erb
@@ -20,6 +20,11 @@
           <%= link_to t('t3.admin.themes'), themes_path, class: 'nav-link' + active_controller_class('themes') %>
         </li>
       <% end %>
+      <% if can? :read, Blueprint %>
+        <li class='nav-item'>
+          <%= link_to t('t3.admin.blueprints'), blueprints_path, class: 'nav-link' + active_controller_class('blueprints') %>
+        </li>
+      <% end %>
       <% if can? :read, Config %>
         <li class='nav-item'>
           <%= link_to t('t3.admin.configs'), config_path, class: 'nav-link' + active_controller_class('configs') %>

--- a/app/views/admin/blueprints/_blueprint.html.erb
+++ b/app/views/admin/blueprints/_blueprint.html.erb
@@ -1,0 +1,7 @@
+<div id="<%= dom_id blueprint %>">
+  <p>
+    <strong>Name:</strong>
+    <%= blueprint.name %>
+  </p>
+
+</div>

--- a/app/views/admin/blueprints/_blueprint.json.jbuilder
+++ b/app/views/admin/blueprints/_blueprint.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! blueprint, :id, :name, :created_at, :updated_at
+json.url blueprint_url(blueprint, format: :json)

--- a/app/views/admin/blueprints/_form.html.erb
+++ b/app/views/admin/blueprints/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: blueprint) do |form| %>
+  <% if blueprint.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(blueprint.errors.count, "error") %> prohibited this blueprint from being saved:</h2>
+
+      <ul>
+        <% blueprint.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :name, style: "display: block" %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/blueprints/edit.html.erb
+++ b/app/views/admin/blueprints/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Editing blueprint</h1>
+
+<%= render "form", blueprint: @blueprint %>
+
+<br>
+
+<div>
+  <%= link_to "Show this blueprint", @blueprint %> |
+  <%= link_to "Back to blueprints", blueprints_path %>
+</div>

--- a/app/views/admin/blueprints/index.html.erb
+++ b/app/views/admin/blueprints/index.html.erb
@@ -1,0 +1,14 @@
+<p style="color: green"><%= notice %></p>
+
+<h1>Blueprints</h1>
+
+<div id="blueprints">
+  <% @blueprints.each do |blueprint| %>
+    <%= render partial: 'blueprint', object: blueprint %>
+    <p>
+      <%= link_to "Show this blueprint", blueprint %>
+    </p>
+  <% end %>
+</div>
+
+<%= link_to "New blueprint", new_blueprint_path %>

--- a/app/views/admin/blueprints/index.json.jbuilder
+++ b/app/views/admin/blueprints/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @blueprints, partial: 'blueprints/blueprint', as: :blueprint

--- a/app/views/admin/blueprints/new.html.erb
+++ b/app/views/admin/blueprints/new.html.erb
@@ -1,0 +1,9 @@
+<h1>New blueprint</h1>
+
+<%= render "form", blueprint: @blueprint %>
+
+<br>
+
+<div>
+  <%= link_to "Back to blueprints", blueprints_path %>
+</div>

--- a/app/views/admin/blueprints/show.html.erb
+++ b/app/views/admin/blueprints/show.html.erb
@@ -1,0 +1,10 @@
+<p style="color: green"><%= notice %></p>
+
+<%= render partial: 'blueprint', object: @blueprint %>
+
+<div>
+  <%= link_to "Edit this blueprint", edit_blueprint_path(@blueprint) %> |
+  <%= link_to "Back to blueprints", blueprints_path %>
+
+  <%= button_to "Destroy this blueprint", @blueprint, method: :delete %>
+</div>

--- a/app/views/admin/blueprints/show.json.jbuilder
+++ b/app/views/admin/blueprints/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'blueprints/blueprint', blueprint: @blueprint

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
     post 'users/:id/password_reset', to: 'users#password_reset', as: :user_password_reset
     resources :users
     resources :roles
+    resources :blueprints
     resources :themes do
       patch 'activate', on: :member
     end

--- a/db/migrate/20230927193253_create_blueprints.rb
+++ b/db/migrate/20230927193253_create_blueprints.rb
@@ -1,0 +1,9 @@
+class CreateBlueprints < ActiveRecord::Migration[7.0]
+  def change
+    create_table :blueprints do |t|
+      t.string :name, index: { unique: true }, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_02_161139) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_27_193253) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_02_161139) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "blueprints", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_blueprints_on_name", unique: true
   end
 
   create_table "bookmarks", id: :serial, force: :cascade do |t|

--- a/spec/factories/blueprints.rb
+++ b/spec/factories/blueprints.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :blueprint do
+    name { Faker::Hipster.words.join(' ').gsub(/[^0-9A-Za-z\-_ ]/, '') }
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -73,6 +73,10 @@ RSpec.describe Ability do
         expect(authz.can?(:manage, Config)).to be true
       end
 
+      it 'can manage Blueprints' do
+        expect(authz.can?(:manage, Blueprint)).to be true
+      end
+
       it 'can read dashboard status' do
         expect(authz.can?(:read, :dashboard)).to be true
       end
@@ -91,10 +95,10 @@ RSpec.describe Ability do
       end
 
       it 'can manage multiple features', :aggregate_failures do
-        expect(authz.can?(:read, :dashboard)).to be true
         expect(authz.can?(:manage, User)).to be true
         expect(authz.can?(:manage, Config)).to be true
         expect(authz.can?(:manage, Theme)).to be false
+        expect(authz.can?(:manage, Blueprint)).to be true
       end
 
       it 'can read dashboard status' do

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Blueprint, :aggregate_failures do
+  describe 'name' do
+    let(:blueprint) { described_class.new }
+
+    it 'cannot be blank' do
+      expect(blueprint).not_to be_valid
+      expect(blueprint.errors.where(:name, :blank)).to be_present
+    end
+
+    it 'must be unique' do
+      existing = FactoryBot.create(:blueprint)
+      blueprint.name = existing.name
+      expect(blueprint).not_to be_valid
+      expect(blueprint.errors.where(:name, :taken)).to be_present
+    end
+
+    it 'can not contain special characters' do
+      blueprint.name = 'This & That'
+      expect(blueprint).not_to be_valid
+      expect(blueprint.errors.where(:name, :invalid)).to be_present
+    end
+  end
+end

--- a/spec/requests/admin/blueprints_spec.rb
+++ b/spec/requests/admin/blueprints_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.describe '/admin/blueprints' do
+  # This should return the minimal set of attributes required to create a valid
+  # Blueprint. As you add validations to Blueprint, be sure to
+  # adjust the attributes here as well.
+  let(:valid_attributes) do
+    FactoryBot.attributes_for(:blueprint)
+  end
+  let(:invalid_attributes) do
+    FactoryBot.attributes_for(:blueprint, name: 'Special Characters: ! <>')
+  end
+  let(:super_admin)  { FactoryBot.create(:super_admin) }
+  let(:regular_user) { FactoryBot.create(:user) }
+
+  before { login_as super_admin }
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      Blueprint.create! valid_attributes
+      get blueprints_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a successful response' do
+      blueprint = Blueprint.create! valid_attributes
+      get blueprint_url(blueprint)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /new' do
+    it 'renders a successful response' do
+      get new_blueprint_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'renders a successful response' do
+      blueprint = Blueprint.create! valid_attributes
+      get edit_blueprint_url(blueprint)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new Blueprint' do
+        expect do
+          post blueprints_url, params: { blueprint: valid_attributes }
+        end.to change(Blueprint, :count).by(1)
+      end
+
+      it 'redirects to the created blueprint' do
+        post blueprints_url, params: { blueprint: valid_attributes }
+        expect(response).to redirect_to(blueprint_url(Blueprint.last))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new Blueprint' do
+        expect do
+          post blueprints_url, params: { blueprint: invalid_attributes }
+        end.not_to change(Blueprint, :count)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        post blueprints_url, params: { blueprint: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do
+      let(:new_attributes) { { name: Faker::Alphanumeric.alphanumeric } }
+
+      it 'updates the requested blueprint' do
+        blueprint = Blueprint.create! valid_attributes
+        patch blueprint_url(blueprint), params: { blueprint: new_attributes }
+        blueprint.reload
+        expect(blueprint.name).to eq new_attributes[:name]
+      end
+
+      it 'redirects to the blueprint' do
+        blueprint = Blueprint.create! valid_attributes
+        patch blueprint_url(blueprint), params: { blueprint: new_attributes }
+        blueprint.reload
+        expect(response).to redirect_to(blueprint_url(blueprint))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        blueprint = Blueprint.create! valid_attributes
+        patch blueprint_url(blueprint), params: { blueprint: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested blueprint' do
+      blueprint = Blueprint.create! valid_attributes
+      expect do
+        delete blueprint_url(blueprint)
+      end.to change(Blueprint, :count).by(-1)
+    end
+
+    it 'redirects to the blueprints list' do
+      blueprint = Blueprint.create! valid_attributes
+      delete blueprint_url(blueprint)
+      expect(response).to redirect_to(blueprints_url)
+    end
+  end
+
+  describe 'resctricts access' do
+    example 'for guest users' do
+      logout
+      get blueprints_url
+      expect(response).to be_not_found
+    end
+
+    example 'for non-admin users' do
+      login_as regular_user
+      get blueprints_url
+      expect(response).to be_unauthorized
+    end
+  end
+end

--- a/spec/routing/admin/blueprints_routing_spec.rb
+++ b/spec/routing/admin/blueprints_routing_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Admin::BlueprintsController do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: '/admin/blueprints').to route_to('admin/blueprints#index')
+    end
+
+    it 'routes to #new' do
+      expect(get: '/admin/blueprints/new').to route_to('admin/blueprints#new')
+    end
+
+    it 'routes to #show' do
+      expect(get: '/admin/blueprints/1').to route_to('admin/blueprints#show', id: '1')
+    end
+
+    it 'routes to #edit' do
+      expect(get: '/admin/blueprints/1/edit').to route_to('admin/blueprints#edit', id: '1')
+    end
+
+    it 'routes to #create' do
+      expect(post: '/admin/blueprints').to route_to('admin/blueprints#create')
+    end
+
+    it 'routes to #update via PUT' do
+      expect(put: '/admin/blueprints/1').to route_to('admin/blueprints#update', id: '1')
+    end
+
+    it 'routes to #update via PATCH' do
+      expect(patch: '/admin/blueprints/1').to route_to('admin/blueprints#update', id: '1')
+    end
+
+    it 'routes to #destroy' do
+      expect(delete: '/admin/blueprints/1').to route_to('admin/blueprints#destroy', id: '1')
+    end
+  end
+end

--- a/spec/views/admin/_sidebar.html.erb_spec.rb
+++ b/spec/views/admin/_sidebar.html.erb_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe 'admin/_sidebar' do
     end
   end
 
+  describe 'blueprints link' do
+    it 'renders for authorized users' do
+      allow(view.controller.current_ability).to receive(:can?).with(:read, Blueprint).and_return(true)
+      render
+      expect(rendered).to have_link(href: blueprints_path)
+    end
+
+    it 'is hidden from unauthorized users' do
+      allow(view.controller.current_ability).to receive(:can?).with(:read, Blueprint).and_return(false)
+      render
+      expect(rendered).not_to have_link(href: blueprints_path)
+    end
+  end
+
   describe 'config link' do
     it 'renders for authorized users' do
       allow(view.controller.current_ability).to receive(:can?).with(:read, Config).and_return(true)

--- a/spec/views/admin/blueprints/edit.html.erb_spec.rb
+++ b/spec/views/admin/blueprints/edit.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/blueprints/edit' do
+  let(:blueprint) do
+    FactoryBot.create(:blueprint)
+  end
+
+  before do
+    assign(:blueprint, blueprint)
+  end
+
+  it 'renders the edit blueprint form' do
+    render
+
+    assert_select 'form[action=?][method=?]', blueprint_path(blueprint), 'post' do
+      assert_select 'input[name=?]', 'blueprint[name]'
+    end
+  end
+end

--- a/spec/views/admin/blueprints/index.html.erb_spec.rb
+++ b/spec/views/admin/blueprints/index.html.erb_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/blueprints/index' do
+  before do
+    assign(:blueprints, FactoryBot.create_list(:blueprint, 2))
+  end
+
+  it 'renders a list of blueprints' do
+    render
+    cell_selector = Rails::VERSION::STRING >= '7' ? 'div>p' : 'tr>td'
+    assert_select cell_selector, text: Regexp.new('Name'.to_s), count: 2
+  end
+end

--- a/spec/views/admin/blueprints/new.html.erb_spec.rb
+++ b/spec/views/admin/blueprints/new.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/blueprints/new' do
+  before do
+    assign(:blueprint, Blueprint.new)
+  end
+
+  it 'renders new blueprint form' do
+    render
+    expect(rendered).to have_selector("form[@action='#{blueprints_path}']")
+  end
+
+  it 'accepts a name' do
+    render
+    expect(rendered).to have_field(id: 'blueprint_name')
+  end
+
+  it 'has a submit button' do
+    render
+    expect(rendered).to have_button(type: 'submit')
+  end
+end

--- a/spec/views/admin/blueprints/show.html.erb_spec.rb
+++ b/spec/views/admin/blueprints/show.html.erb_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/blueprints/show' do
+  before do
+    assign(:blueprint, FactoryBot.create(:blueprint))
+  end
+
+  it 'renders attributes in <p>' do
+    render
+    expect(rendered).to match(/Name/)
+  end
+end


### PR DESCRIPTION
Blueprints are intended to contain all of the configuration information such as field definitions, search behaviors, translations, and other settings required to define the object classes managed in the repository.

We've chosen the term 'blueprint' since model, class, and other related terms are generally already overloaded in both the software and library domains.  Further, borrowing from the idea of an architectural blueprint, this type of plan can contain multiple different layers or types of schematics (structural, electrical, hvac) that combine to completely describe a finished real-world instance.  In a similar way, a blueprint here can define indexing, search, input constraints, etc. that govern unique work instances in the repository.