### PR TITLE
Add reporting and error tracking for Ingests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ Metrics/BlockLength:
     - 'config/environments/**/*'
 
 Metrics/MethodLength:
+  CountAsOne: ['array', 'hash', 'heredoc']
   Exclude:
     - 'db/**/*'
 

--- a/app/helpers/progress_bar_helper.rb
+++ b/app/helpers/progress_bar_helper.rb
@@ -5,11 +5,12 @@ module ProgressBarHelper
   # @param total [Integer] the total number of items; accepts any object that responds to #to_i
   # @param status [String] an optional processing status message
   # @return [String] the tags representing the corresponding progress bar
-  def progress_bar(processed, total, status = nil)
+  def progress_bar(processed, total, status = nil, errored = 0)
+    numerator = errored.zero? ? processed : errored
     tag.div(class: ['status_badge', status]) do
-      tag.div(message(processed, total, status), class: ['status_text']).concat(
-        tag.div(message(processed, total, status), class: ['status_increment'], aria: { hidden: true },
-                                                   style: "clip-path: inset(0 0 0 #{width(processed, total, status)})")
+      tag.div(message(numerator, total, status), class: ['status_text']).concat(
+        tag.div(message(numerator, total, status), class: ['status_increment'], aria: { hidden: true },
+                                                   style: "clip-path: inset(0 0 0 #{width(numerator, total, status)})")
       )
     end
   end

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -7,4 +7,9 @@ class Blueprint < ApplicationRecord
   def fields
     Field.active.order(:sequence)
   end
+
+  # Returns a reverse mapping of source_field ==> field name
+  def key_map
+    fields.to_h { |field| [field.source_field, field.name] }
+  end
 end

--- a/app/models/ingest.rb
+++ b/app/models/ingest.rb
@@ -2,6 +2,7 @@
 class Ingest < ApplicationRecord
   belongs_to :user
   has_one_attached :manifest
+  has_one_attached :report
 
   enum status: {
     initialized: 0, # default via table definition

--- a/app/views/admin/ingests/index.html.erb
+++ b/app/views/admin/ingests/index.html.erb
@@ -17,7 +17,7 @@
         <td class='owner'><%= ingest.user.display_name %></td>
         <td class='manifest'><%= link_to ingest.manifest.filename, rails_blob_path(ingest.manifest, disposition: "attachment") %></td>
         <td class='report'><%= link_to ingest.report.filename, rails_blob_path(ingest.report, disposition: "attachment") if ingest.report.attached? %></td>
-        <td class='status'><%= progress_bar(ingest.processed, ingest.size, ingest.status) %></td>
+        <td class='status'><%= progress_bar(ingest.processed, ingest.size, ingest.status, ingest.error_count) %></td>
       </tr>
     <% end %></tbody>
     <tfoot>

--- a/app/views/admin/ingests/index.html.erb
+++ b/app/views/admin/ingests/index.html.erb
@@ -7,6 +7,7 @@
         <th class='batch_id'>Job</th>
         <th class='owner'>Owner</th>
         <th class='manifest'>Manifest</th>
+        <th class='report'>Report</th>
         <th class='status'>Status</th>
       </tr>
     </thead>
@@ -15,14 +16,16 @@
         <td class='batch_id'><%= ingest.id %> <%= link_to 'view', url_for(ingest) %> </td>
         <td class='owner'><%= ingest.user.display_name %></td>
         <td class='manifest'><%= link_to ingest.manifest.filename, rails_blob_path(ingest.manifest, disposition: "attachment") %></td>
+        <td class='report'><%= link_to ingest.report.filename, rails_blob_path(ingest.report, disposition: "attachment") if ingest.report.attached? %></td>
         <td class='status'><%= progress_bar(ingest.processed, ingest.size, ingest.status) %></td>
-      </td>
+      </tr>
     <% end %></tbody>
     <tfoot>
       <tr>
         <th class='batch_id'>Job</th>
         <th class='owner'>Owner</th>
         <th class='manifest'>Manifest</th>
+        <th class='report'>Report</th>
         <th class='status'>Status</th>
       </tr>
     </tfoot>

--- a/db/migrate/20240221194642_add_errors_to_ingests.rb
+++ b/db/migrate/20240221194642_add_errors_to_ingests.rb
@@ -1,0 +1,5 @@
+class AddErrorsToIngests < ActiveRecord::Migration[7.0]
+  def change
+    add_column :ingests, :error_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_14_210708) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_21_194642) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -101,6 +101,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_14_210708) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "processed", default: 0
+    t.integer "error_count", default: 0
     t.index ["user_id"], name: "index_ingests_on_user_id"
   end
 

