### PR TITLE
Add a link to items in the administrator sidebar

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -2,6 +2,7 @@ module Admin
   # Controller for UI to manage individual Items stored in the repository
   class ItemsController < ApplicationController
     before_action :set_item, only: %i[show edit update destroy]
+    load_and_authorize_resource
 
     # GET /items or /items.json
     def index

--- a/app/views/admin/_sidebar.html.erb
+++ b/app/views/admin/_sidebar.html.erb
@@ -5,6 +5,11 @@
       <li class='nav-item'>
         <%= link_to t('t3.admin.status'), status_path, class: 'nav-link' + active_controller_class('status') %>
       </li>
+      <% if can? :read, Item %>
+        <li class='nav-item'>
+          <%= link_to t('t3.admin.items'), items_path, class: 'nav-link' + active_controller_class('items') %>
+        </li>
+      <% end %>
       <% if can? :read, User %>
         <li class='nav-item'>
           <%= link_to t('t3.admin.users'), users_path, class: 'nav-link' + active_controller_class('users') %>

--- a/spec/views/admin/_sidebar.html.erb_spec.rb
+++ b/spec/views/admin/_sidebar.html.erb_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe 'admin/_sidebar' do
     expect(rendered).to have_link(href: status_path)
   end
 
+  describe 'items link' do
+    it 'renders for authorized users' do
+      allow(view.controller.current_ability).to receive(:can?).with(:read, Item).and_return(true)
+      render
+      expect(rendered).to have_link(href: items_path)
+    end
+
+    it 'is hidden from unauthorized users' do
+      allow(view.controller.current_ability).to receive(:can?).with(:read, Item).and_return(false)
+      render
+      expect(rendered).not_to have_link(href: items_path)
+    end
+  end
+
   describe 'users link' do
     it 'renders for authorized users' do
       allow(view.controller.current_ability).to receive(:can?).with(:read, User).and_return(true)


### PR DESCRIPTION
This commit
1. Adds a link to manage Items to the administator menu
2. Restricts access to manage Items to authorized users