### PR TITLE
Improve UI for Blueprints with ability to manage fields

### DIFF
--- a/app/assets/stylesheets/admin/blueprints.scss
+++ b/app/assets/stylesheets/admin/blueprints.scss
@@ -1,0 +1,47 @@
+#dashboard-content {
+  margin-top: 1.5rem;
+}
+
+#blueprint_fields {
+  th, td {
+    padding-right: 1rem;
+  }
+  th {
+    vertical-align: bottom;
+  }
+  tr {
+    height: 2.5rem;
+  }
+}
+
+.display_label {
+  width: 15rem;
+}
+
+.solr_field_name {
+  width: 13rem;
+}
+
+.field_number, .searchable, .facetable, .search_results, .item_view {
+  text-align: center;
+}
+
+button, a {
+  span.btn-label.bi::before{
+    padding-right: 0.5rem;
+  }
+}
+
+div.blueprint_actions {
+  margin-top: 1.5rem;
+  .btn {
+    margin-right: 1rem;
+  }
+  .blueprint_delete {
+    float: right;
+  }
+}
+
+#blueprints #add_blueprint {
+  margin-top: 1.5rem;
+}

--- a/app/controllers/admin/blueprints_controller.rb
+++ b/app/controllers/admin/blueprints_controller.rb
@@ -1,8 +1,8 @@
 module Admin
   # Manage user roles and authorizations
   class BlueprintsController < ApplicationController
-    before_action :set_blueprint, only: %i[show edit update destroy]
     load_and_authorize_resource
+    before_action :check_for_empty_fields, only: :edit
 
     # GET /blueprints or /blueprints.json
     def index
@@ -14,7 +14,7 @@ module Admin
 
     # GET /blueprints/new
     def new
-      @blueprint = Blueprint.new
+      @blueprint = Blueprint.new(fields: FieldConfig.new)
     end
 
     # GET /blueprints/1/edit
@@ -24,27 +24,15 @@ module Admin
     def create
       @blueprint = Blueprint.new(blueprint_params)
 
-      respond_to do |format|
-        if @blueprint.save
-          format.html { redirect_to blueprint_url(@blueprint), notice: 'Blueprint was successfully created.' }
-          format.json { render :show, status: :created, location: @blueprint }
-        else
-          format.html { render :new, status: :unprocessable_entity }
-          format.json { render json: @blueprint.errors, status: :unprocessable_entity }
-        end
-      end
+      save_or_update_response(:save)
     end
 
     # PATCH/PUT /blueprints/1 or /blueprints/1.json
     def update
-      respond_to do |format|
-        if @blueprint.update(blueprint_params)
-          format.html { redirect_to blueprint_url(@blueprint), notice: 'Blueprint was successfully updated.' }
-          format.json { render :show, status: :ok, location: @blueprint }
-        else
-          format.html { render :edit, status: :unprocessable_entity }
-          format.json { render json: @blueprint.errors, status: :unprocessable_entity }
-        end
+      if params[:manage_field]
+        add_or_delete_field
+      else
+        save_or_update_response(:update, blueprint_params)
       end
     end
 
@@ -60,14 +48,48 @@ module Admin
 
     private
 
-    # Use callbacks to share common setup or constraints between actions.
-    def set_blueprint
-      @blueprint = Blueprint.find(params[:id])
+    NOTICES = { update: 'Blueprint was sucessfully updated',
+                save: 'Blueprint was successfully saved' }.freeze
+
+    def save_or_update_response(*action)
+      return unless action
+
+      respond_to do |format|
+        if @blueprint.send(*action)
+          format.html { redirect_to blueprint_url(@blueprint), notice: NOTICES[action.first] }
+          format.json { render :show, status: :ok, location: @blueprint }
+        else
+          format.html { render :edit, status: :unprocessable_entity }
+          format.json { render json: @blueprint.errors, status: :unprocessable_entity }
+        end
+      end
     end
