### PR TITLE
Revert "Fix flaky timeout in certificate test"

### DIFF
--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -62,7 +62,9 @@ RSpec.describe Certificate, :aggregate_failures do
   end
 
   it 'errors on NET::HTTP exceptions' do
-    allow(TCPSocket).to receive(:open).and_raise(Net::OpenTimeout)
+    # stub the resolution call for a non-live host
+    allow(Resolv).to receive(:getaddress).and_return('127.0.0.1')
+    allow(Net::HTTP).to receive(:start).and_raise(Net::HTTPError)
 
     cert = described_class.new(host: 'host.example.com')
     expect(cert).not_to be_valid


### PR DESCRIPTION
This reverts commit 2be2d58d8930ed848cc0cf1cfcba73e1ba1d2da5.

The new test doesn't actually cover the needed rescue clause and I can no longer replicate the timeout issue that inspired this change so we're reverting back to the earlier test setup which seems to be working without issue.  It seems like there may have been some strange state stuck in the DNS cache or networking state that's now cleared.