### PR TITLE
Update data_types for better Solr compatibility

### DIFF
--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -3,7 +3,7 @@
 class Field < ApplicationRecord
   enum data_type: {
     string: 1, # consider 'exact',  'literal', or 'verbatim' as type or type prefix
-    text: 2,
+    text_en: 2,
     integer: 3,
     float: 4,
     date: 5,
@@ -12,7 +12,7 @@ class Field < ApplicationRecord
 
   TYPE_TO_SOLR = {
     'string' => 's',
-    'text' => 'te',
+    'text_en' => 'te',
     'integer' => 'lt',
     'float' => 'dbt',
     'date' => 'dt',
@@ -53,7 +53,7 @@ class Field < ApplicationRecord
   end
 
   def solr_facet_field
-    @solr_facet_field ||= data_type == 'text' ? solr_field.gsub('_tesi', '_si') : solr_field
+    @solr_facet_field ||= data_type == 'text_en' ? solr_field.gsub('_tesi', '_si') : solr_field
   end
 
   private

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -90,12 +90,12 @@ RSpec.describe Field do
     end
 
     it 'accepts defined types' do
-      expect { field.data_type = 'text' }.not_to raise_exception
+      expect { field.data_type = 'text_en' }.not_to raise_exception
     end
 
     it 'casts to a string when read' do
-      field.data_type = :text
-      expect(field.data_type).to eq 'text'
+      field.data_type = :text_en
+      expect(field.data_type).to eq 'text_en'
     end
 
     it 'has a class method to return valid values' do
@@ -125,7 +125,7 @@ RSpec.describe Field do
     end
 
     it 'uses english token rules for text' do
-      field.data_type = 'text'
+      field.data_type = 'text_en'
       expect(field.solr_suffix).to match(/\A_te[sim]+\z/)
     end
 
@@ -150,7 +150,7 @@ RSpec.describe Field do
 
     it 'replaces dashes and spaces in the name with underscores' do
       field.name = 'Additional co-authors'
-      field.data_type = 'text'
+      field.data_type = 'text_en'
       field.multiple = true
       expect(field.solr_field).to eq 'additional_co_authors_tesim'
     end
@@ -176,12 +176,12 @@ RSpec.describe Field do
     end
 
     it 'does not tokenize text fields' do
-      field.data_type = 'text'
+      field.data_type = 'text_en'
       expect(field.solr_facet_field).to match(/_si\z/)
     end
 
     it 'respects multiple value fields' do
-      field.data_type = 'text'
+      field.data_type = 'text_en'
       field.multiple = true
       expect(field.solr_facet_field).to match(/_sim\z/)
     end


### PR DESCRIPTION
**ISSUE**
Our Solr schema defines text fields using English tokenization rules using the name 'text_en' instead of just 'text'.  When attempting to match internally defined Fields to data returned from the Solr Luke interface, we could use some kind of mapping function. Or more simply, we could just use mathing naming in the application.

**RESOLUTION**
Update the Field data_type from 'text' to 'text_en' for simplicity.