### PR TITLE
Remove duplicated code between Field and Config models

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -27,10 +27,6 @@ class Config < ApplicationRecord
     Field.all.order(:created_at)
   end
 
-  def enabled_fields
-    Field.active.order(:created_at)
-  end
-
   def verified?
     solr_version.present?
   end
@@ -104,7 +100,7 @@ class Config < ApplicationRecord
 
   def blacklight_fields_from_config
     config = Blacklight::Configuration.new
-    enabled_fields.each do |f|
+    Field.active.each do |f|
       config.add_facet_field f.solr_facet_field, label: f.name if f.facetable
       config.add_index_field f.solr_field, label: f.name if f.list_view
       config.add_show_field f.solr_field, label: f.name if f.item_view
@@ -113,7 +109,7 @@ class Config < ApplicationRecord
   end
 
   def title_field_from_config
-    enabled_fields.select { |f| f.name.match(/^Title/) }.last&.solr_field
+    Field.active.order(:sequence).find_by("name ILIKE 'title%'")&.solr_field
   end
 
   def solr_connection_from_config

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -1,6 +1,6 @@
 # Configuration point for field definitions across CatalogController, Blueprints, Items, and
 # import jobs.
-class Field < ApplicationRecord # rubocop:disable Metrics/ClassLength
+class Field < ApplicationRecord
   enum data_type: {
     string: 1, # consider 'exact',  'literal', or 'verbatim' as type or type prefix
     text_en: 2,
@@ -95,27 +95,7 @@ class Field < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def update_catalog_controller
-    CatalogController.configure_blacklight do |config|
-      active_fields = blacklight_fields_from_config
-      config.facet_fields = active_fields.facet_fields
-      config.index_fields = active_fields.index_fields
-      config.show_fields = active_fields.show_fields
-      config.index.title_field = title_field_from_config
-    end
-  end
-
-  def blacklight_fields_from_config
-    config = Blacklight::Configuration.new
-    Field.active.each do |f|
-      config.add_facet_field f.solr_facet_field, label: f.name if f.facetable
-      config.add_index_field f.solr_field, label: f.name if f.list_view
-      config.add_show_field f.solr_field, label: f.name if f.item_view
-    end
-    config
-  end
-
-  def title_field_from_config
-    Field.active.select { |f| f.name.match(/^Title/) }.last&.solr_field
+    Config.current.update_catalog_controller
   end
 
   # Put the field at the end of the sequence if it's sequence order has not ben set

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -294,6 +294,8 @@ RSpec.describe Field do
       relation = described_class.where(id: nil) # empty relation
       allow(relation).to receive(:records).and_return(sample_fields)
       allow(relation).to receive(:order).and_return(sample_fields)
+      allow(relation).to receive(:order).with(:sequence).and_return(relation)
+      allow(relation).to receive(:find_by).and_return(nil)
       allow(described_class).to receive(:active).and_return(relation)
     end
 


### PR DESCRIPTION
Both the Field and Config model need to update the Blacklight configuration at certain times.  For expediency we initially largly duplicated the code in each class.

This change refactors the Field model to rely on the catalog update code in the Config model to eliminate the duplication and make future maintenance easier.