### PR TITLE
Add support for Boostrap Icons font

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -14,6 +14,7 @@
     <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload"  %>
     <!-- Inject dynamically updated style variables-->
     <link type="text/css" rel="stylesheet" href="/admin/themes/<%= theme_id %>.css" data-turbo-track=reload">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
     <% if defined? Importmap %>
       <%= javascript_importmap_tags %>
     <% elsif defined? Propshaft %>


### PR DESCRIPTION
See CDN instructions here:
https://icons.getbootstrap.com/#install