+
+    def add_or_delete_field
+      @blueprint.fields_attributes = blueprint_params[:fields_attributes].to_hash
+      field_to_delete = params.dig(:manage_field, :delete_field)&.to_i
+      if field_to_delete
+        @blueprint.fields.delete_at(field_to_delete)
+      else # add a field
+        @blueprint.fields << FieldConfig.new
+      end
+      render :edit, status: :accepted
+    end
+
+    # Use callbacks to share common setup or constraints between actions.
 
     # Only allow a list of trusted parameters through.
     def blueprint_params
-      params.require(:blueprint).permit(:name)
+      params.require(:blueprint).permit(:name,
+                                        fields_attributes: %i[
+                                          solr_field_name enabled display_label
+                                          searchable facetable search_results item_view
+                                        ])
+    end
+
+    # Ensure at least on empty field exists in the blueprint
+    def check_for_empty_fields
+      @blueprint.fields = [FieldConfig.new] if @blueprint.fields.empty?
     end
   end
 end

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -3,4 +3,13 @@ class Blueprint < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: true
   validates :name, format: { with: /\A([\w _-])+\z/, message: 'can not contain special characters' }, allow_blank: true
+
+  attribute :fields, FieldConfig::ListType.new, default: -> { [] }
+
+  # Emulate #accepts_nested_attributes_for behavior
+  def fields_attributes=(attributes)
+    self.fields = attributes.map do |_i, field_params|
+      FieldConfig.new(field_params)
+    end
+  end
 end

--- a/app/views/admin/blueprints/_blueprint.html.erb
+++ b/app/views/admin/blueprints/_blueprint.html.erb
@@ -1,7 +1,0 @@
-<div id="<%= dom_id blueprint %>">
-  <p>
-    <strong>Name:</strong>
-    <%= blueprint.name %>
-  </p>
-
-</div>

--- a/app/views/admin/blueprints/_form.html.erb
+++ b/app/views/admin/blueprints/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: blueprint) do |form| %>
+<%= form_for blueprint do |form| %>
   <% if blueprint.errors.any? %>
     <div style="color: red">
       <h2><%= pluralize(blueprint.errors.count, "error") %> prohibited this blueprint from being saved:</h2>
@@ -11,12 +11,57 @@
     </div>
   <% end %>
 
-  <div>
-    <%= form.label :name, style: "display: block" %>
-    <%= form.text_field :name %>
+  <% if action_name == 'new' %>
+    <div>
+      <%= form.label :name, style: "display: block" %>
+      <%= form.text_field :name %>
+    </div>
+  <% else %>
+    <%= form.hidden_field :name %>
+  <% end %>
+
+  <div id="blueprint_fields">
+    <table>
+      <tr>
+        <th class='field_number'>Order</th>
+        <th class='display_label'>Label</th>
+        <th class='solr_field_name'>Solr Field Name</th>
+        <th class='searchable'>Searchable</th>
+        <th class='facetable'>Facetable</th>
+        <th class='search_results'>Search <br/>Results</th>
+        <th class='item_view'>Item <br/>View</th>
+        <th class='field_action'>Actions</th>
+      </tr>
+
+      <%= form.fields_for :fields do |field_form| %>
+        <tr>
+          <td class='field_number'><%= field_form.index + 1 %></td>
+          <td class='display_label'><%= field_form.text_field :display_label %></td>
+          <td class='solr_field_name'><%= field_form.text_field :solr_field_name %></td>
+          <td class='searchable'><%= field_form.check_box :searchable %></td>
+          <td class='facetable'><%= field_form.check_box :facetable %></td>
+          <td class='search_results'><%= field_form.check_box :search_results %></td>
+          <td class='item_view'><%= field_form.check_box :item_view %></td>
+          <td class='field_action'>
+            <%= form.button 'Delete', type: 'submit', name: 'manage_field[delete_field]', value: field_form.index, class: 'btn btn-sm btn-outline-danger' do %>
+              <span class="btn-label bi bi-trash">Delete Field</span>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+      <tr>
+        <td class='field_number'></td>
+        <td class='field_action'>
+          <%= form.button 'Add Field', type: 'submit', name: 'manage_field[add_field]', value: 'add_field', class: 'btn btn-sm btn-outline-dark' do %>
+            <span class="btn-label bi bi-plus-square">Add a Field</span>
+          <% end %>
+        </td>
+      </tr>
+    </table>
   </div>
 
