### PR TITLE
Add back-end support for user-definable field ordering

### DIFF
--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -1,6 +1,6 @@
 # Configuration point for field definitions across CatalogController, Blueprints, Items, and
 # import jobs.
-class Field < ApplicationRecord
+class Field < ApplicationRecord # rubocop:disable Metrics/ClassLength
   enum data_type: {
     string: 1, # consider 'exact',  'literal', or 'verbatim' as type or type prefix
     text_en: 2,
@@ -28,10 +28,22 @@ class Field < ApplicationRecord
 
   validates :data_type, presence: true
 
+  before_save :check_sequence
   after_save :clear_solr_field
   after_save :update_catalog_controller
 
   scope :active, -> { where(active: true) }
+
+  class << self
+    # Compact sequence numbers to eliminate gaps
+    # and start the sequence count at 1
+    def resequence
+      fields = Field.order(%i[sequence updated_at])
+      fields.each.with_index(1) do |field, index|
+        field.update!(sequence: index) if field.sequence != index
+      end
+    end
+  end
 
   # If we call render directly on a Field object, e.g. `render field`,
   # we need to explicitly define the partial path because we have
@@ -57,6 +69,22 @@ class Field < ApplicationRecord
 
   def solr_facet_field
     @solr_facet_field ||= data_type == 'text_en' ? solr_field.gsub('_tesi', '_si') : solr_field
+  end
+
+  # Change the field's position in the display sequence
+  def move(position) # rubocop:disable Metrics/MethodLength
+    case position
+    when :up
+      swap_with predecessor
+    when :down
+      swap_with successor
+    when :top
+      move_to beginning_of_sequence
+    when :bottom
+      move_to end_of_sequence
+    else
+      raise ArgumentError, "(#{position}) is not a valid command, must be one of :top, :up, :doewn, :bottom"
+    end
   end
 
   private
@@ -88,5 +116,47 @@ class Field < ApplicationRecord
 
   def title_field_from_config
     Field.active.select { |f| f.name.match(/^Title/) }.last&.solr_field
+  end
+
+  # Put the field at the end of the sequence if it's sequence order has not ben set
+  def check_sequence
+    self.sequence ||= end_of_sequence
+  end
+
+  # Swap the field's sequence order with the passed field
+  def swap_with(other = nil)
+    return unless other
+
+    my_sequence = self.sequence
+
+    update!(sequence: other.sequence)
+    other.update!(sequence: my_sequence)
+  end
+
+  # Set the field position in the sequence
+  # and adjust neighbors to eliminate gaps and start sequence at 1
+  def move_to(position)
+    update!(sequence: position)
+    Field.resequence
+  end
+
+  # Return the Field next closest to the top of the display sequence
+  # returns nil if the field is already first in the list
+  def predecessor
+    Field.where("sequence < #{self.sequence}").order(:sequence).last
+  end
+
+  # Return the Field next closest to the end of the display sequence
+  # returns nil if the field is already last in the list
+  def successor
+    Field.where("sequence > #{self.sequence}").order(:sequence).first
+  end
+
+  def beginning_of_sequence
+    Field.minimum(:sequence).to_i - 1
+  end
+
+  def end_of_sequence
+    Field.maximum(:sequence).to_i + 1
   end
 end

--- a/db/migrate/20231214210708_add_sequence_to_fields.rb
+++ b/db/migrate/20231214210708_add_sequence_to_fields.rb
@@ -1,0 +1,16 @@
+class AddSequenceToFields < ActiveRecord::Migration[7.0]
+  def change
+    add_column :fields, :sequence, :integer
+    add_index :fields, :sequence
+
+    reversible do |direction|
+      direction.up do
+        # add a sequence number to each row
+        execute <<-SQL.squish
+          WITH Sequence AS (SELECT id, ROW_NUMBER() OVER(ORDER BY id) FROM fields)#{' '}
+          UPDATE fields SET sequence = Sequence.row_number FROM Sequence WHERE fields.id = Sequence.id
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_30_022951) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_14_210708) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -89,7 +89,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_30_022951) do
     t.boolean "facetable", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "sequence"
     t.index ["name"], name: "index_fields_on_name", unique: true
+    t.index ["sequence"], name: "index_fields_on_sequence"
   end
 
   create_table "ingests", force: :cascade do |t|

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -208,6 +208,70 @@ RSpec.describe Field do
     end
   end
 
+  describe '#sequence' do
+    it 'gets set to the end of the list' do
+      previous = FactoryBot.create(:field, sequence: 10)
+      FactoryBot.create(:field)
+      expect(described_class.last.sequence).to be > previous.sequence
+    end
+  end
+
+  describe '#move' do
+    let!(:fields) { FactoryBot.create_list(:field, 2) }
+
+    it 'rasiese an exception on invalid commands' do
+      expect { fields[1].move(:sideways) }.to raise_exception ArgumentError
+    end
+
+    describe ':up' do
+      it ':moves the field toward the beginning of the sequence' do
+        fields[1].move(:up)
+        fields.each(&:reload)
+        expect(fields[0].sequence).to be > fields[1].sequence
+      end
+
+      it 'is a no-op if the field is already at the start of the sequence' do
+        expect { fields[0].move(:up) }.not_to(change { described_class.order(:sequence).ids })
+      end
+    end
+
+    describe ':down' do
+      it 'moves the field toward the end of the sequence' do
+        fields[0].move(:down)
+        fields.each(&:reload)
+        expect(fields[1].sequence).to be < fields[0].sequence
+      end
+
+      it 'is a no-op if the field is already at the end of the sequence' do
+        expect { fields[1].move(:down) }.not_to(change { described_class.order(:sequence).ids })
+      end
+    end
+
+    describe ':top' do
+      it 'moves the field to the top of the list' do
+        fields[1].move(:top)
+        fields.each(&:reload)
+        expect(fields[1].sequence).to be < fields[0].sequence
+      end
+
+      it 'is a no-op if the field is already at the start of the sequence' do
+        expect { fields[0].move(:top) }.not_to(change { described_class.order(:sequence).ids })
+      end
+    end
+
+    describe ':bottom' do
+      it 'moves the field to the end of the list' do
+        fields[0].move(:bottom)
+        fields.each(&:reload)
+        expect(fields[0].sequence).to be > fields[1].sequence
+      end
+
+      it 'is a no-op if the field is already at the end of the sequence' do
+        expect { fields[1].move(:down) }.not_to(change { described_class.order(:sequence).ids })
+      end
+    end
+  end
+
   describe '#save' do
     it 'updates the blacklight configuration' do
       allow(field).to receive(:update_catalog_controller)


### PR DESCRIPTION
This change adds a `sequence` number to each Field record to allow arbitrary (i.e. user defined) ordering to Field records.

In order to retrieve records in order, you can use something like
```
Field.order(:sequence)
```

Note that sequence numbers are not required, nor required to be unique. When multiple Field records have the same sequenc number, ordering is non-deterministic. Sequence numbers may also be non-contiguous.

For practicality, we provide a class method to normalize sequence numbers:
```
Field.resequence
```
This method ensures sequence numbers begin at 1 and are assigned contigously through `Field.count`.  This has the side-effect of providing a human-friendly display index.