### PR TITLE
Validate required fields when saving Items

### DIFF
--- a/app/assets/stylesheets/admin/items.scss
+++ b/app/assets/stylesheets/admin/items.scss
@@ -1,3 +1,7 @@
-input, textarea {
+.item input, .item textarea {
   width: 50rem;
+}
+
+.item .required {
+  font-style: italic;
 }

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: item, id: 'item_fields') do |form| %>
+<%= form_with(model: item, id: 'item_fields', class: 'item') do |form| %>
   <% if item.errors.any? %>
     <div style="color: red">
       <h2><%= pluralize(item.errors.count, "error") %> prohibited this item from being saved:</h2>
@@ -20,9 +20,12 @@
   <%= fields_for :description, OpenStruct.new(item.description) do |item_detail| %>
     <% item.blueprint.fields.each do |field| %>
       <div>
-        <%= item_detail.label field.name, style: "display: block" %>
+        <%= item_detail.label field.name, style: "display: block" do -%>
+          <%= field.name -%>
+          <%= content_tag(:span, '(required)', class: 'required') if field.required -%>
+        <% end %>
         <% field_method = Field::TYPE_TO_HELPER[field.data_type] %>
-        <%= item_detail.send(field_method, field.name) %>
+        <%= item_detail.send(field_method, field.name, required: field.required, aria: {label: field.name, required: field.required}) %>
       </div>
     <% end %>
   <% end %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,16 +1,12 @@
 FactoryBot.define do
   factory :item do
     blueprint
-    description { {} }
-
-    factory :populated_item do
-      description do
-        {
-          'Title' => 'One Hundred Years of Solitute',
-          'Author' => ['Márquez, Gabriel García'],
-          'Date' => '1967'
-        }
-      end
+    description do
+      {
+        'Title' => 'One Hundred Years of Solitute',
+        'Author' => ['Márquez, Gabriel García'],
+        'Date' => '1967'
+      }
     end
   end
 end

--- a/spec/requests/admin/items_spec.rb
+++ b/spec/requests/admin/items_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe '/admin/items' do
   describe 'DELETE /destroy' do
     it 'destroys the requested item' do
       # item = Item.create! valid_attributes
-      item = FactoryBot.create(:populated_item)
+      item = FactoryBot.create(:item)
       expect do
         delete item_url(item)
       end.to change(Item, :count).by(-1)
@@ -139,7 +139,7 @@ RSpec.describe '/admin/items' do
 
     it 'redirects to the items list' do
       # item = Item.create! valid_attributes
-      item = FactoryBot.create(:populated_item)
+      item = FactoryBot.create(:item)
       delete item_url(item)
       expect(response).to redirect_to(items_url)
     end

--- a/spec/views/admin/items/edit.html.erb_spec.rb
+++ b/spec/views/admin/items/edit.html.erb_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe 'admin/items/edit', :solr do
     expect(field_ids).to eq ['description_Title', 'description_Author', 'description_Format']
   end
 
+  it 'indiicates required inputs' do
+    allow(blueprint).to receive(:fields).and_return([
+                                                      FactoryBot.build(:field, name: 'Title', required: true),
+                                                      FactoryBot.build(:field, name: 'Author'),
+                                                      FactoryBot.build(:field, name: 'Format', required: true)
+                                                    ])
+    render
+    input_fields = Capybara.string(rendered).all('label:has(span.required)')
+    field_ids = input_fields.pluck(:for)
+    expect(field_ids).to eq ['description_Title', 'description_Format']
+  end
+
   describe 'a text field' do
     let(:text_field) do
       FactoryBot.build(:field, name: 'abstract', data_type: 'text_en', multiple: false, id: 1, sequence: 1)


### PR DESCRIPTION
This commit adds validations that check each field marked as required and ensures that the field is not blank for the item.

If the field is blank, the validation adds an error indicating that the field name can not be blank.

This change also adds a check to ensure that description is not blank. Item tests and factories are updated to reflect that description is no longer valid when blank.