### PR TITLE
Fix flaky test

### DIFF
--- a/spec/views/layouts/blacklight/base.html.erb_spec.rb
+++ b/spec/views/layouts/blacklight/base.html.erb_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'layouts/blacklight/base' do
   let(:catalog) { CatalogController.new }
+  let(:theme) { Theme.new(site_name: 'A fancy new archive') }
 
   before do
     allow(view).to receive(:controller).and_return(catalog)
@@ -10,11 +11,10 @@ RSpec.describe 'layouts/blacklight/base' do
 
     stub_template('shared/_header_navbar.html.erb' => 'HEADER',
                   'shared/_footer.html.erb' => 'FOOTER')
+    allow(Theme).to receive(:current).and_return(theme)
   end
 
   it 'includes the Theme site name in metadata' do
-    allow(Theme.current).to receive(:site_name).and_return('A fancy new archive')
-
     render
     expect(rendered).to have_title('A fancy new archive')
   end


### PR DESCRIPTION
The current theme can be modified by other tests which change the favicon, leaving it in an underterminate state.

This change ensures that `Theme.current` returns a known entity for the layout tests.