### PR TITLE
Use the first active ordered field as the Blacklight title field

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -98,9 +98,10 @@ class Config < ApplicationRecord
 
   private
 
-  def blacklight_fields_from_config
+  def blacklight_fields_from_config # rubocop:disable Metrics/AbcSize
     config = Blacklight::Configuration.new
-    Field.active.order(:sequence).each do |f|
+    # NOTE: skip the first field because it's always used as the main title field for Blacklight
+    Field.active.order(:sequence)[1..]&.each do |f|
       config.add_facet_field f.solr_facet_field, label: f.name if f.facetable
       config.add_index_field f.solr_field, label: f.name if f.list_view
       config.add_show_field f.solr_field, label: f.name if f.item_view
@@ -109,7 +110,7 @@ class Config < ApplicationRecord
   end
 
   def title_field_from_config
-    Field.active.order(:sequence).find_by("name ILIKE 'title%'")&.solr_field
+    Field.active.order(:sequence).first&.solr_field
   end
 
   def solr_connection_from_config

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -307,19 +307,22 @@ RSpec.describe Field do
       allow(relation).to receive(:order).and_return(sample_fields)
       allow(relation).to receive(:order).with(:sequence).and_return(relation)
       allow(relation).to receive(:find_by).and_return(nil)
+      allow(relation).to receive(:first).and_return(sample_fields[0])
       allow(described_class).to receive(:active).and_return(relation)
     end
 
     it 'updates index fields', :aggregate_failures do
+      # NOTE: the first active field is used as the title field and already displays in index and show views
       expect { field.send(:update_catalog_controller) }
         .to change { CatalogController.blacklight_config.index_fields.values.map(&:label) }
-        .from([]).to(['field1', 'field2'])
+        .from([]).to(['field2'])
     end
 
     it 'updates show fields', :aggregate_failures do
+      # NOTE: the first active field is used as the title field and already displays in index and show views
       expect { field.send(:update_catalog_controller) }
         .to change { CatalogController.blacklight_config.show_fields.values.map(&:label) }
-        .from([]).to(['field1', 'field3'])
+        .from([]).to(['field3'])
     end
 
     it 'updates facet fields', :aggregate_failures do

--- a/spec/system/catalog_config_spec.rb
+++ b/spec/system/catalog_config_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Catalog Config' do
   let(:field_seeds) do
-    [{ name: 'Title', data_type: 'text_en', list_view: true, item_view: true },
+    [{ name: 'Title',       data_type: 'text_en', list_view: true,  item_view: true },
      { name: 'Identifier',  data_type: 'string',  list_view: true,  item_view: true },
      { name: 'Description', data_type: 'text_en', list_view: false, item_view: true, multiple: true },
      { name: 'Creator',     data_type: 'text_en', list_view: true,  item_view: true, multiple: true, facetable: true },
@@ -23,11 +23,16 @@ RSpec.describe 'Catalog Config' do
     Config.current
   end
 
+  it 'sets CatalogController title field to the first active field' do
+    # Get the title field name from the catalog controller
+    title_field = CatalogController.blacklight_config.index.title_field
+    expect(title_field).to eq 'title_tesi'
+  end
+
   it 'sets CatalogController index fields from the current Config' do
     # Get the name => lable pairs from the catalog controller
     index_fields = CatalogController.blacklight_config.index_fields.map { |_k, v| [v.field, v.label] }
     expect(index_fields).to eq([
-                                 ['title_tesi', 'Title'],
                                  ['identifier_ssi', 'Identifier'],
                                  ['creator_tesim', 'Creator']
                                ])
@@ -37,7 +42,6 @@ RSpec.describe 'Catalog Config' do
     # Get the name => lable pairs from the catalog controller
     show_fields = CatalogController.blacklight_config.show_fields.map { |_k, v| [v.field, v.label] }
     expect(show_fields).to eq([
-                                ['title_tesi', 'Title'],
                                 ['identifier_ssi', 'Identifier'],
                                 ['description_tesim', 'Description'],
                                 ['creator_tesim', 'Creator'],

--- a/spec/system/field_order_spec.rb
+++ b/spec/system/field_order_spec.rb
@@ -1,23 +1,26 @@
 require 'rails_helper'
 
 describe 'Field Order' do
-  let!(:first_field) { FactoryBot.create(:field, name: 'Alpha') }
+  let!(:first_field)  { FactoryBot.create(:field, name: 'Alpha') }
   let!(:second_field) { FactoryBot.create(:field, name: 'Beta') }
+  let!(:third_field)  { FactoryBot.create(:field, name: 'Gamma') }
 
   it 'updates from the UI', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
     # Check initial order
     expect(first_field.sequence).to be < second_field.sequence
+    expect(second_field.sequence).to be < third_field.sequence
 
     # Confirm fields index view respects the order
     visit fields_path
-    expect(page.all('#fields td.name').map(&:text)).to eq ['Alpha', 'Beta']
+    expect(page.all('#fields td.name').map(&:text)).to eq ['Alpha', 'Beta', 'Gamma']
 
     # Reorder fields
     click_on "move_down_field_#{first_field.id}"
-    expect(page.all('#fields td.name').map(&:text)).to eq ['Beta', 'Alpha']
+    expect(page.all('#fields td.name').map(&:text)).to eq ['Beta', 'Alpha', 'Gamma']
 
     # Check Catalog configuration reflects updated field order
+    # NOTE: first field is used as the title field and suppressed from index_fields and show_fields
     show_fields = CatalogController.blacklight_config.show_fields.values.map(&:label)
-    expect(show_fields).to eq ['Beta', 'Alpha']
+    expect(show_fields).to eq ['Alpha', 'Gamma']
   end
 end


### PR DESCRIPTION
Blacklight requries a title field to be configured for the application. This field is used as the linkable title for documents in search results and as the item header in single-item views.

Previously, we set this by looking for the first field that matched the string "Title".  Over time we found that
1. We wanted to use the word "Title" in the name of more than one field e.g. "Alternate Titles" and "Primary Title".
2. We typically ordered fields so title was at the top of the list to reflect how blacklight displays field ordering.

With these insights, it became clear that using the first field in the ordered field list would be the easiest solution for users to manage. It also has the benefit of being clear and easy to implement from a code perspective.