### PR TITLE
git cValidate required fields when saving Items

### DIFF
--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,16 +1,12 @@
 FactoryBot.define do
   factory :item do
     blueprint
-    description { {} }
-
-    factory :populated_item do
-      description do
-        {
-          'Title' => 'One Hundred Years of Solitute',
-          'Author' => ['Márquez, Gabriel García'],
-          'Date' => '1967'
-        }
-      end
+    description do
+      {
+        'Title' => 'One Hundred Years of Solitute',
+        'Author' => ['Márquez, Gabriel García'],
+        'Date' => '1967'
+      }
     end
   end
 end

--- a/spec/requests/admin/items_spec.rb
+++ b/spec/requests/admin/items_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe '/admin/items' do
   describe 'DELETE /destroy' do
     it 'destroys the requested item' do
       # item = Item.create! valid_attributes
-      item = FactoryBot.create(:populated_item)
+      item = FactoryBot.create(:item)
       expect do
         delete item_url(item)
       end.to change(Item, :count).by(-1)
@@ -139,7 +139,7 @@ RSpec.describe '/admin/items' do
 
     it 'redirects to the items list' do
       # item = Item.create! valid_attributes
-      item = FactoryBot.create(:populated_item)
+      item = FactoryBot.create(:item)
       delete item_url(item)
       expect(response).to redirect_to(items_url)
     end


### PR DESCRIPTION
This commit adds validations that check each field marked as required and ensures that the field is not blank for the item.

If the field is blank, the validation adds an error indicating that the field name can not be blank.

This change also adds a check to ensure that description is not blank. Item tests and factories are updated to reflect that description is no longer valid when blank.