### PR TITLE
Display individual metdata fields on Item edit form

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,9 @@ Metrics/BlockLength:
     - 'config/routes.rb'
     - 'config/environments/**/*'
 
+Metrics/ClassLength:
+  CountAsOne: ['array', 'hash', 'heredoc']
+
 Metrics/MethodLength:
   CountAsOne: ['array', 'hash', 'heredoc']
   Exclude:

--- a/app/assets/stylesheets/admin/items.scss
+++ b/app/assets/stylesheets/admin/items.scss
@@ -1,0 +1,3 @@
+input, textarea {
+  width: 50rem;
+}

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -19,6 +19,15 @@ class Field < ApplicationRecord
     'boolean' => 'b'
   }.freeze
 
+  TYPE_TO_HELPER = {
+    'string' => :text_field,
+    'text_en' => :text_area,
+    'integer' => :number_field,
+    'float' => :number_field,
+    'date' => :date_field,
+    'boolean' => :check_box
+  }.freeze
+
   validates :name, presence: true
   validates :name, uniqueness: { case_sensitive: false }
   validates :name, format: { with: /\A[a-z0-9]/i, message: 'must begin with a letter or number' }

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -13,13 +13,19 @@
 
   <div>
     <%= form.label :blueprint_id, style: "display: block" %>
-    <%= form.text_field :blueprint_id %>
+    <%= form.collection_select :blueprint_id, Blueprint.order(:name), :id, :name, {}, {disabled: controller.action_name == 'edit'} %>
+    <%= form.hidden_field :blueprint_id, value: item.blueprint_id %>
   </div>
 
-  <div>
-    <%= form.label :description, style: "display: block" %>
-    <%= form.text_field :description %>
-  </div>
+  <%= fields_for :description, OpenStruct.new(item.description) do |item_detail| %>
+    <% item.blueprint.fields.each do |field| %>
+      <div>
+        <%= item_detail.label field.name, style: "display: block" %>
+        <% field_method = Field::TYPE_TO_HELPER[field.data_type] %>
+        <%= item_detail.send(field_method, field.name) %>
+      </div>
+    <% end %>
+  <% end %>
 
   <div>
     <%= form.submit %>

--- a/spec/requests/admin/items_spec.rb
+++ b/spec/requests/admin/items_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe '/admin/items' do
   # Item. As you add validations to Item, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) { { 'description' => { 'title' => 'My Title' }, 'blueprint_id' => Blueprint.first.id } }
-  let(:invalid_attributes) { { blueprint_id: '' } }
+  let(:invalid_attributes) { { description: 'invalid' } }
 
   # Fake a minimal Solr server
   before do
@@ -117,8 +117,11 @@ RSpec.describe '/admin/items' do
     end
 
     context 'with invalid parameters' do
+      let(:item) { Item.create! valid_attributes }
+
       it "renders a response with 422 status (i.e. to display the 'edit' template)" do
-        item = Item.create! valid_attributes
+        allow(item).to receive(:update).and_return false
+        allow(Item).to receive(:find).and_return item
         patch item_url(item), params: { item: invalid_attributes }
         expect(response).to have_http_status(:unprocessable_entity)
       end

--- a/spec/views/admin/items/edit.html.erb_spec.rb
+++ b/spec/views/admin/items/edit.html.erb_spec.rb
@@ -1,25 +1,110 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/items/edit', :solr do
+  let(:blueprint) { Blueprint.new(name: 'Simple Blueprint') }
+
   let(:item) do
     Item.create!(
-      blueprint: Blueprint.first,
-      description: ''
+      blueprint: blueprint,
+      description: { 'Title' => '1 Print' }
     )
   end
 
   before do
     stub_solr
     assign(:item, item)
+    allow(controller).to receive(:action_name).and_return('edit')
   end
 
-  it 'renders the edit item form' do
+  it 'displays a form' do
     render
+    expect(rendered).to have_selector("form[action=\"#{item_path(item)}\"][method=\"post\"]")
+  end
 