--- a/spec/fixtures/files/report.json
+++ b/spec/fixtures/files/report.json
@@ -1,0 +1,22 @@
+{
+  "report": {
+    "status": "completed",
+    "docs": [
+      {
+        "timestamp": "2024-02-20T19:24:23.010Z",
+        "id": "987654321",
+        "status": "completed"
+      },
+      {
+        "timestamp": "2024-02-20T19:24:23.573Z",
+        "id": "987654322",
+        "status": "completed"
+      },
+      {
+        "timestamp": "2024-02-20T19:24:24.129Z",
+        "id": "987654323",
+        "status": "completed"
+      }
+    ]
+  }
+}

--- a/spec/helpers/progress_bar_helper_spec.rb
+++ b/spec/helpers/progress_bar_helper_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe ProgressBarHelper do
     it 'yields a custom progress bar' do
       expect(helper.progress_bar(5, 100)).to match 'class="status_badge"'
     end
+
+    it 'includes error count when passed' do
+      expect(helper.progress_bar(15, 20, 'errored', 5)).to match '5 of 20 errored'
+    end
   end
 
   describe '#width' do

--- a/spec/jobs/import_job_spec.rb
+++ b/spec/jobs/import_job_spec.rb
@@ -79,6 +79,22 @@ RSpec.describe ImportJob do
     expect(ingest.processed).to eq 2
   end
 
+  context 'with errors' do
+    before do
+      allow(job).to receive(:save_record).and_return({ status: 'created' }, { status: 'error' }, { status: 'created' })
+    end
+
+    it 'sets the job status' do
+      job.perform_now
+      expect(ingest).to be_errored
+    end
+
+    it 'sets the error count' do
+      job.perform_now
+      expect(ingest.error_count).to eq 1
+    end
+  end
+
   describe 'status report' do
     it 'gets attached at job completion' do
       allow(job).to receive(:process_record).and_return({ status: 'created' })

--- a/spec/jobs/import_job_spec.rb
+++ b/spec/jobs/import_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ImportJob do
     end
 
     it 'gets called once for each item in the manifest' do
-      allow(job).to receive(:process_record)
+      allow(job).to receive(:process_record).and_return({ status: 'created' })
       job.perform_now
       expect(job).to have_received(:process_record).exactly(2).times
     end
@@ -49,37 +49,85 @@ RSpec.describe ImportJob do
   describe 'ingest status' do
     it 'upates on enque' do
       described_class.perform_later(ingest)
-      ingest.reload
       expect(ingest.status).to eq 'queued'
     end
 
     it 'updates on perform' do
-      allow(job).to receive(:process_record)
+      allow(job).to receive(:process_record).and_return({ status: 'created' })
       allow(ingest).to receive(:update)
       job.perform_now
       expect(ingest).to have_received(:update).with(status: Ingest.statuses[:processing])
     end
 
     it 'updates on completion' do
-      allow(job).to receive(:process_record)
+      allow(job).to receive(:process_record).and_return({ status: 'created' })
       job.perform_now
-      ingest.reload
       expect(ingest.status).to eq 'completed'
     end
 
     it 'updates on exceptions' do
       allow(job).to receive(:process_record).and_raise RuntimeError
       job.perform_now
-      ingest.reload
       expect(ingest.status).to eq 'errored'
     end
   end
 
   it 'updates the ingest record processed record count', :aggregate_failures do
-    allow(job).to receive(:process_record)
+    allow(job).to receive(:process_record).and_return({ status: 'created' })
     expect(ingest.processed).to eq 0
     job.perform_now
