### PR TITLE
Add an Item model and update import job

### DIFF
--- a/app/controllers/admin/blueprints_controller.rb
+++ b/app/controllers/admin/blueprints_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  # Manage user roles and authorizations
+  # Manage data model definitions
   class BlueprintsController < ApplicationController
     load_and_authorize_resource
     before_action :check_for_empty_fields, only: :edit

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,0 +1,74 @@
+module Admin
+  # Controller for UI to manage individual Items stored in the repository
+  class ItemsController < ApplicationController
+    before_action :set_item, only: %i[show edit update destroy]
+
+    # GET /items or /items.json
+    def index
+      @items = Item.all
+    end
+
+    # GET /items/1 or /items/1.json
+    def show; end
+
+    # GET /items/new
+    def new
+      blueprint_id = params['blueprint_id']
+      @item = Item.new(blueprint_id: blueprint_id)
+      @blueprint = Blueprint.find(blueprint_id) if blueprint_id
+    end
+
+    # GET /items/1/edit
+    def edit; end
+
+    # POST /items or /items.json
+    def create
+      @item = Item.new(item_params)
+
+      respond_to do |format|
+        if @item.save
+          format.html { redirect_to item_url(@item), notice: 'Item was successfully created.' }
+          format.json { render :show, status: :created, location: @item }
+        else
+          format.html { render :new, status: :unprocessable_entity }
+          format.json { render json: @item.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    # PATCH/PUT /items/1 or /items/1.json
+    def update
+      respond_to do |format|
+        if @item.update(item_params)
+          format.html { redirect_to item_url(@item), notice: 'Item was successfully updated.' }
+          format.json { render :show, status: :ok, location: @item }
+        else
+          format.html { render :edit, status: :unprocessable_entity }
+          format.json { render json: @item.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    # DELETE /items/1 or /items/1.json
+    def destroy
+      @item.destroy
+
+      respond_to do |format|
+        format.html { redirect_to items_url, notice: 'Item was successfully destroyed.' }
+        format.json { head :no_content }
+      end
+    end
+
+    private
+
+    # Use callbacks to share common setup or constraints between actions.
+    def set_item
+      @item = Item.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def item_params
+      params.require(:item).permit(:blueprint_id, description: {})
+    end
+  end
+end

--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -31,7 +31,15 @@ class ImportJob < ApplicationJob
     end
   end
 
-  def process_record(_doc)
-    sleep(1)
+  def process_record(doc)
+    blueprint_name = doc['has_model_ssim']&.first
+    blueprint = Blueprint.find_by(name: blueprint_name)
+    blueprint ||= Blueprint.find_by(name: 'Default') # TODO: remove when more blueprint functionality exists
+    d2 = {}
+    doc.each do |key, value|
+      new_key = blueprint.fields.find { |f| f.solr_field_name == key }&.display_label || key
+      d2[new_key] = value
+    end
+    Item.create(blueprint: blueprint, description: d2)
   end
 end

--- a/app/models/field_config.rb
+++ b/app/models/field_config.rb
@@ -14,6 +14,10 @@ class FieldConfig
   attribute :search_results, :boolean, default: true
   attribute :item_view, :boolean, default: true
 
+  # TODO: add data types
+  # see https://github.com/curationexperts/t3/blob/45a218ddae2a9637a0e387f9ae9dfb29329cdf6a/app/models/field.rb
+  # and JSON.parse(ActiveRecord::Type.registry.to_json)['registrations'].map{|r| r['name']}.compact.sort
+
   def initialize(*)
     super
     self.display_label ||= suggested_label

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,36 @@
+# Basic repository object, smallest unit of discovery
+class Item < ApplicationRecord
+  belongs_to :blueprint
+
+  after_save :update_index
+
+  def to_partial_path
+    "admin/#{super}"
+  end
+
+  def update_index
+    save if changed?
+    document = to_solr
+    solr_connection.update params: {}, data: { add: { doc: document } }.to_json,
+                           headers: { 'Content-Type' => 'application/json' }
+    solr_connection.update params: {}, data: { commit: {} }.to_json, headers: { 'Content-Type' => 'application/json' }
+  end
+
+  def to_solr
+    doc = []
+    doc << ['blueprint_ssi', blueprint.name]
+    doc << ['id', id]
+    blueprint.fields.each do |field|
+      label = field.solr_field_name
+      value = description[field.display_label]
+      doc << [label, value]
+    end
+    doc.to_h
+  end
+
+  private
+
+  def solr_connection
+    @solr_connection ||= CatalogController.blacklight_config.repository.connection
+  end
+end

--- a/app/views/admin/items/_choose_blueprint.html.erb
+++ b/app/views/admin/items/_choose_blueprint.html.erb
@@ -1,0 +1,9 @@
+<h2>Choose a Blueprint</h2>
+<div id='choose_blueprint'>
+  <% Blueprint.all.each do |blueprint| %>
+    <%= form_with(model: item) do |form| %>
+      <%= form.hidden_field :blueprint_id, value: blueprint.id %>
+        <%= form.submit blueprint.name %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: item, id: 'item_fields') do |form| %>
+  <% if item.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(item.errors.count, "error") %> prohibited this item from being saved:</h2>
+
+      <ul>
+        <% item.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :blueprint_id, style: "display: block" %>
+    <%= form.text_field :blueprint_id %>
+  </div>
+
+  <div>
+    <%= form.label :description, style: "display: block" %>
+    <%= form.text_field :description %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/items/_item.html.erb
+++ b/app/views/admin/items/_item.html.erb
@@ -1,0 +1,12 @@
+<div id="<%= dom_id item %>">
+  <p>
+    <strong>Blueprint:</strong>
+    <%= item.blueprint_id %>
+  </p>
+
+  <p>
+    <strong>Description:</strong>
+    <%= item.description %>
+  </p>
+
+</div>

--- a/app/views/admin/items/_item.json.jbuilder
+++ b/app/views/admin/items/_item.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! item, :id, :blueprint_id, :description, :created_at, :updated_at
+json.url item_url(item, format: :json)

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Editing item</h1>
+
+<%= render "form", item: @item %>
+
+<br>
+
+<div>
+  <%= link_to "Show this item", @item %> |
+  <%= link_to "Back to items", items_path %>
+</div>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,0 +1,14 @@
+<p style="color: green"><%= notice %></p>
+
+<h1>Items</h1>
+
+<div id="items">
+  <% @items.each do |item| %>
+    <%= render item %>
+    <p>
+      <%= link_to "Show this item", item %>
+    </p>
+  <% end %>
+</div>
+
+<%= link_to "New item", new_item_path %>

--- a/app/views/admin/items/index.json.jbuilder
+++ b/app/views/admin/items/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @items, partial: 'items/item', as: :item

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,0 +1,13 @@
+<h1>New item</h1>
+
+<% if @blueprint %>
+  <%= render "form", item: @item, blueprint: @blueprint %>
+<% else %>
+  <%= render "choose_blueprint", item: @item, blueprint: @blueprint %>
+<% end %>
+
+<br>
+
+<div>
+  <%= link_to "Back to items", items_path %>
+</div>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,0 +1,10 @@
+<p style="color: green"><%= notice %></p>
+
+<%= render @item %>
+
+<div>
+  <%= link_to "Edit this item", edit_item_path(@item) %> |
+  <%= link_to "Back to items", items_path %>
+
+  <%= button_to "Destroy this item", @item, method: :delete %>
+</div>

--- a/app/views/admin/items/show.json.jbuilder
+++ b/app/views/admin/items/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'items/item', item: @item

--- a/config/initializers/default_records.rb
+++ b/config/initializers/default_records.rb
@@ -10,6 +10,10 @@ Rails.application.config.after_initialize do
     Role.create_with(description: 'Manages system configuration and defaults')
         .find_or_create_by(name: 'System Manager')
   end
+
+  if ActiveRecord::Base.connection.table_exists? 'blueprints'
+    Blueprint.create_with(fields: []).find_or_create_by(name: 'Default')
+  end
 rescue ActiveRecord::NoDatabaseError
   # database doesn't exist, don't try to do this yet
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     get :status, to: 'status#index'
     post 'users/:id/password_reset', to: 'users#password_reset', as: :user_password_reset
     resources :ingests
+    resources :items
     resources :users
     resources :roles
     resources :blueprints

--- a/db/migrate/20231108170540_create_items.rb
+++ b/db/migrate/20231108170540_create_items.rb
@@ -1,0 +1,10 @@
+class CreateItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :items do |t|
+      t.references :blueprint, null: false, foreign_key: true
+      t.jsonb :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_02_143342) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_08_170540) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -90,6 +90,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_02_143342) do
     t.index ["user_id"], name: "index_ingests_on_user_id"
   end
 
