### PR TITLE
Show the custom site name in the page title

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <%= content_tag :html, class: 'no-js', **html_tag_attributes do %>
+  <% content_for(:page_title) { Theme.current.site_name } %>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/spec/views/layouts/blacklight/base.html.erb_spec.rb
+++ b/spec/views/layouts/blacklight/base.html.erb_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'layouts/blacklight/base' do
+  let(:catalog) { CatalogController.new }
+
+  before do
+    allow(view).to receive(:controller).and_return(catalog)
+    allow(view).to receive(:application_name).and_return('Test App')
+    allow(catalog).to receive(:request).and_return(request)
+
+    stub_template('shared/_header_navbar.html.erb' => 'HEADER',
+                  'shared/_footer.html.erb' => 'FOOTER')
+  end
+
+  it 'includes the Theme site name in metadata' do
+    allow(Theme.current).to receive(:site_name).and_return('A fancy new archive')
+
+    render
+    expect(rendered).to have_title('A fancy new archive')
+  end
+
+  it 'sets a favicon link' do
+    render
+    expect(rendered).to match(/<link rel="icon".*href=".*tenejo_knot_sm.png"/)
+  end
+end


### PR DESCRIPTION
This commit updates the main application layout file to include the site name configured in the current Theme as the HTML page title.

This causes the site name to be diplayed in browser tabs, favorites, and search engine search results.