### PR TITLE
Implement backround processing for Ingest batches

### DIFF
--- a/app/controllers/admin/ingests_controller.rb
+++ b/app/controllers/admin/ingests_controller.rb
@@ -26,6 +26,7 @@ module Admin
 
       status = @ingest.save
       render_response_for(status)
+      ImportJob.perform_later(@ingest) if status
     end
 
     # PATCH/PUT /ingests/1 or /ingests/1.json

--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -1,0 +1,37 @@
+# Iterate over items in an Ingest manifest and
+# create associated repository objects
+class ImportJob < ApplicationJob
+  queue_as :default
+
+  after_enqueue do |job|
+    ingest = job.arguments.first
+    ingest.update(status: Ingest.statuses[:queued])
+  end
+
+  around_perform do |job, block|
+    raise ArgumentError unless job.arguments.first.is_a?(Ingest)
+
+    ingest = job.arguments.first
+    ingest.update(status: Ingest.statuses[:processing])
+    block.call
+    ingest.update(status: Ingest.statuses[:completed])
+  rescue RuntimeError
+    ingest.update(status: Ingest.statuses[:errored])
+  end
+
+  def perform(ingest)
+    processed = 0
+    metadata = JSON.parse(ingest.manifest.download)
+    docs = metadata.dig('response', 'docs')
+    docs.each do |doc|
+      process_record(doc)
+      processed += 1
+      # use update_column for fast updates - bypass validations & callbacks becuse we're only incremeting a counter
+      ingest.update_column(:processed, processed) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  def process_record(_doc)
+    sleep(5)
+  end
+end

--- a/app/models/ingest.rb
+++ b/app/models/ingest.rb
@@ -13,10 +13,21 @@ class Ingest < ApplicationRecord
 
   validates :size, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validate :manifest_attached
+  validate :manifest_format, on: :create
 
   def manifest_attached
     return if manifest.attached?
 
     errors.add(:manifest, :missing, message: 'must be attached')
+  end
+
+  def manifest_format
+    return if !manifest.attached? || size.positive?
+
+    raw_data = attachment_changes['manifest'].attachable
+    metadata = JSON.load_file(raw_data)
+    self.size = metadata.dig('response', 'docs')&.count || 0
+  rescue JSON::ParserError, TypeError
+    errors.add(:manifest, :file_format, message: 'does not contain valid JSON')
   end
 end

--- a/db/migrate/20231102143342_add_processed_to_ingests.rb
+++ b/db/migrate/20231102143342_add_processed_to_ingests.rb
@@ -1,0 +1,5 @@
+class AddProcessedToIngests < ActiveRecord::Migration[7.0]
+  def change
+    add_column :ingests, :processed, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_27_175455) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_02_143342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -86,6 +86,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_27_175455) do
     t.integer "size", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "processed", default: 0
     t.index ["user_id"], name: "index_ingests_on_user_id"
   end
 

--- a/spec/jobs/import_job_spec.rb
+++ b/spec/jobs/import_job_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe ImportJob do
+  let(:ingest) { FactoryBot.create(:ingest) }
+  let(:job) { described_class.new(ingest) }
+
+  before do
+    # stub calls to sleep in tests
+    # TODO: remove this when a full implementation of #process_reocrd is implemented
+    allow(job).to receive(:sleep)
+  end
+
+  it 'has a real implementation of #process_record' do
+    pending 'remove when a real #process_record method is implemented'
+    job.perform_now
+    expect(job).not_to have_received(:sleep)
+  end
+
+  it 'requires an Ingest instance' do
+    expect { described_class.perform_now(nil) }.to raise_exception ArgumentError
+  end
+
+  describe 'ingest status' do
+    it 'upates on enque' do
+      described_class.perform_later(ingest)
+      ingest.reload
+      expect(ingest.status).to eq 'queued'
+    end
+
+    it 'updates on perform' do
+      allow(job).to receive(:process_record)
+      allow(ingest).to receive(:update)
+      job.perform_now
+      expect(ingest).to have_received(:update).with(status: Ingest.statuses[:processing])
+    end
+
+    it 'updates on completion' do
+      allow(job).to receive(:process_record)
+      job.perform_now
+      ingest.reload
+      expect(ingest.status).to eq 'completed'
+    end
+
+    it 'updates on exceptions' do
+      allow(job).to receive(:process_record).and_raise RuntimeError
+      job.perform_now
+      ingest.reload
+      expect(ingest.status).to eq 'errored'
+    end
+  end
+
+  it 'updates the ingest record processed record count', :aggregate_failures do
+    expect(ingest.processed).to eq 0
+    job.perform_now
+    ingest.reload
+    expect(ingest.processed).to eq 2
+  end
+end

--- a/spec/models/ingest_spec.rb
+++ b/spec/models/ingest_spec.rb
@@ -74,4 +74,34 @@ RSpec.describe Ingest do
       expect(ingest.errors.where(:manifest, :missing)).to be_empty
     end
   end
+
+  describe '#check_manifest' do
+    let(:invalid_manifest) { Rack::Test::UploadedFile.new('spec/fixtures/files/sample_logo.png', 'image/png') }
+
+    it 'validates the attachment contains JSON' do
+      ingest = FactoryBot.build(:ingest)
+      ingest.manifest_format
+      # The factory attaches a json manifest
+      expect(ingest.errors.where(:manifest, :file_format)).to be_empty
+    end
+
+    it 'adds an error for non json manifests' do
+      ingest = FactoryBot.build(:ingest, manifest: invalid_manifest)
+      ingest.manifest_format
+      expect(ingest.errors.where(:manifest, :file_format)).to be_present
+    end
+
+    it 'sets the size from the manifest' do
+      ingest = FactoryBot.build(:ingest)
+      ingest.manifest_format
+      expect(ingest.size).to eq 2
+    end
+
+    it 'gets called on save' do
+      ingest = FactoryBot.build(:ingest)
+      allow(ingest).to receive(:manifest_format)
+      ingest.save
+      expect(ingest).to have_received(:manifest_format)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,4 +86,9 @@ RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by(:rack_test)
   end
+
+  config.after(:suite) do
+    # Delete any ActiveStorage blobs saved during tests
+    FileUtils.rm_rf(Dir.glob("#{ActiveStorage::Blob.service.root}/*"))
+  end
 end

--- a/spec/requests/admin/ingests_spec.rb
+++ b/spec/requests/admin/ingests_spec.rb
@@ -71,13 +71,11 @@ RSpec.describe '/ingests' do
       end
 
       it 'enques an import job' do
-        pending 'job implementation'
         post ingests_url, params: { ingest: valid_attributes }
         expect(ImportJob).to have_been_enqueued.with(Ingest.last)
       end
 
       it 'sets the Ingest status' do
-        pending 'job implementation'
         post ingests_url, params: { ingest: valid_attributes }
         expect(Ingest.last.status).to eq 'queued'
       end


### PR DESCRIPTION
When an administrator uploads a new manifest for ingest, submit a background job to iterate through each record in the manifest.

The current implementation does not do anything with the record, but adds a process counter and status updates to display whether the Ingest is 'queued', 'processing', 'completed', or 'errored'.

TODO
* Implement a version of the #process_record method in the ImportJob class that reads the supplied metadata and creates the corresponding repository object.
* Update the Administrator UI to display the processing status