### PR TITLE
Remove dead code

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -1,5 +1,5 @@
 # Data object for Solr and Field configuration
-class Config < ApplicationRecord # rubocop:todo Metrics/ClassLength
+class Config < ApplicationRecord
   DEFAULT_CONFIG = { solr_host: 'http://localhost:8983',
                      solr_core: 'blacklight-core',
                      solr_version: 'checked' }.freeze
@@ -86,16 +86,6 @@ class Config < ApplicationRecord # rubocop:todo Metrics/ClassLength
     true
   end
 
-  def populate_fields
-    return unless fields.empty? && solr_host.present? && solr_core.present?
-
-    available_fields.map do |solr_field, config|
-      name = infer_name(solr_field, config)
-      field = Field.where(name: name).first_or_initialize
-      update_settings(field, name, config)
-    end
-  end
-
   def update_catalog_controller # rubocop:disable Metrics/AbcSize
     CatalogController.configure_blacklight do |config|
       config.connection_config[:url] = solr_connection_from_config
@@ -128,17 +118,5 @@ class Config < ApplicationRecord # rubocop:todo Metrics/ClassLength
 
   def check_for_existing
     raise ActiveRecord::RecordInvalid if Config.count >= 1
-  end
-
-  def infer_name(solr_field, config)
-    solr_field.delete_suffix(config['dynamicBase'].to_s.delete_prefix('*'))&.titleize&.strip
-  end
-
-  def update_settings(field, name, config)
-    field.update!(
-      data_type: config['type'],
-      multiple: config['schema'].include?('M'),
-      facetable: Field.exists?(name: name)
-    )
   end
 end

--- a/spec/models/config_spec.rb
+++ b/spec/models/config_spec.rb
@@ -226,26 +226,4 @@ RSpec.describe Config, :aggregate_failures do
       expect(config.available_fields).to eq []
     end
   end
-
-  describe '#populate_fields' do
-    let(:config) { FactoryBot.build(:config, solr_host: 'http://localhost:8983', solr_core: 'tenejo') }
-
-    it 'has the same number of elements as the solr index' do
-      config.populate_fields
-      # facet fields are de-duplicated by populate_fields
-      deduped_field_count = config.available_fields.count - config.fields.select { |f| f.facetable }.count
-      expect(config.fields.count).to eq deduped_field_count
-    end
-
-    it 'populates "fields" with a list of Field objects' do
-      config.populate_fields
-      expect(config.fields.map(&:class).uniq).to eq [Field]
-    end
-
-    it 'adds a suggested label in the initial list' do
-      config.populate_fields
-      resource_type = config.fields.select { |f| f.solr_field.match(/resource_type/) }.first
-      expect(resource_type.name).to eq 'Resource Type'
-    end
-  end
 end


### PR DESCRIPTION
Remove the code used to infer fields from an existing Solr index.

The current use cases don't include attaching to an existing Solr core.  Instead, we'll re-introduce similar functionality to import from a legacy Solr core as an add-on in the future.  For now, the code provides no value and adds cognitive complexity to the Config model.