### PR TITLE
Indicate required fields on the edit form

### DIFF
--- a/app/assets/stylesheets/admin/items.scss
+++ b/app/assets/stylesheets/admin/items.scss
@@ -1,3 +1,7 @@
-input, textarea {
+.item input, .item textarea {
   width: 50rem;
+}
+
+.item .required {
+  font-style: italic;
 }

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: item, id: 'item_fields') do |form| %>
+<%= form_with(model: item, id: 'item_fields', class: 'item') do |form| %>
   <% if item.errors.any? %>
     <div style="color: red">
       <h2><%= pluralize(item.errors.count, "error") %> prohibited this item from being saved:</h2>
@@ -20,9 +20,12 @@
   <%= fields_for :description, OpenStruct.new(item.description) do |item_detail| %>
     <% item.blueprint.fields.each do |field| %>
       <div>
-        <%= item_detail.label field.name, style: "display: block" %>
+        <%= item_detail.label field.name, style: "display: block" do -%>
+          <%= field.name -%>
+          <%= content_tag(:span, '(required)', class: 'required') if field.required -%>
+        <% end %>
         <% field_method = Field::TYPE_TO_HELPER[field.data_type] %>
-        <%= item_detail.send(field_method, field.name) %>
+        <%= item_detail.send(field_method, field.name, required: field.required, aria: {label: field.name, required: field.required}) %>
       </div>
     <% end %>
   <% end %>

--- a/spec/views/admin/items/edit.html.erb_spec.rb
+++ b/spec/views/admin/items/edit.html.erb_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe 'admin/items/edit', :solr do
     expect(field_ids).to eq ['description_Title', 'description_Author', 'description_Format']
   end
 
+  it 'indiicates required inputs' do
+    allow(blueprint).to receive(:fields).and_return([
+                                                      FactoryBot.build(:field, name: 'Title', required: true),
+                                                      FactoryBot.build(:field, name: 'Author'),
+                                                      FactoryBot.build(:field, name: 'Format', required: true)
+                                                    ])
+    render
+    input_fields = Capybara.string(rendered).all('label:has(span.required)')
+    field_ids = input_fields.pluck(:for)
+    expect(field_ids).to eq ['description_Title', 'description_Format']
+  end
+
   describe 'a text field' do
     let(:text_field) do
       FactoryBot.build(:field, name: 'abstract', data_type: 'text_en', multiple: false, id: 1, sequence: 1)


### PR DESCRIPTION
This commit adds text, css, html, and aria labels to flag any fields marked as required in the field configuration.

## BEFORE
<img width="923" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/3b817b1f-6397-4ede-bcfb-c3030a577a02">

## AFTER
<img width="928" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/d21cf72b-24f3-41cc-85c2-b227046c14ba">
