### PR TITLE
Allow administrators to upload a file for ingest

### DIFF
--- a/app/controllers/admin/ingests_controller.rb
+++ b/app/controllers/admin/ingests_controller.rb
@@ -48,7 +48,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def ingest_params
-      params.require(:ingest).permit(:user_id, :status, :size)
+      params.require(:ingest).permit(:manifest)
     end
 
     # Render success or failure for create and update actions

--- a/app/models/ingest.rb
+++ b/app/models/ingest.rb
@@ -1,6 +1,7 @@
 # Ingest job tracking
 class Ingest < ApplicationRecord
   belongs_to :user
+  has_one_attached :manifest
 
   enum status: {
     initialized: 0, # default via table definition
@@ -11,4 +12,11 @@ class Ingest < ApplicationRecord
   }
 
   validates :size, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validate :manifest_attached
+
+  def manifest_attached
+    return if manifest.attached?
+
+    errors.add(:manifest, :missing, message: 'must be attached')
+  end
 end

--- a/app/views/admin/ingests/new.html.erb
+++ b/app/views/admin/ingests/new.html.erb
@@ -1,6 +1,28 @@
 <h1>New ingest</h1>
 
-<%= render "form", ingest: @ingest %>
+<% ingest = @ingest %>
+<%= form_with(model: ingest) do |form| %>
+  <% if ingest.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(ingest.errors.count, "error") %> prohibited this ingest from being saved:</h2>
+
+      <ul>
+        <% ingest.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :manifest, style: "display: block" %>
+    <%= form.file_field :manifest %>
+  </div>
+
+  <div>
+    <%= form.submit class: 'btn btn-primary' %>
+  </div>
+<% end %>
 
 <br>
 

--- a/spec/factories/ingests.rb
+++ b/spec/factories/ingests.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :ingest do
     user factory: %i[super_admin]
     status { :initialized }
+    manifest { Rack::Test::UploadedFile.new('spec/fixtures/files/ingest.json', 'application/json') }
   end
 end

--- a/spec/fixtures/files/ingest.json
+++ b/spec/fixtures/files/ingest.json
@@ -1,0 +1,90 @@
+{
+  "response": {
+    "docs": [
+      {
+        "has_model_ssim": [
+          "Publication"
+        ],
+        "title_tesim": [
+          "Redundant Haptic Protocol: Synthesizing the virtual feed"
+        ],
+        "resource_type_tesim": [
+          "Research Paper"
+        ],
+        "creator_tesim": [
+          "Ayşe, Imogen",
+          "Prescott, Lemuel."
+        ],
+        "publisher_tesim": [
+          "Data Curation Experts"
+        ],
+        "license_tesim": [
+          "https://creativecommons.org/licenses/by-nc/4.0/"
+        ],
+        "date_created_tesim": [
+          "1991-07"
+        ],
+        "identifier_tesim": [
+          "http://boehm.test/rashad/d906:e7f2:721c:2972:37d9:66c6:c436:9cea"
+        ],
+        "member_of_collections_ssim": [
+          "Staff Reports"
+        ],
+        "member_of_collection_ids_ssim": [
+          "s7526c45q"
+        ],
+        "file_set_ids_ssim": [
+          "cf95jb559"
+        ],
+        "visibility_ssi": "open",
+        "admin_set_tesim": [
+          "Entire Collection"
+        ],
+        "title_ssi": "Redundant Haptic Protocol: Synthesizing the virtual feed",
+        "date_created_ssi": "1991-01"
+      },
+      {
+        "has_model_ssim": [
+          "Publication"
+        ],
+        "title_tesim": [
+          "Admiral of the Black Fathom: Landlubber's & Scallywags"
+        ],
+        "resource_type_tesim": [
+          "Oral History"
+        ],
+        "creator_tesim": [
+          "Nutlee, Halbert",
+          "Johnson, Kendall C."
+        ],
+        "publisher_tesim": [
+          "Data Curation Experts"
+        ],
+        "license_tesim": [
+          "https://creativecommons.org/licenses/by-nc/4.0/"
+        ],
+        "date_created_tesim": [
+          "2004-03"
+        ],
+        "identifier_tesim": [
+          "http://boehm.test/rashad/f38e:7a8e:2c60:6881:5c38:71a8:e6f9:6ab1"
+        ],
+        "member_of_collections_ssim": [
+          "Hitory"
+        ],
+        "member_of_collection_ids_ssim": [
+          "s7526c45q"
+        ],
+        "file_set_ids_ssim": [
+          "cf95jb559"
+        ],
+        "visibility_ssi": "open",
+        "admin_set_tesim": [
+          "Entire Collection"
+        ],
+        "title_ssi": "Admiral of the Black Fathom: Landlubber's & Scallywags",
+        "date_created_ssi": "2004-03"
+      }
+    ]
+  }
+}