-    ingest.reload
     expect(ingest.processed).to eq 2
+  end
+
+  describe 'status report' do
+    it 'gets attached at job completion' do
+      allow(job).to receive(:process_record).and_return({ status: 'created' })
+      job.perform_now
+      expect(ingest.report).to be_attached
+    end
+
+    it 'includes job metrics', :aggregate_failures do
+      allow(job).to receive(:process_record).and_return({ status: 'created' })
+      job.perform_now
+      report = JSON.parse(ingest.report.download, { symbolize_names: true })
+      expect(report).to include(
+        context: a_hash_including(
+          status: 'completed',
+          submitted: /\A\d{4}-\d{2}-\d{2}/,
+          finished: /\d{2}\.\d{3}Z\z/,
+          submitted_by: ingest.user.display_name
+        ),
+        items: a_kind_of(Array)
+      )
+    end
+
+    context 'with errors' do
+      before do
+        # Simulate an error on creating one of two records
+        allow(Item).to receive(:create) do |params|
+          raise 'Testing exception handling' if params[:description]['title_ssi'].match?(/Admiral/)
+
+          Item.new(id: 1)
+        end
+      end
+
+      it 'captures errors', :aggregate_failures do
+        job.perform_now
+        expect(ingest).to be_errored
+        report = JSON.parse(ingest.report.download, { symbolize_names: true })
+        expect(report).to include(
+          context: a_hash_including(
+            status: 'errored',
+            submitted: /\d{4}-\d{2}-\d{2}/,
+            started: /\d{4}-\d{2}-\d{2}/,
+            finished: /\d{4}-\d{2}-\d{2}/,
+            submitted_by: ingest.user.display_name,
+            processed: 2,
+            errored: 1
+          ),
+          items: include(a_hash_including(message: 'Testing exception handling'))
+        )
+      end
+    end
   end
 end

--- a/spec/models/ingest_spec.rb
+++ b/spec/models/ingest_spec.rb
@@ -75,6 +75,25 @@ RSpec.describe Ingest do
     end
   end
 
+  describe '#report' do
+    it 'is an ActiveStorage attachment' do
+      ingest = described_class.new
+      expect(ingest.report).to be_a ActiveStorage::Attached::One
+    end
+
+    it 'is empty on initialization' do
+      ingest = described_class.new
+      expect(ingest.report).not_to be_attached
+    end
+
+    it 'is not required for validation' do
+      ingest = FactoryBot.build(:ingest)
+      ingest.report.purge
+      ingest.validate
+      expect(ingest.errors).to be_empty
+    end
+  end
+
   describe '#check_manifest' do
     let(:invalid_manifest) { Rack::Test::UploadedFile.new('spec/fixtures/files/sample_logo.png', 'image/png') }
 

--- a/spec/views/admin/ingests/index.html.erb_spec.rb
+++ b/spec/views/admin/ingests/index.html.erb_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe 'admin/ingests/index' do
     expect(rendered).to have_selector('td.manifest a', text: ingests[1].manifest.filename)
   end
 
+  it 'links to the report' do
+    ingests[2].report = Rack::Test::UploadedFile.new('spec/fixtures/files/report.json', 'application/json')
+    render
+    expect(rendered).to have_selector('td.report a', text: ingests[1].report.filename)
+  end
+
   it 'displays the display_name for each owner' do
     render
     expect(rendered).to have_selector('td.owner', text: ingests[0].user.display_name)


### PR DESCRIPTION
This pull request adds reporting and error tracking to the ImportJob that processes Ingest records.

Key features include:
* Adding a report that persists status about each item in the Ingest, including whether it was successfully created or an error occurred.
* Refactoring the ImportJob to catch exceptions at a lower level so we can extract more specific information about what went wrong when errors occur.
* Saving the error count as part of the high-level metadata so we can easily display it in Ingest views.
* Displaying the error count in user-facing progress bars when it's present.

<img width="907" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/70bca726-4d14-49a4-8313-45f38e6a0a9c">