+  <br/>
   <div>
-    <%= form.submit %>
+    <%= form.submit class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/admin/blueprints/edit.html.erb
+++ b/app/views/admin/blueprints/edit.html.erb
@@ -1,4 +1,5 @@
-<h1>Editing blueprint</h1>
+<h1 class='blueprint_name'><%= @blueprint.name %></h1>
+<h4>Editing Blueprint</h4>
 
 <%= render "form", blueprint: @blueprint %>
 

--- a/app/views/admin/blueprints/index.html.erb
+++ b/app/views/admin/blueprints/index.html.erb
@@ -1,14 +1,41 @@
-<p style="color: green"><%= notice %></p>
-
 <h1>Blueprints</h1>
 
 <div id="blueprints">
-  <% @blueprints.each do |blueprint| %>
-    <%= render partial: 'blueprint', object: blueprint %>
-    <p>
-      <%= link_to "Show this blueprint", blueprint %>
-    </p>
-  <% end %>
+  <table>
+    <thead>
+      <tr>
+        <th class='blueprint_name'>Name</th>
+        <th class="blueprint_actions">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+    <% @blueprints.each do |blueprint| %>
+      <tr>
+        <td class='blueprint_name'><%= blueprint.name %></td>
+        <td class='blueprint_actions'>
+          <%= link_to blueprint, id: dom_id(blueprint, :view), class: 'btn btn-sm btn-primary' do %>
+            <span class='btn-label bi bi-file-earmark-ruled'>View</span>
+          <% end %>
+          <%= link_to edit_blueprint_path(blueprint), id: dom_id(blueprint, :edit), class: 'btn btn-sm btn-success' do %>
+            <span class='btn-label bi bi-pencil-square'>Edit</span>
+          <% end %>
+          <%= button_to blueprint, method: :delete, id: dom_id(blueprint, :delete), class: 'btn btn-sm btn-danger' do %>
+            <span class="btn-label bi bi-trash">Delete</span>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+    <tfoot>
+      <tr>
+        <td class='blueprint_name'>
+          <%= link_to new_blueprint_path, id: 'add_blueprint', class: 'btn btn-outline-primary'  do %>
+            <span class="btn-label bi bi-plus-square">New Blueprint</span>
+          <% end %>
+        </td>
+      </tr>
+    </tfoot>
+  </table>
 </div>
 
-<%= link_to "New blueprint", new_blueprint_path %>
+

--- a/app/views/admin/blueprints/show.html.erb
+++ b/app/views/admin/blueprints/show.html.erb
@@ -1,10 +1,46 @@
-<p style="color: green"><%= notice %></p>
+<div id="<%= dom_id @blueprint %>">
+  <h1 class='blueprint_name'><%= @blueprint.name %></h1>
+  <h4>Blueprint</h4>
 
-<%= render partial: 'blueprint', object: @blueprint %>
+  <div id="blueprint_fields">
+    <table>
+      <thead>
+      <tr>
+        <th class='field_number'>Order</th>
+        <th class='display_label'>Label</th>
+        <th class='solr_field_name'>Solr Field Name</th>
+        <th class='searchable'>Searchable</th>
+        <th class='facetable'>Facetable</th>
+        <th class='search_results'>Search <br/>Results</th>
+        <th class='item_view'>Item <br/>View</th>
+      </tr>
+      </thead>
+      <tbody>
+      <% @blueprint.fields.each_with_index do |field, index| %>
+        <tr id=<%= "field_config_#{index}" %>>
+          <td class='field_number'><%= index + 1 %></td>
+          <td class='display_label'><%= field.display_label %></td>
+          <td class='solr_field_name'><%= field.solr_field_name %></td>
+          <td class='searchable'><span class="bi <%= field.searchable ? 'bi-check-square-fill' : 'bi-square' %>"></span></td>
+          <td class='facetable'><span class="bi <%= field.facetable ? 'bi-check-square-fill' : 'bi-square' %>"></span></td>
+          <td class='search_results'><span class="bi <%= field.search_results ? 'bi-check-square-fill' : 'bi-square' %>"></span></td>
+          <td class='item_view'><span class="bi <%= field.item_view ? 'bi-check-square-fill' : 'bi-square' %>"></span></td>
+        </tr>
+      <% end %>
 
