### PR TITLE
Support adding new entries to multi-value fields

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -39,14 +39,10 @@ module Admin
 
     # PATCH/PUT /items/1 or /items/1.json
     def update
-      respond_to do |format|
-        if @item.update(item_params)
-          format.html { redirect_to item_url(@item), notice: 'Item was successfully updated.' }
-          format.json { render :show, status: :ok, location: @item }
-        else
-          format.html { render :edit, status: :unprocessable_entity }
-          format.json { render json: @item.errors, status: :unprocessable_entity }
-        end
+      if params[:refresh]
+        refresh_client
+      else
+        update_item
       end
     end
 
@@ -70,6 +66,29 @@ module Admin
     # Only allow a list of trusted parameters through.
     def item_params
       params.require(:item).permit(:blueprint_id, metadata: {})
+    end
+
+    # Modify fields in browser without updating database
+    def refresh_client
+      return unless params[:refresh][:add_entry]
+
+      field_name = params[:refresh][:add_entry]
+      @item.assign_attributes(item_params)
+      @item.metadata[field_name].push(nil)
+      render :edit, status: :accepted
+    end
+
+    # Persist form data to the Item in the database
+    def update_item
+      respond_to do |format|
+        if @item.update(item_params)
+          format.html { redirect_to item_url(@item) }
+          format.json { render :show, status: :ok, location: @item }
+        else
+          format.html { render :edit, status: :unprocessable_entity }
+          format.json { render json: @item.errors, status: :unprocessable_entity }
+        end
+      end
     end
   end
 end

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -33,6 +33,7 @@
                                    multiple: field.multiple, aria: {label: field.name + " #{index}",
                                                                     required: field.required}) %>
             <% end %>
+            <%= form.button t('t3.item.add_entry', field: field.name), name: 'refresh[add_entry]', value: field.name, class: 'add_value' %>
           <% else %>
             <%= item_detail.send(field_method, field.name, multiple: field.multiple,
                                  aria: {label: field.name, required: field.required}) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,8 @@ en:
   t3:
     header_links:
       status: 'Dashboard'
+    item:
+      add_entry: 'Add %{field}'
 
   activerecord:
     errors:

--- a/spec/views/admin/items/edit.html.erb_spec.rb
+++ b/spec/views/admin/items/edit.html.erb_spec.rb
@@ -133,16 +133,21 @@ RSpec.describe 'admin/items/edit', :solr do
       allow(blueprint).to receive(:fields).and_return([string_field])
     end
 
-    it 'renders multiple inputs' do
+    # If the parameter name ends with an empty set of square brackets [] then they will be accumulated in an array
+    # see https://guides.rubyonrails.org/form_helpers.html#basic-structures
+    it 'returns values as an array' do
       render
       expect(rendered).to have_field('item[metadata][keyword][]', count: 2)
     end
 
-    # If the parameter name ends with an empty set of square brackets [] then they will be accumulated in an array
-    # see https://guides.rubyonrails.org/form_helpers.html#basic-structures
-    it 'returns an array in parameters' do
+    it 'renders each value in a separate input field' do
       render
       expect(rendered).to have_field('item_metadata_keyword_2', with: 'test example')
+    end
+
+    it 'has a button to add additional values' do
+      render
+      expect(rendered).to have_button('refresh[add_entry]', text: 'keyword')
     end
   end
 end


### PR DESCRIPTION
This change adds a button that allows authorized users to update items by adding additional entry slot on mulit-value fields.

## BEFORE
<img width="825" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/a26f73a2-e3f6-4c91-a87d-de456ce32bd9">

## AFTER
<img width="814" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/2c4973ae-4bf5-404d-9913-bcb14dc4914b">
