### PR TITLE
Remove unused method stub in tests

### DIFF
--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -64,7 +64,6 @@ RSpec.describe Certificate, :aggregate_failures do
   it 'errors on NET::HTTP exceptions' do
     # stub the resolution call for a non-live host
     allow(Resolv).to receive(:getaddress).and_return('127.0.0.1')
-    allow(Net::HTTP).to receive(:start).and_raise(Net::HTTPError)
 
     cert = described_class.new(host: 'host.example.com')
     expect(cert).not_to be_valid


### PR DESCRIPTION
While diagnosing a previous test issue, I noticed that there was an unnecessary stubbed method.