-    assert_select 'form[action=?][method=?]', item_path(item), 'post' do
-      assert_select 'input[name=?]', 'item[blueprint_id]'
+  it 'displays the (disabled) blueprint name' do
+    render
+    expect(rendered).to have_field('item_blueprint_id', text: 'Simple Blueprint', disabled: true)
+  end
 
-      assert_select 'input[name=?]', 'item[description]'
+  it 'displays fields in order' do
+    allow(blueprint).to receive(:fields).and_return([
+                                                      FactoryBot.build(:field, name: 'Title'),
+                                                      FactoryBot.build(:field, name: 'Author'),
+                                                      FactoryBot.build(:field, name: 'Format')
+                                                    ])
+    render
+    input_fields = Capybara.string(rendered).all('input[@type!="submit"], textarea')
+    field_ids = input_fields.pluck(:id)
+    expect(field_ids).to eq ['description_Title', 'description_Author', 'description_Format']
+  end
+
+  describe 'a text field' do
+    let(:text_field) do
+      FactoryBot.build(:field, name: 'abstract', data_type: 'text_en', multiple: false, id: 1, sequence: 1)
+    end
+
+    it 'renders as a textarea input' do
+      allow(blueprint).to receive(:fields).and_return([text_field])
+      render
+      expect(rendered).to have_selector('textarea#description_abstract')
+    end
+  end
+
+  describe 'a string field' do
+    let(:string_field) do
+      FactoryBot.build(:field, name: 'genre', data_type: 'string', multiple: true, id: 1, sequence: 1)
+    end
+
+    it 'renders as a text_field input' do
+      allow(blueprint).to receive(:fields).and_return([string_field])
+      render
+      expect(rendered).to have_selector('input#description_genre[@type="text"]')
+    end
+  end
+
+  describe 'a date field' do
+    let(:date_field) { FactoryBot.build(:field, name: 'date', data_type: 'date', multiple: false, id: 1, sequence: 1) }
+
+    it 'renders as a date_field input' do
+      allow(blueprint).to receive(:fields).and_return([date_field])
+      render
+      expect(rendered).to have_selector('input#description_date[@type="date"]')
+    end
+  end
+
+  describe 'a boolean field' do
+    let(:boolean_field) do
+      FactoryBot.build(:field, name: 'special_collections', data_type: 'boolean', multiple: false, id: 1, sequence: 1)
+    end
+
+    it 'renders as a checkbox' do
+      allow(blueprint).to receive(:fields).and_return([boolean_field])
+      render
+      expect(rendered).to have_selector('input#description_special_collections[@type="checkbox"]')
+    end
+  end
+
+  describe 'an integer field' do
+    let(:integer_field) do
+      FactoryBot.build(:field, name: 'year', data_type: 'integer', multiple: false, id: 1, sequence: 1)
+    end
+
+    it 'renders as a numeric field' do
+      allow(blueprint).to receive(:fields).and_return([integer_field])
+      render
+      expect(rendered).to have_selector('input#description_year[@type="number"]')
+    end
+  end
+
+  describe 'an float field' do
+    let(:float_field) do
+      FactoryBot.build(:field, name: 'score', data_type: 'float', multiple: false, id: 1, sequence: 1)
+    end
+
+    it 'renders as a numeric field' do
+      allow(blueprint).to receive(:fields).and_return([float_field])
+      render
+      expect(rendered).to have_selector('input#description_score[@type="number"]')
     end
   end
 end


### PR DESCRIPTION
Previously, the Item edit form had a single field with all metadata fields combined into a single JSON field.  This made editing individual description fields brittle since format errors would impact all fields.

This commit displays each field in the item's blueprint in its own edit field.

## BEFORE
![image](https://github.com/curationexperts/t3/assets/3064318/f3b03286-25d9-4cda-ba7b-e15f089a9f6c)

## AFTER
![image](https://github.com/curationexperts/t3/assets/3064318/470337ae-c38c-48c6-b7f6-f0470afcd3e9)
