### PR TITLE
Rename Item 'description' to 'metadata' (⛔️ Requires Downtime)

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -68,7 +68,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def item_params
-      params.require(:item).permit(:blueprint_id, description: {})
+      params.require(:item).permit(:blueprint_id, metadata: {})
     end
   end
 end

--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -38,8 +38,8 @@ class ImportJob < ApplicationJob
 
   def process_record(doc)
     blueprint = find_blueprint(doc)
-    description = build_description(blueprint, doc)
-    save_record(blueprint, description)
+    metadata = build_description(blueprint, doc)
+    save_record(blueprint, metadata)
   end
 
   # Return the blueprint object matching the name from the input document
@@ -54,13 +54,13 @@ class ImportJob < ApplicationJob
   end
 
   # Save a new Item, rescuing & capturing exceptions
-  def save_record(blueprint, description)
-    item = Item.create(blueprint: blueprint, description: description)
+  def save_record(blueprint, metadata)
+    item = Item.create(blueprint: blueprint, metadata: metadata)
     { id: item.id, status: 'created', timestamp: Time.current.iso8601(3) }
   rescue RuntimeError => e
     logger.error { "#{e}: #{e.message}" }
     { id: nil, status: 'error', timestamp: Time.current.iso8601(3), error_class: e.class, message: e.message,
-      ref: description[:ingest_key] }
+      ref: metadata[:ingest_key] }
   end
 
   # Utility class to encapsulate the details of status reporting from

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,7 +5,7 @@ class Item < ApplicationRecord
   after_save :update_index
   after_destroy_commit :delete_index
 
-  validates :description, presence: true
+  validates :metadata, presence: true
   validate :required_fields_present
 
   class << self
@@ -74,7 +74,7 @@ class Item < ApplicationRecord
     blueprint.fields.each do |field|
       solr_field = field.solr_field
       solr_facet = field.solr_facet_field
-      value = description[field.name]
+      value = metadata[field.name]
       doc[solr_field] = value
       doc[solr_facet] = value if field.facetable
     end
@@ -87,7 +87,7 @@ class Item < ApplicationRecord
     return if blueprint&.fields.blank?
 
     blueprint.fields.select(&:required).each do |required_field|
-      present = description.keys.include?(required_field.name)
+      present = metadata.keys.include?(required_field.name)
       unless present
         errors.add(required_field.name.downcase.to_sym, :blank, message:
           "Required field 'required_field.name' can not be blank")

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -17,7 +17,7 @@
     <%= form.hidden_field :blueprint_id, value: item.blueprint_id %>
   </div>
 
-  <%= fields_for :description, OpenStruct.new(item.description) do |item_detail| %>
+  <%= fields_for :metadata, OpenStruct.new(item.metadata) do |item_detail| %>
     <% item.blueprint.fields.each do |field| %>
       <div>
         <%= item_detail.label field.name, style: "display: block" do -%>

--- a/app/views/admin/items/_item.html.erb
+++ b/app/views/admin/items/_item.html.erb
@@ -5,8 +5,8 @@
   </p>
 
   <p>
-    <strong>Description:</strong>
-    <%= item.description %>
+    <strong>Metadata:</strong>
+    <%= item.metadata %>
   </p>
 
 </div>

--- a/app/views/admin/items/_item.json.jbuilder
+++ b/app/views/admin/items/_item.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! item, :id, :blueprint_id, :description, :created_at, :updated_at
+json.extract! item, :id, :blueprint_id, :metadata, :created_at, :updated_at
 json.url item_url(item, format: :json)

--- a/db/migrate/20240328224015_rename_item_description_to_metadata.rb
+++ b/db/migrate/20240328224015_rename_item_description_to_metadata.rb
@@ -1,0 +1,5 @@
+class RenameItemDescriptionToMetadata < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :items, :description, :metadata
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_21_194642) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_28_224015) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -107,7 +107,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_21_194642) do
 
   create_table "items", force: :cascade do |t|
     t.bigint "blueprint_id", null: false
-    t.jsonb "description"
+    t.jsonb "metadata"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["blueprint_id"], name: "index_items_on_blueprint_id"

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :item do
     blueprint
