### PR TITLE
Add an animated progress bar to ingests

### DIFF
--- a/app/assets/stylesheets/admin/dashboard.scss
+++ b/app/assets/stylesheets/admin/dashboard.scss
@@ -1,0 +1,9 @@
+#dashboard-content {
+  a {
+    color: #000099;
+  }
+
+  a.btn-secondary {
+    color: white;
+  }
+}

--- a/app/assets/stylesheets/admin/ingests.scss
+++ b/app/assets/stylesheets/admin/ingests.scss
@@ -1,0 +1,44 @@
+#ingests td {
+  padding-right: 1rem;
+}
+
+.status {
+  width: 15rem;
+}
+
+.status_badge {
+  position: relative;
+  width: 100%;
+  text-align: center;
+  border-radius: 0.2rem;
+  border-color: darkslategray;
+  border-width: 2px;
+  border-style: solid;
+  color: white;
+  background-color: dimgray;
+  &.queued {
+    color: darkslateblue;
+    background-color: lightsteelblue;
+  }
+  &.processing {
+    color: white;
+    background-color: darkslateblue;
+  }
+  &.completed {
+    color: white;
+    background-color: darkolivegreen;
+  }
+  &.errored {
+    color: white;
+    background-color: brown;
+  }
+  .status_increment {
+    position: absolute;
+    top: 0;
+    left: 0;
+    color: black;
+    background-color: lightsteelblue;
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/app/controllers/admin/ingests_controller.rb
+++ b/app/controllers/admin/ingests_controller.rb
@@ -5,7 +5,7 @@ module Admin
 
     # GET /ingests or /ingests.json
     def index
-      @ingests = Ingest.all
+      @ingests = Ingest.order(created_at: :desc)
     end
 
     # GET /ingests/1 or /ingests/1.json

--- a/app/helpers/progress_bar_helper.rb
+++ b/app/helpers/progress_bar_helper.rb
@@ -1,0 +1,40 @@
+# Helper to yield a progress bar component
+module ProgressBarHelper
+  # Yield the tags for a progress bar
+  # @param processed [Integer] the number of items processed so far; accepts any object that responds to #to_i
+  # @param total [Integer] the total number of items; accepts any object that responds to #to_i
+  # @param status [String] an optional processing status message
+  # @return [String] the tags representing the corresponding progress bar
+  def progress_bar(processed, total, status = nil)
+    tag.div(class: ['status_badge', status]) do
+      tag.div(message(processed, total, status), class: ['status_text']).concat(
+        tag.div(message(processed, total, status), class: ['status_increment'], aria: { hidden: true },
+                                                   style: "clip-path: inset(0 0 0 #{width(processed, total, status)})")
+      )
+    end
+  end
+
+  # Caluclate the width of the progress bar as a percent
+  # @param see ProgressBarHelper#progress_bar
+  # @return [String] the progreess bar width at a percentage
+  def width(processed, total, status = 'processing')
+    return '100%' unless status == 'processing'
+
+    "#{processed.to_i * 100 / total.to_i}%"
+  rescue ZeroDivisionError
+    '100%'
+  end
+
+  # Return the text for the progress bar
+  # @param processed [] the number of items processed so far (numerator)
+  # @param total [#to_i] the number of items total (denominator)
+  # @param status[String] the state of the item represented by the progress bar
+  # @return [String] A string like "12 queued" or "7 of 20 processed"
+  def message(processed, total, status = nil)
+    message = []
+    message << "#{processed} of" if (processed != total) && (status != 'queued')
+    message << total
+    message << status
+    message.compact.join(' ')
+  end
+end

--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -32,6 +32,6 @@ class ImportJob < ApplicationJob
   end
 
   def process_record(_doc)
-    sleep(5)
+    sleep(1)
   end
 end

--- a/app/views/admin/ingests/index.html.erb
+++ b/app/views/admin/ingests/index.html.erb
@@ -1,23 +1,44 @@
 <h1>Ingests</h1>
 
 <div id="ingests">
-  <% @ingests.each do |ingest| %>
-    <div id="<%= dom_id ingest %>">
-      <p>
-        <strong>User:</strong>
-        <%= ingest.user_id %>
-      </p>
-
-      <p>
-        <strong>Status:</strong>
-        <%= ingest.status %>
-      </p>
-
-    </div>
-    <p>
-      <%= link_to "Show this ingest", ingest %>
-    </p>
-  <% end %>
+  <table>
+    <thead>
+      <tr>
+        <th class='batch_id'>Job</th>
+        <th class='owner'>Owner</th>
+        <th class='manifest'>Manifest</th>
+        <th class='status'>Status</th>
+      </tr>
+    </thead>
+    <tbody><% @ingests.each do |ingest| %>
+      <tr>
+        <td class='batch_id'><%= ingest.id %> <%= link_to 'view', url_for(ingest) %> </td>
+        <td class='owner'><%= ingest.user.display_name %></td>
+        <td class='manifest'><%= link_to ingest.manifest.filename, rails_blob_path(ingest.manifest, disposition: "attachment") %></td>
+        <td class='status'><%= progress_bar(ingest.processed, ingest.size, ingest.status) %></td>
+      </td>
+    <% end %></tbody>
+    <tfoot>
+      <tr>
+        <th class='batch_id'>Job</th>
+        <th class='owner'>Owner</th>
+        <th class='manifest'>Manifest</th>
+        <th class='status'>Status</th>
+      </tr>
+    </tfoot>
+  </table>
 </div>
 
-<%= link_to "New ingest", new_ingest_path %>
+<%= link_to "Submit new batch", new_ingest_path, id: 'new_ingest', class: 'btn btn-secondary btn-sm' %>
+
+<!--Hack to get job processing updates-->
+<!--TODO: Use Turbo streams for status badge updates-->
+<% if @ingests.map(&:status).include?('processing') %>
+  <script>
+      function autoRefresh() {
+          window.location = window.location.href;
+      }
+      setInterval('autoRefresh()', 2000);
+  </script>
+<% end %>
+

--- a/spec/helpers/progress_bar_helper_spec.rb
+++ b/spec/helpers/progress_bar_helper_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ProgressBarHelperHelper. For example:
+#
+# describe ProgressBarHelperHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ProgressBarHelper do
+  describe '#progress_bar' do
+    it 'yields a custom progress bar' do
+      expect(helper.progress_bar(5, 100)).to match 'class="status_badge"'
+    end
+  end
+
+  describe '#width' do
+    it 'returns processed / total as a percentage' do
+      expect(helper.width(104, 160)).to eq '65%'
+    end
+
+    it 'accepts strings that can be cast to integers' do
+      expect(helper.width('15', '20')).to eq '75%'
+    end
+
+    it 'returns "100%" when flagged' do
+      expect(helper.width(0, 25, 'queued')).to eq '100%'
+    end
+
+    describe 'invalid data returns "100%"' do
+      example 'for division by 0' do
+        expect(helper.width('anything', 0)).to eq '100%'
+      end
+
+      example 'for non-integer divisors' do
+        expect(helper.width('anything', 'not-a-number')).to eq '100%'
+      end
+    end
+  end
+
+  describe '#message' do
+    it 'returns "x of y" when processed != total' do
+      expect(helper.message(104, 160)).to eq '104 of 160'
+    end
+
+    it 'accepts string values' do
+      expect(helper.message('5', 'unknown')).to eq '5 of unknown'
+    end
+
+    it 'returns status when passed' do
+      expect(helper.message(0, 0, 'errored')).to eq '0 errored'
+    end
+
+    it 'suppresses processed=0 when queued' do
+      expect(helper.message(0, 25, 'queued')).to eq '25 queued'
+    end
+  end
+end

--- a/spec/views/admin/ingests/index.html.erb_spec.rb
+++ b/spec/views/admin/ingests/index.html.erb_spec.rb
@@ -1,14 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/ingests/index' do
-  before do
-    assign(:ingests, FactoryBot.build_list(:ingest, 2))
-  end
+  let(:ingests) { (1..3).collect { |i| FactoryBot.build(:ingest, id: i) } }
+
+  before { assign(:ingests, ingests) }
 
   it 'renders a list of ingests' do
     render
-    cell_selector = 'div>p'
-    assert_select cell_selector, text: Regexp.new('User'), count: 2
-    assert_select cell_selector, text: Regexp.new('Status'), count: 2
+    expect(rendered).to have_selector('td.owner', count: 3)
+  end
+
+  it 'links to the individual batch' do
+    render
+    expect(rendered).to have_link('view', href: url_for(ingests[1]))
+  end
+
+  it 'links to the manifest' do
+    render
+    expect(rendered).to have_selector('td.manifest a', text: ingests[1].manifest.filename)
+  end
+
+  it 'displays the display_name for each owner' do
+    render
+    expect(rendered).to have_selector('td.owner', text: ingests[0].user.display_name)
+  end
+
+  it 'displays the ingest status' do
+    render
+    expect(rendered).to have_selector('td.status', text: 'initialized', count: 3)
+  end
+
+  it 'has a link to create a new ingest' do
+    render
+    expect(rendered).to have_link(:new_ingest, href: new_ingest_path)
   end
 end


### PR DESCRIPTION
This change adds a helper and CSS that formats Ingest information in a badge-like component.

The text in the badge provides the basic processing status of the Ingest including the number of items processed.  CSS is used to add color cues for the status along with animation showing how many items in the corresponding job have been processed so far.