### PR TITLE
Store Solr download files in persistent directory

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,6 +1,7 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
 # version: 8.11.1
+artifact_path: ./tmp
 collection:
   dir: solr/conf/
   name: blacklight-core


### PR DESCRIPTION
**ISSUE**
In development environments, `solr_wrapper` downloads files to a temp folder under `/var/folders`.  On OSX, these folders are deleted after each reboot and the solr executables need to be redownloaded.  This can be frustrating when working on a slow network.

**SOLUTION**
Configure `solr_wrapper` to download the executable archives to a folder that persists across reboots.