### PR TITLE
Move button for new Ingests to top of form

### DIFF
--- a/app/assets/stylesheets/admin/ingests.scss
+++ b/app/assets/stylesheets/admin/ingests.scss
@@ -1,44 +1,57 @@
-#ingests td {
-  padding-right: 1rem;
-}
+#ingests {
+  h1 {
+    display: inline-block;
+  }
 
-.status {
-  width: 15rem;
-}
+  #new_ingest {
+    margin-left: 5.75rem;
+    margin-bottom: 0.75rem;
+    color: var(--bs-btn-color);
+  }
 
-.status_badge {
-  position: relative;
-  width: 100%;
-  text-align: center;
-  border-radius: 0.2rem;
-  border-color: darkslategray;
-  border-width: 2px;
-  border-style: solid;
-  color: white;
-  background-color: dimgray;
-  &.queued {
-    color: darkslateblue;
-    background-color: lightsteelblue;
+  td {
+    padding-right: 1rem;
   }
-  &.processing {
-    color: white;
-    background-color: darkslateblue;
+
+  .status {
+    width: 15rem;
   }
-  &.completed {
-    color: white;
-    background-color: darkolivegreen;
-  }
-  &.errored {
-    color: white;
-    background-color: brown;
-  }
-  .status_increment {
-    position: absolute;
-    top: 0;
-    left: 0;
-    color: black;
-    background-color: lightsteelblue;
+
+  .status_badge {
+    position: relative;
     width: 100%;
     text-align: center;
+    border-radius: 0.2rem;
+    border-color: darkslategray;
+    border-width: 2px;
+    border-style: solid;
+    color: white;
+    background-color: dimgray;
+    &.queued {
+      color: darkslateblue;
+      background-color: lightsteelblue;
+    }
+    &.processing {
+      color: white;
+      background-color: darkslateblue;
+    }
+    &.completed {
+      color: white;
+      background-color: darkolivegreen;
+    }
+    &.errored {
+      color: white;
+      background-color: brown;
+    }
+    .status_increment {
+      position: absolute;
+      top: 0;
+      left: 0;
+      color: black;
+      background-color: lightsteelblue;
+      width: 100%;
+      text-align: center;
+    }
   }
 }
+

--- a/app/views/admin/ingests/index.html.erb
+++ b/app/views/admin/ingests/index.html.erb
@@ -1,6 +1,7 @@
-<h1>Ingests</h1>
-
 <div id="ingests">
+  <h1>Ingests</h1>
+  <%= link_to "Submit new job", new_ingest_path, id: 'new_ingest', class: 'btn btn-primary' %>
+
   <table>
     <thead>
       <tr>
@@ -31,8 +32,6 @@
     </tfoot>
   </table>
 </div>
-
-<%= link_to "Submit new batch", new_ingest_path, id: 'new_ingest', class: 'btn btn-secondary btn-sm' %>
 
 <!--Hack to get job processing updates-->
 <!--TODO: Use Turbo streams for status badge updates-->


### PR DESCRIPTION
**ISSUE**
When the list of ingests gets longer than one screen, it becomes less convenient to scroll to the end of the list to click the button to submit a new job. Some users might even miss the button because the didn't think to scroll to the bottom.

**RESOLUTION**
Move the button to start a new ingest to the top of the screen so it is always visible when the screen first renders.

**AFTER**
<img width="1439" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/73bfea12-29a7-4beb-aac2-f62d0004e764">

**BEFORE**
<img width="1446" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/afb5332e-85f4-4ca6-b7be-c90aa13a2a8c">
Scroll, scroll, scroll...
<img width="1439" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/bd0a6c48-6b1c-4743-a6e4-44ba635142f9">