+  create_table "items", force: :cascade do |t|
+    t.bigint "blueprint_id", null: false
+    t.jsonb "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["blueprint_id"], name: "index_items_on_blueprint_id"
+  end
+
   create_table "roles", force: :cascade do |t|
     t.string "name"
     t.string "description"
@@ -166,6 +174,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_02_143342) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "ingests", "users"
+  add_foreign_key "items", "blueprints"
   add_foreign_key "roles_users", "roles"
   add_foreign_key "roles_users", "users"
 end

--- a/spec/factories/blueprints.rb
+++ b/spec/factories/blueprints.rb
@@ -1,5 +1,16 @@
 FactoryBot.define do
   factory :blueprint do
-    name { Faker::Hipster.words.join(' ').gsub(/[^0-9A-Za-z\-_ ]/, '') }
+    sequence(:name) { |n| "blank_blueprint_#{n}" }
+  end
+
+  factory :blueprint_with_basic_fields, class: 'Blueprint' do
+    sequence(:name) { |n| "basic_blueprint_#{n}" }
+    fields do
+      [
+        build(:field_config, display_label: 'title', solr_suffix: '*_tesi'),
+        build(:field_config, display_label: 'author', solr_suffix: '*_tesim'),
+        build(:field_config, display_label: 'date', solr_suffix: '*_isi')
+      ]
+    end
   end
 end

