### PR TITLE
Fix flaky job test

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,6 +36,10 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 
+  # Use a test queuing backend for Active Job
+  config.active_job.queue_adapter     = :test
+  config.active_job.queue_name_prefix = 't3_test'
+
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.


### PR DESCRIPTION
**ISSUE**
Jobs were being tested with the `:async` queue adapter which allowed background processing of jobs in tests.  This could result in unxpected state during tests when background processig occurred while tests were running that expected object state not to change.

At leat one test was exhibiting flaky behavior as a result of this unexpecteced configuration.

**FIX**
Configure the test environment to use the `:test` queue adapter so that jobs are only run when explicitly called or run via calling `perform_enqueued_jobs`.

**REFERENCES**
https://edgeguides.rubyonrails.org/testing.html#testing-jobs https://edgeapi.rubyonrails.org/classes/ActiveJob/QueueAdapters.html https://edgeapi.rubyonrails.org/classes/ActiveJob/QueueAdapters/TestAdapter.html