-    description do
+    metadata do
       {
         'Title' => 'One Hundred Years of Solitute',
         'Author' => ['Márquez, Gabriel García'],

--- a/spec/jobs/import_job_spec.rb
+++ b/spec/jobs/import_job_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe ImportJob do
       FactoryBot.create(:field, name: 'Date', data_type: 'integer', source_field: 'date_isi')
 
       job.process_record(doc)
-      expect(Item.last.description).to include('Title' => 'Anna Karenina',
-                                               'Author' => ['Tolstoy, Lev Nikolayevich',
-                                                            'Tolstoy, Leo', 'Толстой, Лев Николаевич'],
-                                               'Date' => 1878)
+      expect(Item.last.metadata).to include('Title' => 'Anna Karenina',
+                                            'Author' => ['Tolstoy, Lev Nikolayevich',
+                                                         'Tolstoy, Leo', 'Толстой, Лев Николаевич'],
+                                            'Date' => 1878)
     end
   end
 
@@ -121,7 +121,7 @@ RSpec.describe ImportJob do
       before do
         # Simulate an error on creating one of two records
         allow(Item).to receive(:create) do |params|
-          raise 'Testing exception handling' if params[:description]['title_ssi'].match?(/Admiral/)
+          raise 'Testing exception handling' if params[:metadata]['title_ssi'].match?(/Admiral/)
 
           Item.new(id: 1)
         end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Item do
-  let(:new_item) { described_class.new(description: basic_description) }
+  let(:new_item) { described_class.new(metadata: basic_description) }
   let(:basic_description) do
     {
       'Title' => 'One Hundred Years of Solitute',
@@ -18,14 +18,14 @@ RSpec.describe Item do
     }
   end
 
-  describe '#description' do
+  describe '#metadata' do
     it 'defaults to nil' do
-      expect(described_class.new.description).to be_nil
+      expect(described_class.new.metadata).to be_nil
     end
 
     it 'accepts JSON' do
-      new_item.description = basic_description.as_json
-      expect(new_item.description['Date']).to eq '1967'
+      new_item.metadata = basic_description.as_json
+      expect(new_item.metadata['Date']).to eq '1967'
     end
   end
 
@@ -48,7 +48,7 @@ RSpec.describe Item do
 
   describe '#to_solr' do
     let(:blueprint) { FactoryBot.build(:blueprint, name: 'Sample Blueprint') }
-    let(:new_item) { described_class.new(blueprint: blueprint, description: basic_description.as_json) }
+    let(:new_item) { described_class.new(blueprint: blueprint, metadata: basic_description.as_json) }
 
     it 'generates a solr document' do
       allow(blueprint).to receive(:fields).and_return(
@@ -85,7 +85,7 @@ RSpec.describe Item do
 
   describe '#save' do
     let(:blueprint) { FactoryBot.build(:blueprint) }
-    let(:new_item) { described_class.new(blueprint: blueprint, description: basic_description.as_json) }
+    let(:new_item) { described_class.new(blueprint: blueprint, metadata: basic_description.as_json) }
 
     before do
       # Stub solr calls which are tested elsewhere
@@ -96,10 +96,10 @@ RSpec.describe Item do
       expect { new_item.save! }.to change(described_class, :count).by(1)
     end
 
-    it 'validates description is present' do
-      new_item.description = nil
+    it 'validates metadata is present' do
+      new_item.metadata = nil
       new_item.save
-      expect(new_item.errors.where(:description, :blank)).to be_present
+      expect(new_item.errors.where(:metadata, :blank)).to be_present
     end
 
     it 'validates required fields' do
@@ -135,10 +135,10 @@ RSpec.describe Item do
     end
 
     it 'saves any unsaved changes' do
-      item.description['Title'] = 'An Updated Title'
+      item.metadata['Title'] = 'An Updated Title'
       item.update_index
       item.reload
-      expect(item.description['Title']).to eq 'An Updated Title'
+      expect(item.metadata['Title']).to eq 'An Updated Title'
     end
   end
 

--- a/spec/requests/admin/items_spec.rb
+++ b/spec/requests/admin/items_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe '/admin/items' do
   # This should return the minimal set of attributes required to create a valid
   # Item. As you add validations to Item, be sure to
   # adjust the attributes here as well.
-  let(:valid_attributes) { { 'description' => { 'title' => 'My Title' }, 'blueprint_id' => Blueprint.first.id } }
-  let(:invalid_attributes) { { description: 'invalid' } }
+  let(:valid_attributes) { { 'metadata' => { 'title' => 'My Title' }, 'blueprint_id' => Blueprint.first.id } }
+  let(:invalid_attributes) { { 'metadata' => 'invalid' } }
 
   # Fake a minimal Solr server
   before do
@@ -98,14 +98,14 @@ RSpec.describe '/admin/items' do
   describe 'PATCH /update' do
     context 'with valid parameters' do
       let(:new_attributes) do
-        { description: valid_attributes['description'].merge({ 'alternate_title' => 'Weiterer Titel' }) }
+        { metadata: valid_attributes['metadata'].merge({ 'alternate_title' => 'Weiterer Titel' }) }
       end
 
       it 'updates the requested item' do
         item = Item.create! valid_attributes
         patch item_url(item), params: { item: new_attributes }
         item.reload
-        expect(item.description['alternate_title']).to eq 'Weiterer Titel'
+        expect(item.metadata['alternate_title']).to eq 'Weiterer Titel'
       end
 
       it 'redirects to the item' do

--- a/spec/views/admin/items/edit.html.erb_spec.rb
+++ b/spec/views/admin/items/edit.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'admin/items/edit', :solr do
   let(:item) do
     Item.create!(
       blueprint: blueprint,
-      description: { 'Title' => '1 Print' }
+      metadata: { 'Title' => '1 Print' }
     )
   end
 
@@ -35,7 +35,7 @@ RSpec.describe 'admin/items/edit', :solr do
     render
     input_fields = Capybara.string(rendered).all('input[@type!="submit"], textarea')
     field_ids = input_fields.pluck(:id)
-    expect(field_ids).to eq ['description_Title', 'description_Author', 'description_Format']
+    expect(field_ids).to eq ['metadata_Title', 'metadata_Author', 'metadata_Format']
   end
 
   it 'indiicates required inputs' do
@@ -47,7 +47,7 @@ RSpec.describe 'admin/items/edit', :solr do
     render
     input_fields = Capybara.string(rendered).all('label:has(span.required)')
     field_ids = input_fields.pluck(:for)
-    expect(field_ids).to eq ['description_Title', 'description_Format']
+    expect(field_ids).to eq ['metadata_Title', 'metadata_Format']
   end
 
   describe 'a text field' do
@@ -58,7 +58,7 @@ RSpec.describe 'admin/items/edit', :solr do
     it 'renders as a textarea input' do
       allow(blueprint).to receive(:fields).and_return([text_field])
       render
-      expect(rendered).to have_selector('textarea#description_abstract')
+      expect(rendered).to have_selector('textarea#metadata_abstract')
     end
   end
 
@@ -70,7 +70,7 @@ RSpec.describe 'admin/items/edit', :solr do
     it 'renders as a text_field input' do
       allow(blueprint).to receive(:fields).and_return([string_field])
       render
-      expect(rendered).to have_selector('input#description_genre[@type="text"]')
+      expect(rendered).to have_selector('input#metadata_genre[@type="text"]')
     end
   end
 
@@ -80,7 +80,7 @@ RSpec.describe 'admin/items/edit', :solr do
     it 'renders as a date_field input' do
       allow(blueprint).to receive(:fields).and_return([date_field])
       render
-      expect(rendered).to have_selector('input#description_date[@type="date"]')
+      expect(rendered).to have_selector('input#metadata_date[@type="date"]')
     end
   end
 
@@ -92,7 +92,7 @@ RSpec.describe 'admin/items/edit', :solr do
     it 'renders as a checkbox' do
       allow(blueprint).to receive(:fields).and_return([boolean_field])
       render
-      expect(rendered).to have_selector('input#description_special_collections[@type="checkbox"]')
+      expect(rendered).to have_selector('input#metadata_special_collections[@type="checkbox"]')
     end
   end
 
@@ -104,7 +104,7 @@ RSpec.describe 'admin/items/edit', :solr do
     it 'renders as a numeric field' do
       allow(blueprint).to receive(:fields).and_return([integer_field])
       render
-      expect(rendered).to have_selector('input#description_year[@type="number"]')
+      expect(rendered).to have_selector('input#metadata_year[@type="number"]')
     end
   end
 
@@ -116,7 +116,7 @@ RSpec.describe 'admin/items/edit', :solr do
     it 'renders as a numeric field' do
       allow(blueprint).to receive(:fields).and_return([float_field])
       render
-      expect(rendered).to have_selector('input#description_score[@type="number"]')
+      expect(rendered).to have_selector('input#metadata_score[@type="number"]')
     end
   end
 end

--- a/spec/views/admin/items/index.html.erb_spec.rb
+++ b/spec/views/admin/items/index.html.erb_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe 'admin/items/index' do
     assign(:items, [
              Item.new(
                blueprint: Blueprint.first,
-               description: '',
+               metadata: {},
                id: 'not-persisted-1'
              ),
              Item.new(
                blueprint: Blueprint.first,
-               description: '',
+               metadata: {},
                id: 'not-persisted-2'
              )
            ])

--- a/spec/views/admin/items/show.html.erb_spec.rb
+++ b/spec/views/admin/items/show.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'admin/items/show' do
   before do
     assign(:item, Item.new(
                     blueprint: Blueprint.first,
-                    description: '',
+                    metadata: {},
                     id: 'not-persisted'
                   ))
   end


### PR DESCRIPTION
After some time using the name 'description' to refer to the JSON metadata field that describes an item, the name has come to seem a bit awkward in general use.  It also feels clunky when referring to a client field named 'description': we get constructs like `description['description']` or `description.description`

This change modifies those usages to `metadata['description']` and `metadata.description`.

More generally, referring to an item's metadata feels more consistent with the library domain where description is just one subset of metadata.

⛔️ DOWNTIME EXPLANATION
The table migration will invalidate the database for commits prior to this change becasuse the old code will refere to an attribute name `description` while the database will have a column `metadata`.

To address this, stop any running instances of the application before deploying, allow the migration and code deployment to be completed successfully with no live instances accessing the database. Once the column rename in the migration is complete, the application can be restarted with the updated code and the new attribute name will map to the correct database column.