-<div>
-  <%= link_to "Edit this blueprint", edit_blueprint_path(@blueprint) %> |
-  <%= link_to "Back to blueprints", blueprints_path %>
+      </tbody>
+    </table>
+  </div>
 
-  <%= button_to "Destroy this blueprint", @blueprint, method: :delete %>
+  <div class='blueprint_actions'>
+    <%= link_to edit_blueprint_path(@blueprint), id: dom_id(@blueprint, :edit), class: 'btn btn-success' do %>
+      <span class='btn-label bi bi-pencil-square'>Edit</span>
+    <% end %>
+    <%= link_to blueprints_path, id: 'blueprints_index', class: 'btn btn-primary' do %>
+      <span class='btn-label bi bi-list-task'>Back to Blueprints</span>
+    <% end %>
+    <%= button_to @blueprint, method: :delete, id: dom_id(@blueprint, :delete), class: 'btn btn-danger', form_class: 'blueprint_delete' do %>
+      <span class="btn-label bi bi-trash">Delete</span>
+    <% end %>
+  </div>
 </div>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -45,7 +45,7 @@
         <%= render partial: 'admin/sidebar' %>
       <% end %>
 
-      <div class='d-block'>
+      <div id='dashboard-content' class='d-block'>
         <%= content_for(:container_header) %>
         <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
         <div class="row">

--- a/db/migrate/20230928165713_add_fields_to_blueprints.rb
+++ b/db/migrate/20230928165713_add_fields_to_blueprints.rb
@@ -1,0 +1,5 @@
+class AddFieldsToBlueprints < ActiveRecord::Migration[7.0]
+  def change
+    add_column :blueprints, :fields, :jsonb, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_27_193253) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_28_165713) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,6 +46,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_27_193253) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "fields", default: []
     t.index ["name"], name: "index_blueprints_on_name", unique: true
   end
 

--- a/spec/factories/field_configs.rb
+++ b/spec/factories/field_configs.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :field_config do
+    display_label { Faker::Lorem.word.capitalize }
+    solr_suffix { '*_tsi' }
+    solr_field_name { display_label.downcase + solr_suffix[1, 10] }
+    enabled { true }
+    searchable { true }
+    facetable { true }
+    search_results { true }
+    item_view { true }
+  end
+end

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Blueprint, :aggregate_failures do
-  describe 'name' do
-    let(:blueprint) { described_class.new }
+  let(:blueprint) { described_class.new }
 
+  describe 'name' do
     it 'cannot be blank' do
       expect(blueprint).not_to be_valid
       expect(blueprint.errors.where(:name, :blank)).to be_present
@@ -21,6 +21,32 @@ RSpec.describe Blueprint, :aggregate_failures do
       blueprint.name = 'This & That'
       expect(blueprint).not_to be_valid
       expect(blueprint.errors.where(:name, :invalid)).to be_present
+    end
+  end
+
+  describe 'fields' do
+    it 'defaults to an empty list' do
+      expect(described_class.new.fields).to eq []
+    end
+
+    it 'validates when empty' do
+      blueprint.name = FactoryBot.attributes_for(:blueprint)[:name]
+      blueprint.fields = []
+      expect(blueprint).to be_valid
+    end
+
+    it 'may contain FieldConfig objects' do
+      blueprint.name = FactoryBot.attributes_for(:blueprint)[:name]
+      blueprint.fields << FactoryBot.build(:field_config)
+      expect(blueprint).to be_valid
+    end
+
+    it 'can be persisted' do
+      fields = [FactoryBot.build(:field_config), FactoryBot.build(:field_config), FactoryBot.build(:field_config)]
+      blueprint = FactoryBot.create(:blueprint, fields: fields)
+      persisted = described_class.find(blueprint.id)
+      expect(persisted.fields.count).to eq 3
+      expect(persisted.fields.map(&:class).uniq).to eq [FieldConfig]
     end
   end
 end

