### PR TITLE
Allow admins to re-order fields

### DIFF
--- a/app/assets/stylesheets/admin/blueprints.scss
+++ b/app/assets/stylesheets/admin/blueprints.scss
@@ -12,18 +12,15 @@
   tr {
     height: 2.5rem;
   }
-}
-
-.name {
-  width: 15rem;
-}
-
-.solr_field {
-  width: 13rem;
-}
-
-.field_number, .searchable, .facetable, .list_view, .item_view {
-  text-align: center;
+  .name {
+    width: 15rem;
+  }
+  .solr_field {
+    width: 13rem;
+  }
+  .field_number, .searchable, .facetable, .list_view, .item_view {
+    text-align: center;
+  }
 }
 
 button, a {

--- a/app/assets/stylesheets/admin/fileds.scss
+++ b/app/assets/stylesheets/admin/fileds.scss
@@ -39,7 +39,10 @@
   }
 }
 
-#fields {
+table#fields {
+  table-layout: fixed;
+  width: 100%;
+
   thead {
     border-color: color-mix(in srgb, var(--bs-body-bg) 50%, white);;
     border-style: solid;
@@ -60,19 +63,49 @@
     background-color: color-mix(in srgb, var(--bs-body-bg) 50%, white);
   }
 
+  tr {
+    height: 3.25rem;
+  }
+
+  th.order {
+    padding-left: 1rem;
+  }
+
+  .order {
+    width: 5.5rem;
+    button {
+      margin: 0 0.5rem 0 0;
+      border: 0;
+      padding: 0.25rem 0 0.25rem 0;
+      background-color: rgba(0, 0, 0, 0) ;
+
+      &.up {
+        padding-left: 0.5rem;
+        margin-left: 0.5rem;
+      }
+      &.down {
+        padding-right: 0.5rem;
+      }
+    }
+  }
   .name {
-    min-width: 15rem;
+    width: 10rem;
   }
 
   .data_type {
-    min-width: 10rem;
+    width: 10rem;
+  }
+
+  .settings {;
+    width: 15rem;
+  }
+
+  .solr_field {
+    width: 15rem;
+    word-wrap: break-word;
   }
 
   .source_field {
-    min-width: 15rem;
-  }
-
-  .settings {
-    min-width: 20rem;
+    word-wrap: break-word;
   }
 }

--- a/app/controllers/admin/fields_controller.rb
+++ b/app/controllers/admin/fields_controller.rb
@@ -7,7 +7,7 @@ module Admin
 
     # GET /fields or /fields.json
     def index
-      @fields = Field.all
+      @fields = Field.order(:sequence)
     end
 
     # GET /fields/1 or /fields/1.json
@@ -53,7 +53,7 @@ module Admin
     def move # rubocop:disable Metrics/AbcSize
       respond_to do |format|
         if @field.move(params[:move])
-          format.html { redirect_to fields_url, notice: 'Field was successfully moved.' }
+          format.html { redirect_to fields_url }
           format.json { render :show, status: :ok, location: @field }
         else
           format.html { redirect_to fields_url, status: :unprocessable_entity, alert: @field.errors.full_messages }

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -5,6 +5,6 @@ class Blueprint < ApplicationRecord
   validates :name, format: { with: /\A([\w _-])+\z/, message: 'can not contain special characters' }, allow_blank: true
 
   def fields
-    Field.active
+    Field.active.order(:sequence)
   end
 end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -100,7 +100,7 @@ class Config < ApplicationRecord
 
   def blacklight_fields_from_config
     config = Blacklight::Configuration.new
-    Field.active.each do |f|
+    Field.active.order(:sequence).each do |f|
       config.add_facet_field f.solr_facet_field, label: f.name if f.facetable
       config.add_index_field f.solr_field, label: f.name if f.list_view
       config.add_show_field f.solr_field, label: f.name if f.item_view

--- a/app/views/admin/fields/index.html.erb
+++ b/app/views/admin/fields/index.html.erb
@@ -1,48 +1,53 @@
 <h1>Fields</h1>
 
-<div id="fields">
-  <table>
-    <thead>
+<table id="fields">
+  <thead>
+    <tr>
+      <th class="order">Order</th>
+      <th class="name">Name</th>
+      <th class="data_type">Data Type</th>
+      <th class="settings">Settings</th>
+      <th class="solr_field">Indexes to</th>
+      <th class="source_field">Source</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @fields.each do |field| %>
       <tr>
