### PR TITLE
Suppress format validation on blank Blueprint names

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -2,5 +2,5 @@
 class Blueprint < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: true
-  validates :name, format: { with: /\A([\w _-])+\z/, message: 'can not contain special characters' }
+  validates :name, format: { with: /\A([\w _-])+\z/, message: 'can not contain special characters' }, allow_blank: true
 end

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Blueprint, :aggregate_failures do
     it 'cannot be blank' do
       expect(blueprint).not_to be_valid
       expect(blueprint.errors.where(:name, :blank)).to be_present
+      expect(blueprint.errors.where(:name, :invalid)).not_to be_present
     end
 
     it 'must be unique' do


### PR DESCRIPTION
**ISSUE**
Blueprint validations would trigger both presence and format errors when the `:name` attribute was blank. This is redundant and could be confusing to users who just need to address the presence error.

**SOLUTION**
Allow blanks for the `:name` format validation.