--- a/spec/requests/admin/blueprints_spec.rb
+++ b/spec/requests/admin/blueprints_spec.rb
@@ -93,6 +93,37 @@ RSpec.describe '/admin/blueprints' do
       end
     end
 
+    context 'with nested field parameters' do
+      let(:field_attributes) do
+        { fields_attributes: { '0' => { display_label: 'Title', solr_field_name: 'title_tesim' },
+                               '1' => { display_label: 'Keywords', solr_field_name: 'keyword_ssim', facetable: 1 } } }
+      end
+
+      it 'updates the fields attribute', :aggregate_failures do
+        blueprint = Blueprint.create! valid_attributes
+        patch blueprint_url(blueprint), params: { blueprint: field_attributes }
+        blueprint.reload
+        expect(blueprint.fields.count).to eq 2
+        expect(blueprint.fields[1].facetable).to be true
+      end
+
+      it 'can add a field', :aggregate_failures do
+        blueprint = Blueprint.create! valid_attributes
+        patch blueprint_url(blueprint),
+              params: { blueprint: field_attributes, manage_field: { add_field: 'add_field' } }
+        # Fields 0 and 1 come from fields_attributes, so we should get field 2 from the add_field parameter
+        expect(response.body).to match 'id="blueprint_fields_attributes_2_display_label"'
+      end
+
+      it 'can delete a field', :aggregate_failures do
+        blueprint = Blueprint.create! valid_attributes
+        patch blueprint_url(blueprint), params: { blueprint: field_attributes, manage_field: { delete_field: '0' } }
+        expect(response.body).not_to match 'id="blueprint_fields_attributes_1_display_label"'
+        expect(response.body).to match 'id="blueprint_fields_attributes_0_display_label"'
+        expect(response.body).to match 'value="Keywords"'
+      end
+    end
+
     context 'with invalid parameters' do
       it "renders a response with 422 status (i.e. to display the 'edit' template)" do
         blueprint = Blueprint.create! valid_attributes

--- a/spec/views/admin/blueprints/edit.html.erb_spec.rb
+++ b/spec/views/admin/blueprints/edit.html.erb_spec.rb
@@ -1,19 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/blueprints/edit' do
-  let(:blueprint) do
-    FactoryBot.create(:blueprint)
-  end
+  let(:fields) { (0..2).map { FactoryBot.build(:field_config) } }
+  let(:blueprint) { FactoryBot.create(:blueprint, fields: fields) }
 
   before do
     assign(:blueprint, blueprint)
+    allow(controller).to receive(:action_name).and_return('edit')
   end
 
-  it 'renders the edit blueprint form' do
+  it 'renders new blueprint form' do
     render
+    expect(rendered).to have_selector("form[@action='#{blueprint_path(blueprint)}']")
+  end
 
-    assert_select 'form[action=?][method=?]', blueprint_path(blueprint), 'post' do
-      assert_select 'input[name=?]', 'blueprint[name]'
+  it 'has a submit button' do
+    render
+    expect(rendered).to have_button(type: 'submit')
+  end
+
+  it 'displays the blueprint name' do
+    render
+    expect(rendered).to have_selector('.blueprint_name', text: blueprint.name)
+  end
+
+  describe 'fields', :aggregate_failures do
+    it 'displays inputs and values for each field' do
+      render
+      expect(rendered).to have_field('blueprint_fields_attributes_0_display_label', with: fields[0].display_label)
+      expect(rendered).to have_field('blueprint_fields_attributes_2_display_label', with: fields[2].display_label)
+    end
+
+    it 'has a button to add a field' do
+      render
+      expect(rendered).to have_button(type: 'submit', name: 'manage_field[add_field]')
+    end
+
+    it 'has a button do delete each field' do
+      render
+      expect(rendered).to have_button(type: 'submit', name: 'manage_field[delete_field]', count: 3)
     end
   end
 end

--- a/spec/views/admin/blueprints/index.html.erb_spec.rb
+++ b/spec/views/admin/blueprints/index.html.erb_spec.rb
@@ -1,13 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/blueprints/index' do
+  let(:blueprints) { FactoryBot.create_list(:blueprint, 3) }
+
   before do