--- a/spec/factories/field_configs.rb
+++ b/spec/factories/field_configs.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :field_config do
-    display_label { Faker::Lorem.word.capitalize }
+    sequence(:display_label) { |n| "field_#{n}" }
     solr_suffix { '*_tsi' }
-    solr_field_name { display_label.downcase + solr_suffix[1, 10] }
+    solr_field_name { display_label.downcase + solr_suffix.delete_prefix('*') }
     enabled { true }
     searchable { true }
     facetable { true }

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :item do
+    blueprint
+    description { '' }
+  end
+
+  factory :populated_item, class: 'Item' do
+    blueprint factory: %i[blueprint_with_basic_fields]
+    description do
+      {
+        'title' => 'One Hundred Years of Solitute',
+        'author' => 'Márquez, Gabriel García',
+        'date' => '1967'
+      }
+    end
+  end
+end

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Blueprint, :aggregate_failures do
   let(:blueprint) { described_class.new }
 
+  it 'initializes a default instance' do
+    expect(described_class.where(name: 'Default')).to exist
+  end
+
   describe 'name' do
     it 'cannot be blank' do
       expect(blueprint).not_to be_valid

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe Item do
+  let(:new_item) { described_class.new }
+  let(:basic_description) do
+    {
+      'title' => 'One Hundred Years of Solitute',
+      'author' => 'Márquez, Gabriel García',
+      'date' => '1967'
+    }
+  end
+  let(:solr_doc) do
+    {
+      'blueprint_ssi' => /basic_blueprint/,
+      'title_tesi' => 'One Hundred Years of Solitute',
+      'author_tesim' => 'Márquez, Gabriel García',
+      'date_isi' => '1967'
+    }
+  end
+
+  describe '#description' do
+    it 'defaults to nil' do
+      expect(new_item.description).to be_nil
+    end
+
+    it 'accepts JSON' do
+      new_item.description = basic_description.as_json
+      expect(new_item.description['date']).to eq '1967'
+    end
+  end
+
+  describe '#blueprint' do
+    it 'refers to a Blueprint' do
+      placeholder = FactoryBot.build(:blueprint)
+      new_item.blueprint = placeholder
+      expect(new_item).to be_valid
+    end
+
+    it 'must have a value' do
+      new_item.blueprint = nil
+      expect(new_item).not_to be_valid
+    end
+
+    it 'must be a kind of Blueprint' do
+      expect { new_item.blueprint = 'not a blueprint' }.to raise_exception ActiveRecord::AssociationTypeMismatch
+    end
+  end
+
+  describe '#to_solr' do
+    it 'generates a solr document' do
+      new_item.description = basic_description.as_json
+      new_item.blueprint = FactoryBot.build(:blueprint_with_basic_fields)
+      expect(new_item.to_solr).to include(solr_doc)
+    end
+
+    it 'uses the ActiveRecord ID as the solr ID' do
+      item = FactoryBot.build(:populated_item, id: 'placeholder_id')
+      expect(item.to_solr['id']).to eq item.id
+    end
+  end
+
+  it 'saves successfully' do
+    # Stub solr calls which are tested elsewhere
+    allow(new_item).to receive(:update_index)
+    new_item.blueprint = FactoryBot.build(:blueprint_with_basic_fields)
+    new_item.description = basic_description.as_json
+    expect { new_item.save! }.to change(described_class, :count).by(1)
+  end
+
+  describe '#update_index', :solr do
+    let(:item) { FactoryBot.build(:populated_item) }
+    let(:solr_client) { RSolr::Client.new(nil) }
+
+    # Fake a minimal Solr server
+    before do
+      stub_solr
+    end
+
+    it 'gets called when saving an item' do
+      allow(item).to receive(:update_index)
+      item.save!
+      expect(item).to have_received(:update_index)
+    end
+
+    it 'sends documents to Solr' do
+      allow(item).to receive(:save)
+      item.update_index
+      expect(solr_client).to have_received(:update)
+        .with(hash_including(data: { add: { doc: item.to_solr } }.to_json))
+    end
+
+    it 'saves any unsaved changes' do
+      item.description['title'] = 'An Updated Title'
+      item.update_index
+      item.reload
+      expect(item.description['title']).to eq 'An Updated Title'
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ require 'devise'
 require 'capybara/rspec'
 require 'view_component/test_helpers'
 require 'view_component/system_test_helpers'