-        <th class="name">Name</th>
-        <th class="data_type">Data Type</th>
-        <th class="source_field">Source</th>
-        <th class="settings">Settings</th>
-        <th class="solr_field">Indexes to</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @fields.each do |field| %>
-        <tr>
-          <td class="name"><%= link_to field.name, field -%></td>
-          <td class="data_type"><%= field.data_type -%><%= ' (multiple)' if field.multiple -%></td>
-          <td class="source_field"><%= field.source_field -%></td>
-          <td class="settings">
-            <% settings = field.active ? ['active'] : ['disabled'] %>
-            <% settings << ['required'] if field.required %>
-            <% settings << ['list view'] if field.list_view %>
-            <% settings << ['item view'] if field.item_view %>
-            <% settings << ['searchable'] if field.searchable %>
-            <% settings << ['facetable'] if field.facetable %>
-            <%= settings.join(', ') -%>
+        <td class="order">
+          <%= button_to '🔼', move_field_path(field, move: :up), id: dom_id(field, :move_up), class: 'up', method: :patch, disabled: field.sequence == 1 %>
+          <%= button_to '🔽', move_field_path(field, move: :down), id: dom_id(field, :move_down), class: 'down', method: :patch, disabled: field.sequence == Field.count %>
+        </td>
+        <td class="name"><%= link_to field.name, field -%></td>
+        <td class="data_type"><%= field.data_type -%><%= ' (multiple)' if field.multiple -%></td>
+        <td class="settings">
+          <% settings = field.active ? ['active'] : ['disabled'] %>
+          <% settings << ['required'] if field.required %>
+          <% settings << ['list view'] if field.list_view %>
+          <% settings << ['item view'] if field.item_view %>
+          <% settings << ['searchable'] if field.searchable %>
+          <% settings << ['facetable'] if field.facetable %>
+          <%= settings.join(', ') -%>
 
-          </td>
-          <td class="solr_field"><%= field.solr_field %></td>
-        </tr>
-      <% end %>
-
-    </tbody>
-    <tfoot>
-      <tr>
-        <th class="name">Name</th>
-        <th class="data_type">Data Type</th>
-        <th class="source_field">Source</th>
-        <th class="settings">Settings</th>
-        <th class="solr_field">Indexes to</th>
+        </td>
+        <td class="solr_field"><%= field.solr_field %></td>
+        <td class="source_field"><%= field.source_field -%></td>
       </tr>
-    </tfoot>
-  </table>
-</div>
+    <% end %>
+
+  </tbody>
+  <tfoot>
+    <tr>
+      <th class="order">Order</th>
+      <th class="name">Name</th>
+      <th class="data_type">Data Type</th>
+      <th class="settings">Settings</th>
+      <th class="solr_field">Indexes to</th>
+      <th class="source_field">Source</th>
+    </tr>
+  </tfoot>
+</table>
+
 
 <br>
 <%= link_to "Add field", new_field_path, class: 'btn btn-outline-primary' %>

--- a/spec/system/field_order_spec.rb
+++ b/spec/system/field_order_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'Field Order' do
+  let!(:first_field) { FactoryBot.create(:field, name: 'Alpha') }
+  let!(:second_field) { FactoryBot.create(:field, name: 'Beta') }
+
+  it 'updates from the UI', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    # Check initial order
+    expect(first_field.sequence).to be < second_field.sequence
+
+    # Confirm fields index view respects the order
+    visit fields_path
+    expect(page.all('#fields td.name').map(&:text)).to eq ['Alpha', 'Beta']
+
+    # Reorder fields
+    click_on "move_down_field_#{first_field.id}"
+    expect(page.all('#fields td.name').map(&:text)).to eq ['Beta', 'Alpha']
+
+    # Check Catalog configuration reflects updated field order
+    show_fields = CatalogController.blacklight_config.show_fields.values.map(&:label)
+    expect(show_fields).to eq ['Beta', 'Alpha']
+  end
+end


### PR DESCRIPTION
This commit adds user interface controls in the Fields index view to allow system administrators to modify the order fields are displayed in.

The field order is used in multiple locations in the application:
* Field dashboard
* Blueprint dashboard - viewing fields in an individual blueprint
* Search result listings
* Item view pages

A single field order is used across the application to support a user's ability to scan content across the application.