### PR TITLE
Output semantic metadata to logs in JSON format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem 'stimulus-rails'
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem 'jbuilder'
 
+# Support semantic logs in JSON format [https://logger.rocketjob.io/rails.html]
+gem 'rails_semantic_logger'
+
 # Use Redis adapter to run Action Cable in production
 gem 'redis', '~> 4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,6 +323,10 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails_semantic_logger (4.14.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.13)
     railties (7.0.8.1)
       actionpack (= 7.0.8.1)
       activesupport (= 7.0.8.1)
@@ -405,6 +409,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    semantic_logger (4.15.0)
+      concurrent-ruby (~> 1.0)
     sidekiq (7.1.4)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
@@ -499,6 +505,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.6)
   rails (~> 7.0.8)
+  rails_semantic_logger
   redis (~> 4.0)
   rsolr (>= 1.0, < 3)
   rspec-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,4 +27,11 @@ class ApplicationController < ActionController::Base
         super
       end
   end
+
+  private
+
+  def append_info_to_payload(payload)
+    super
+    payload[:request_id] = request.request_id
+  end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,14 @@
+# Application-wide job behaviors
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
+
+  # Add JobID tags for semantic logger
+  # for context see https://github.com/rails/rails/blob/v7.0.8.1/activejob/lib/active_job/logging.rb#L17-L19
+  def perform_now
+    SemanticLogger.tagged(job_id: job_id) { super }
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,9 @@ module T3
 
     # Don't allow non-authorized users to infer existence of resources
     config.action_dispatch.rescue_responses.merge!('CanCan::AccessDenied' => :not_found)
+
+    # Output logs in JSON format
+    config.rails_semantic_logger.format = :json
+    config.semantic_logger.application = Rails.application.class.module_parent_name
   end
 end


### PR DESCRIPTION
In order to easily leaverage search and filtering capabilities in log aggregation and analysis tools like AWS CloudWatch logs, we want to send our logs in an easily parsable format.

We've chosen [Semantic Logger](https://logger.rocketjob.io/index.html) because it provides an easy drop-in replacement for the default Rails logger. Semantic Logger doesn't require us to change any of our existing logging code and makes it simple to output logs in JSON format.

We also take advantage of the [metric](https://logger.rocketjob.io/metrics.html) features of Semantic Logger to capture performance (e.g. duration) statistics for areas of the code that we want to monitor for potential bottlenecks as the codebase grows and evolves.