+require 'suspport/solr_stub'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -85,6 +86,10 @@ RSpec.configure do |config|
 
   config.before(:each, type: :system) do
     driven_by(:rack_test)
+  end
+
+  config.before do
+    config.include SolrStub, :solr
   end
 
   config.after(:suite) do

--- a/spec/requests/admin/items_spec.rb
+++ b/spec/requests/admin/items_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+
+RSpec.describe '/admin/items' do
+  # This should return the minimal set of attributes required to create a valid
+  # Item. As you add validations to Item, be sure to
+  # adjust the attributes here as well.
+  let(:valid_attributes) { { 'description' => { 'title' => 'My Title' }, 'blueprint_id' => Blueprint.first.id } }
+  let(:invalid_attributes) { { blueprint_id: '' } }
+
+  # Fake a minimal Solr server
+  before do
+    solr_client = RSolr::Client.new(nil)
+    allow(RSolr::Client).to receive(:new).and_return(solr_client)
+    allow(solr_client).to receive(:get).and_return({ 'lucene' => { 'solr-spec-version' => '9.4.0' } })
+    allow(solr_client).to receive(:update)
+  end
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      Item.create(valid_attributes)
+      get items_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a successful response' do
+      item = Item.create(valid_attributes)
+      get item_url(item)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /new' do
+    context 'without a blueprint selected' do
+      it 'renders a parital completion response' do
+        get new_item_url
+        expect(response).to be_successful
+      end
+
+      it 'renders the _choose_blueprint selection partial' do
+        get new_item_url
+        expect(response.body).to include('id=\'choose_blueprint\'')
+      end
+    end
+
+    context 'with a blueprint selected' do
+      let(:blueprint) { FactoryBot.create(:blueprint) }
+
+      it 'renders a successful response' do
+        get new_item_url, params: { blueprint_id: blueprint.id }
+        expect(response).to be_successful
+      end
+
+      it 'renders the _form fields partial' do
+        get new_item_url, params: { blueprint_id: blueprint.id }
+        expect(response.body).to include('id="item_fields"')
+      end
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'renders a successful response' do
+      item = Item.create! valid_attributes
+      get edit_item_url(item)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new Item' do
+        expect do
+          post items_url, params: { item: valid_attributes }
+        end.to change(Item, :count).by(1)
+      end
+
+      it 'redirects to the created item' do
+        post items_url, params: { item: valid_attributes }
+        expect(response).to redirect_to(item_url(Item.last))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new Item' do
+        expect do
+          post items_url, params: { item: invalid_attributes }
+        end.not_to change(Item, :count)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        post items_url, params: { item: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do
+      let(:new_attributes) do
+        { description: valid_attributes['description'].merge({ 'alternate_title' => 'Weiterer Titel' }) }
+      end
+
+      it 'updates the requested item' do
+        item = Item.create! valid_attributes
+        patch item_url(item), params: { item: new_attributes }
+        item.reload
+        expect(item.description['alternate_title']).to eq 'Weiterer Titel'
+      end
+
+      it 'redirects to the item' do
+        item = Item.create! valid_attributes
+        patch item_url(item), params: { item: new_attributes }
+        item.reload
+        expect(response).to redirect_to(item_url(item))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        item = Item.create! valid_attributes
+        patch item_url(item), params: { item: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested item' do
+      # item = Item.create! valid_attributes
+      item = FactoryBot.create(:populated_item)
+      expect do
+        delete item_url(item)
+      end.to change(Item, :count).by(-1)
+    end
+
+    it 'redirects to the items list' do
+      # item = Item.create! valid_attributes
+      item = FactoryBot.create(:populated_item)
+      delete item_url(item)
+      expect(response).to redirect_to(items_url)
+    end
+  end
+end

--- a/spec/routing/admin/items_routing_spec.rb
+++ b/spec/routing/admin/items_routing_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ItemsController do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: '/admin/items').to route_to('admin/items#index')
+    end
+
+    it 'routes to #new' do
+      expect(get: '/admin/items/new').to route_to('admin/items#new')
+    end
+
+    it 'routes to #show' do
+      expect(get: '/admin/items/1').to route_to('admin/items#show', id: '1')
+    end
+
+    it 'routes to #edit' do
+      expect(get: '/admin/items/1/edit').to route_to('admin/items#edit', id: '1')
+    end
+
+    it 'routes to #create' do
+      expect(post: '/admin/items').to route_to('admin/items#create')
+    end
+
+    it 'routes to #update via PUT' do
+      expect(put: '/admin/items/1').to route_to('admin/items#update', id: '1')
+    end
+
+    it 'routes to #update via PATCH' do
+      expect(patch: '/admin/items/1').to route_to('admin/items#update', id: '1')
+    end
+
+    it 'routes to #destroy' do
+      expect(delete: '/admin/items/1').to route_to('admin/items#destroy', id: '1')
+    end
+  end
+end

--- a/spec/suspport/solr_stub.rb
+++ b/spec/suspport/solr_stub.rb
@@ -1,0 +1,10 @@
+# Stub calls to external Solr services via RSolr
+module SolrStub
+  # Fake a minimal Solr instance
+  def stub_solr
+    solr_client = RSolr::Client.new(nil)
+    allow(RSolr::Client).to receive(:new).and_return(solr_client)
+    allow(solr_client).to receive(:get).and_return({ 'lucene' => { 'solr-spec-version' => '9.4.0' } })
+    allow(solr_client).to receive(:update)
+  end
+end

--- a/spec/views/admin/items/edit.html.erb_spec.rb
+++ b/spec/views/admin/items/edit.html.erb_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/items/edit', :solr do
+  let(:item) do
+    Item.create!(
+      blueprint: Blueprint.first,
+      description: ''
+    )
+  end
+
+  before do
+    stub_solr
+    assign(:item, item)
+  end
+
+  it 'renders the edit item form' do
+    render
+
+    assert_select 'form[action=?][method=?]', item_path(item), 'post' do
+      assert_select 'input[name=?]', 'item[blueprint_id]'
+
+      assert_select 'input[name=?]', 'item[description]'
+    end
+  end
+end

--- a/spec/views/admin/items/index.html.erb_spec.rb
+++ b/spec/views/admin/items/index.html.erb_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/items/index' do
+  before do
+    assign(:items, [
+             Item.new(
+               blueprint: Blueprint.first,
+               description: '',
+               id: 'not-persisted-1'
+             ),
+             Item.new(
+               blueprint: Blueprint.first,
+               description: '',
+               id: 'not-persisted-2'
+             )
+           ])
+  end
+
+  it 'renders a list of items' do
+    render
+    cell_selector = Rails::VERSION::STRING >= '7' ? 'div>p' : 'tr>td'
+    assert_select cell_selector, text: Regexp.new(nil.to_s), count: 6
+  end
+end

--- a/spec/views/admin/items/new.html.erb_spec.rb
+++ b/spec/views/admin/items/new.html.erb_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/items/new' do
+  before do
+    assign(:item, item)
+  end
+
+  context 'without a blueprint' do
+    let(:item) { Item.new }
+
+    it 'prompts for blueprint selection' do
+      render
+      expect(rendered).to have_selector('#choose_blueprint')
+    end
+  end
+
+  context 'with a blueprint' do
+    let(:item) { Item.new(blueprint: Blueprint.first) }
+
+    it 'renders field inputs' do
+      render
+      expect(rendered).to have_selector('form')
+    end
+  end
+end

--- a/spec/views/admin/items/show.html.erb_spec.rb
+++ b/spec/views/admin/items/show.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/items/show' do
+  before do
+    assign(:item, Item.new(
+                    blueprint: Blueprint.first,
+                    description: '',
+                    id: 'not-persisted'
+                  ))
+  end
+
+  it 'renders attributes in <p>' do
+    render
+    expect(rendered).to match(//)
+  end
+end


### PR DESCRIPTION
This change adds a model that handles persistence for the primary repository object.  We use the name 'Item' rather than 'Concern', 'Work', or 'Record' because it aligns better with archival practices. I.E. the repository reflects an archive consisting of item which may or may not be human created (work), or have a separate instantiation (record).  'Concern' was rejected because it does not correlate stongly to existing concepts in the archival domain.

The item currently stores a desicription - i.e. descriptive data or metadata tied to the item.  The item is governed by a blueprint which describes how the item should be displayed, indexed, searched, imported, and exported.

This change also updates the import job to create items when processing an ingest file.