### PR TITLE
Fix flaky timeout in certificate test

### DIFF
--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -62,9 +62,7 @@ RSpec.describe Certificate, :aggregate_failures do
   end
 
   it 'errors on NET::HTTP exceptions' do
-    # stub the resolution call for a non-live host
-    allow(Resolv).to receive(:getaddress).and_return('127.0.0.1')
-    allow(Net::HTTP).to receive(:start).and_raise(Net::HTTPError)
+    allow(TCPSocket).to receive(:open).and_raise(Net::OpenTimeout)
 
     cert = described_class.new(host: 'host.example.com')
     expect(cert).not_to be_valid


### PR DESCRIPTION
**ISSUE**
One of the certificate tests could occaisionally wait for a timeout error before completing, causing the example to take over a minute to run.

**FIX**
Explicitly inject the timeout error without waiting for the delay.