--- a/spec/models/ingest_spec.rb
+++ b/spec/models/ingest_spec.rb
@@ -49,4 +49,29 @@ RSpec.describe Ingest do
       expect(ingest.errors.where(:size, :not_an_integer)).to be_present
     end
   end
+
+  describe '#manifest' do
+    it 'is an ActiveStorage attachment' do
+      ingest = described_class.new
+      expect(ingest.manifest).to be_a ActiveStorage::Attached::One
+    end
+
+    it 'is empty on initialization' do
+      ingest = described_class.new
+      expect(ingest.manifest).not_to be_attached
+    end
+
+    it 'is required for validation' do
+      ingest = FactoryBot.build(:ingest)
+      ingest.manifest.purge
+      ingest.validate
+      expect(ingest.errors.where(:manifest, :missing)).to be_present
+    end
+
+    it 'is added by the factory' do
+      ingest = FactoryBot.build(:ingest)
+      ingest.validate
+      expect(ingest.errors.where(:manifest, :missing)).to be_empty
+    end
+  end
 end

--- a/spec/requests/admin/ingests_spec.rb
+++ b/spec/requests/admin/ingests_spec.rb
@@ -16,8 +16,11 @@ RSpec.describe '/ingests' do
   # This should return the minimal set of attributes required to create a valid
   # Ingest. As you add validations to Ingest, be sure to
   # adjust the attributes here as well.
-  let(:valid_attributes) { { user: super_admin, status: 'queued' } }
-  let(:invalid_attributes) { { size: 'invalid' } }
+  let(:valid_attributes) do
+    { user: super_admin,
+      manifest: Rack::Test::UploadedFile.new('spec/fixtures/files/ingest.json', 'application/json') }
+  end
+  let(:invalid_attributes) { { manifest: nil } }
   let(:super_admin)  { FactoryBot.create(:super_admin) }
   let(:regular_user) { FactoryBot.create(:user) }
 
@@ -66,6 +69,18 @@ RSpec.describe '/ingests' do
         post ingests_url, params: { ingest: valid_attributes }
         expect(response).to redirect_to(ingests_url)
       end
+
+      it 'enques an import job' do
+        pending 'job implementation'
+        post ingests_url, params: { ingest: valid_attributes }
+        expect(ImportJob).to have_been_enqueued.with(Ingest.last)
+      end
+
+      it 'sets the Ingest status' do
+        pending 'job implementation'
+        post ingests_url, params: { ingest: valid_attributes }
+        expect(Ingest.last.status).to eq 'queued'
+      end
     end
 
     context 'with invalid parameters' do
@@ -89,6 +104,7 @@ RSpec.describe '/ingests' do
       end
 
       it 'updates the requested ingest' do
+        skip 'wait until some real use case surfaces'
         ingest = Ingest.create! valid_attributes
         patch ingest_url(ingest), params: { ingest: new_attributes }
         ingest.reload

--- a/spec/views/admin/ingests/new.html.erb_spec.rb
+++ b/spec/views/admin/ingests/new.html.erb_spec.rb
@@ -2,16 +2,21 @@ require 'rails_helper'
 
 RSpec.describe 'admin/ingests/new' do
   before do
-    assign(:ingest, FactoryBot.build(:ingest))
+    assign(:ingest, Ingest.new)
   end
 
   it 'renders new ingest form' do
     render
+    expect(rendered).to have_selector("form[@action='#{ingests_path}']")
+  end
 
-    assert_select 'form[action=?][method=?]', ingests_path, 'post' do
-      assert_select 'input[name=?]', 'ingest[user_id]'
+  it 'accepts manifest file' do
+    render
+    expect(rendered).to have_field(id: 'ingest_manifest')
+  end
 
-      assert_select 'input[name=?]', 'ingest[status]'
-    end
+  it 'has a submit button' do
+    render
+    expect(rendered).to have_button(type: 'submit')
   end
 end


### PR DESCRIPTION
This change updates the Ingest controller and view to allow an administrative user to select a file and upload it when creating a new ingest batch.