### PR TITLE
Add a method to delete orphan Solr documents

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,6 +5,45 @@ class Item < ApplicationRecord
   after_save :update_index
   after_destroy_commit :delete_index
 
+  class << self
+    def reindex_all
+      Item.find_each do |item|
+        item.update_index(commit: false)
+      end
+      Config.solr_connection.commit
+    end
+
+    def delete_orphans
+      previously_checked = Item.minimum(:id)
+      # Delete any Solr documents with IDs less than the lowest database ID
+      Config.solr_connection.delete_by_query("id:[ * TO #{previously_checked} }")
+
+      # Compare Database and Solr IDs in batches (of 1,000)
+      Item.in_batches do |batch|
+        prune_orphans(batch, previously_checked)
+        previously_checked = batch.last.id
+      end
+
+      # Delete any Solr documents with IDs greater than the highest database ID
+      Config.solr_connection.delete_by_query("id:{ #{Item.maximum(:id)} TO * ]")
+      Config.solr_connection.commit
+    end
+
+    private
+
+    def prune_orphans(batch, previously_checked)
+      max_id = batch.last.id
+      # Query Solr for IDs between the last ID checked and the highest ID in the batch
+      response = Config.solr_connection.get 'select',
+                                            params: { q: "id:{#{previously_checked} TO #{max_id}]", fl: 'id',
+                                                      sort: 'id ASC', wt: :csv, facet: false, spellcheck: false }
+      solr_ids = response.split("\n").drop(1).map(&:to_i) # drop the CSV column header, cast IDs to Integers
+      db_ids = batch.map(&:id)
+      orphans = solr_ids - db_ids
+      Config.solr_connection.delete_by_id(orphans)
+    end
+  end
+
   def to_partial_path
     "admin/#{super}"
   end
@@ -21,13 +60,6 @@ class Item < ApplicationRecord
     Config.solr_connection.update data: { delete: { id: id } }.to_json,
                                   headers: { 'Content-Type' => 'application/json' },
                                   params: { commit: true }
-  end
-
-  def self.reindex_all
-    Item.all.find_each do |item|
-      item.update_index(commit: false)
-    end
-    Config.solr_connection.commit
   end
 
   def to_solr


### PR DESCRIPTION
**STORY**
My Solr index has gotten out of sync somehow and I need a way to remove Solr documents that don't have a corresponding Item in the database.