-    assign(:blueprints, FactoryBot.create_list(:blueprint, 2))
+    assign(:blueprints, blueprints)
   end
 
   it 'renders a list of blueprints' do
     render
-    cell_selector = Rails::VERSION::STRING >= '7' ? 'div>p' : 'tr>td'
-    assert_select cell_selector, text: Regexp.new('Name'.to_s), count: 2
+    expect(rendered).to have_selector('tbody .blueprint_name', count: 3)
+  end
+
+  it 'has a link to add a new blueprint' do
+    render
+    expect(rendered).to have_link('add_blueprint')
+  end
+
+  it 'has a link to view each blueprint' do
+    render
+    expect(rendered).to have_link(dom_id(blueprints[0], :view), href: blueprint_path(blueprints[0]))
+  end
+
+  it 'has a link to edit each blueprint' do
+    render
+    expect(rendered).to have_link(dom_id(blueprints[1], :edit), href: edit_blueprint_path(blueprints[1]))
+  end
+
+  it 'has a link to delete each blueprint', :aggregate_failures do
+    render
+    expect(rendered).to have_selector("form[@action='#{blueprint_path(blueprints[2])}']")
+    expect(rendered).to have_button(dom_id(blueprints[2], :delete))
   end
 end

--- a/spec/views/admin/blueprints/new.html.erb_spec.rb
+++ b/spec/views/admin/blueprints/new.html.erb_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/blueprints/new' do
+  let(:blueprint) { Blueprint.new(fields: FieldConfig.new) }
+
   before do
-    assign(:blueprint, Blueprint.new)
+    assign(:blueprint, blueprint)
   end
 
   it 'renders new blueprint form' do
@@ -11,6 +13,7 @@ RSpec.describe 'admin/blueprints/new' do
   end
 
   it 'accepts a name' do
+    allow(controller).to receive(:action_name).and_return('new')
     render
     expect(rendered).to have_field(id: 'blueprint_name')
   end

--- a/spec/views/admin/blueprints/show.html.erb_spec.rb
+++ b/spec/views/admin/blueprints/show.html.erb_spec.rb
@@ -1,12 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/blueprints/show' do
+  let(:fields) { (0..2).map { FactoryBot.build(:field_config) } }
+  let(:blueprint) { FactoryBot.create(:blueprint, fields: fields) }
+
   before do
-    assign(:blueprint, FactoryBot.create(:blueprint))
+    assign(:blueprint, blueprint)
   end
 
-  it 'renders attributes in <p>' do
+  it 'displays the blueprint name' do
     render
-    expect(rendered).to match(/Name/)
+    expect(rendered).to have_selector('.blueprint_name', text: blueprint.name)
+  end
+
+  it 'displays the blueprint fields' do
+    render
+    expect(rendered).to have_selector('#blueprint_fields .display_label', text: fields[1].display_label)
   end
 end


### PR DESCRIPTION
Replace the generated Blueprint views with custom views that support a cleaner and more streamlined admin experience.

Add the ability to manage individual fiend definitions for a blueprint.

TECHNICAL NOTE:
Fields are stored as a JSON (jsonb) blob in the database.  This simplifies management of field ordering (i.e. we don't need a separate order field or data structure) and ensures that fields' lifecycles are managed in parallel with their respective blueprint (i.e. this architecture prevents the possiblity of orphan fields).  It also avoids complications that would occur if a field were shared between two blueprints, but edited in only one.

<img width="1661" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/53733cb4-4625-480d-a34d-00242d8a78ed">

<img width="1675" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/198801f0-f643-4bc5-8d7e-0ad1f6bd5d8a">

<img width="1670" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/637db05c-dc82-4f9b-8c8f-427a3bb847e3">

<img width="1672" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/c2f7e66b-ba5e-43b1-b7da-413aaf6d2be2">

<img width="1674" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/94736627-9bc0-4d63-b592-1982f2fc1603">

<img width="1673" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/b914c874-d93b-4b4e-8833-83e89742f6fe">
