### PR TITLE
Allow administrators to edit existing multi-value fields

### DIFF
--- a/app/assets/stylesheets/admin/items.scss
+++ b/app/assets/stylesheets/admin/items.scss
@@ -1,5 +1,6 @@
 .item input, .item textarea {
   width: 50rem;
+  display: block;
 }
 
 .item .required {

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -20,12 +20,24 @@
   <%= form.fields_for :metadata, OpenStruct.new(item.metadata) do |item_detail| %>
     <% item.blueprint.fields.each do |field| %>
       <div>
-        <%= item_detail.label field.name, style: "display: block" do -%>
+        <label>
           <%= field.name -%>
           <%= content_tag(:span, '(required)', class: 'required') if field.required -%>
-        <% end %>
-        <% field_method = Field::TYPE_TO_HELPER[field.data_type] %>
-        <%= item_detail.send(field_method, field.name, required: field.required, aria: {label: field.name, required: field.required}) %>
+
+          <% field_method = Field::TYPE_TO_HELPER[field.data_type] %>
+          <% if field.multiple %>
+            <% item_detail.object[field.name] ||= [nil] %>
+            <% item_detail.object[field.name].each.with_index(1) do |value, index| %>
+              <%= item_detail.send(field_method, field.name,
+                                   value: value, id: item_detail.field_id(field.name, index),
+                                   multiple: field.multiple, aria: {label: field.name + " #{index}",
+                                                                    required: field.required}) %>
+            <% end %>
+          <% else %>
+            <%= item_detail.send(field_method, field.name, multiple: field.multiple,
+                                 aria: {label: field.name, required: field.required}) %>
+          <% end %>
+        </label>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
When an Item has a field that can be multi-valued, and the field has more than one existing values, this change allows individual values to be modified.

This change does not handle adding or removing values from the list.