### PR TITLE
Add routing and request handling for updating Field sequence

### DIFF
--- a/app/controllers/admin/fields_controller.rb
+++ b/app/controllers/admin/fields_controller.rb
@@ -3,7 +3,7 @@ module Admin
   # This class ensures consistent behavior across various other
   # objects including the CatalogController, Items, and Blueprints
   class FieldsController < ApplicationController
-    before_action :set_field, only: %i[show edit update destroy]
+    before_action :set_field, only: %i[show edit update move destroy]
 
     # GET /fields or /fields.json
     def index
@@ -44,6 +44,19 @@ module Admin
           format.json { render :show, status: :ok, location: @field }
         else
           format.html { render :edit, status: :unprocessable_entity }
+          format.json { render json: @field.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    # PATCH /fields/1/move or /fields/1/move.json
+    def move # rubocop:disable Metrics/AbcSize
+      respond_to do |format|
+        if @field.move(params[:move])
+          format.html { redirect_to fields_url, notice: 'Field was successfully moved.' }
+          format.json { render :show, status: :ok, location: @field }
+        else
+          format.html { redirect_to fields_url, status: :unprocessable_entity, alert: @field.errors.full_messages }
           format.json { render json: @field.errors, status: :unprocessable_entity }
         end
       end

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -74,16 +74,18 @@ class Field < ApplicationRecord
   # Change the field's position in the display sequence
   def move(position) # rubocop:disable Metrics/MethodLength
     case position
-    when :up
+    when :up, 'up'
       swap_with predecessor
-    when :down
+    when :down, 'down'
       swap_with successor
-    when :top
+    when :top, 'top'
       move_to beginning_of_sequence
-    when :bottom
+    when :bottom, 'bottom'
       move_to end_of_sequence
     else
-      raise ArgumentError, "(#{position}) is not a valid command, must be one of :top, :up, :doewn, :bottom"
+      errors.add(:sequence, :position,
+                 message: "move (#{position}) is not a valid command, must be one of :top, :up, :down, :bottom")
+      false
     end
   end
 
@@ -104,13 +106,11 @@ class Field < ApplicationRecord
   end
 
   # Swap the field's sequence order with the passed field
-  def swap_with(other = nil)
-    return unless other
+  def swap_with(other)
+    return true unless other
 
     my_sequence = self.sequence
-
-    update!(sequence: other.sequence)
-    other.update!(sequence: my_sequence)
+    update(sequence: other.sequence) && other.update(sequence: my_sequence)
   end
 
   # Set the field position in the sequence
@@ -118,6 +118,7 @@ class Field < ApplicationRecord
   def move_to(position)
     update!(sequence: position)
     Field.resequence
+    true
   end
 
   # Return the Field next closest to the top of the display sequence

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,9 @@ Rails.application.routes.draw do
     resources :users
     resources :roles
     resources :blueprints
-    resources :fields
+    resources :fields do
+      patch 'move', on: :member
+    end
     resources :themes do
       patch 'activate', on: :member
     end

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -217,10 +217,17 @@ RSpec.describe Field do
   end
 
   describe '#move' do
-    let!(:fields) { FactoryBot.create_list(:field, 2) }
+    let(:fields) { FactoryBot.create_list(:field, 2) }
 
-    it 'rasiese an exception on invalid commands' do
-      expect { fields[1].move(:sideways) }.to raise_exception ArgumentError
+    context 'with invalid commands' do
+      it 'returns false' do
+        expect(field.move(:sideways)).to be false
+      end
+
+      it 'adds an error' do
+        field.move(:sideways)
+        expect(field.errors.where(:sequence, :position)).to be_present
+      end
     end
 
     describe ':up' do
@@ -230,7 +237,8 @@ RSpec.describe Field do
         expect(fields[0].sequence).to be > fields[1].sequence
       end
 
-      it 'is a no-op if the field is already at the start of the sequence' do
+      it 'is a no-op if the field is already at the start of the sequence', :aggregate_failures do
+        expect(fields[0].sequence).to eq 1
         expect { fields[0].move(:up) }.not_to(change { described_class.order(:sequence).ids })
       end
     end
@@ -242,7 +250,8 @@ RSpec.describe Field do
         expect(fields[1].sequence).to be < fields[0].sequence
       end
 
-      it 'is a no-op if the field is already at the end of the sequence' do
+      it 'is a no-op if the field is already at the end of the sequence', :aggregate_failures do
+        expect(fields[0].sequence).to eq 1
         expect { fields[1].move(:down) }.not_to(change { described_class.order(:sequence).ids })
       end
     end
@@ -254,7 +263,8 @@ RSpec.describe Field do
         expect(fields[1].sequence).to be < fields[0].sequence
       end
 
-      it 'is a no-op if the field is already at the start of the sequence' do
+      it 'is a no-op if the field is already at the start of the sequence', :aggregate_failures do
+        expect(fields[0].sequence).to eq 1
         expect { fields[0].move(:top) }.not_to(change { described_class.order(:sequence).ids })
       end
     end
@@ -266,7 +276,8 @@ RSpec.describe Field do
         expect(fields[0].sequence).to be > fields[1].sequence
       end
 
-      it 'is a no-op if the field is already at the end of the sequence' do
+      it 'is a no-op if the field is already at the end of the sequence', :aggregate_failures do
+        expect(fields[0].sequence).to eq 1
         expect { fields[1].move(:down) }.not_to(change { described_class.order(:sequence).ids })
       end
     end

--- a/spec/requests/admin/fields_spec.rb
+++ b/spec/requests/admin/fields_spec.rb
@@ -107,6 +107,35 @@ RSpec.describe '/admin/fields' do
     end
   end
 
+  describe 'PATCH /move' do
+    context 'with valid parameters' do
+      it 'sends a move message to the object' do
+        field = Field.create! valid_attributes
+        allow(Field).to receive(:find).with(field.id.to_s).and_return(field)
+        allow(field).to receive(:move).and_return(true)
+
+        patch move_field_path(field), params: { 'move' => 'up' }
+        expect(field).to have_received(:move).with('up')
+      end
+
+      it 'redirects to the index view' do
+        field = Field.create! valid_attributes
+        patch move_field_path(field), params: { move: :up }
+        expect(response).to redirect_to fields_url
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'renders a response with 422 status' do
+        field = FactoryBot.build(:field, id: 1)
+        allow(Field).to receive(:find).with(field.id.to_s).and_return(field)
+
+        patch move_field_path(field), params: { move: :sideways }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
   describe 'DELETE /destroy' do
     it 'destroys the requested field' do
       field = Field.create! valid_attributes

--- a/spec/routing/admin/fields_routing_spec.rb
+++ b/spec/routing/admin/fields_routing_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe Admin::FieldsController do
       expect(patch: '/admin/fields/1').to route_to('admin/fields#update', id: '1')
     end
 
+    it 'routes to #move via PATCH' do
+      expect(patch: '/admin/fields/1/move').to route_to('admin/fields#move', id: '1')
+    end
+
     it 'routes to #destroy' do
       expect(delete: '/admin/fields/1').to route_to('admin/fields#destroy', id: '1')
     end


### PR DESCRIPTION
This change adds a RESTful route for the `move` action on fields.

Note that the move action typically makes changes to other fields in additon to the field it is called on. I.E. most moves will update the sequence number for the subject field and one or more other fields.

* `up` decrement the field's sequence order (i.e. move it closer to the head of the list)
* `down` increment the field's sequence order (i.e. move it closer to the tail of the list)
* `top` move the field to the head of the list
* `bottom` move the field to the tail of the list

Calling `up` or `top` when the field is already at the top of the list will leave sequence numbers unchanged.

Calling `down` or `botton` when the field is already at the tail of the list will will the sequence numbers unchanged.