### PR TITLE
Allow administrators to delete a value from multi-value fields

### DIFF
--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -32,8 +32,9 @@
                                    value: value, id: item_detail.field_id(field.name, index),
                                    multiple: field.multiple, aria: {label: field.name + " #{index}",
                                                                     required: field.required}) %>
+              <%= form.button t('t3.item.delete_entry', field: field.name, index: index), name: 'refresh', value: ['delete', field.name, index], class: 'delete_value' %>
             <% end %>
-            <%= form.button t('t3.item.add_entry', field: field.name), name: 'refresh[add_entry]', value: field.name, class: 'add_value' %>
+            <%= form.button t('t3.item.add_entry', field: field.name), name: 'refresh', value: ['add', field.name, -1], class: 'add_value' %>
           <% else %>
             <%= item_detail.send(field_method, field.name, multiple: field.multiple,
                                  aria: {label: field.name, required: field.required}) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
       status: 'Dashboard'
     item:
       add_entry: 'Add %{field}'
+      delete_entry: 'Delete %{field} %{index}'
 
   activerecord:
     errors:

--- a/spec/views/admin/items/edit.html.erb_spec.rb
+++ b/spec/views/admin/items/edit.html.erb_spec.rb
@@ -147,7 +147,12 @@ RSpec.describe 'admin/items/edit', :solr do
 
     it 'has a button to add additional values' do
       render
-      expect(rendered).to have_button('refresh[add_entry]', text: 'keyword')
+      expect(rendered).to have_button('refresh', value: 'add keyword -1')
+    end
+
+    it 'has a button to delete each existing value' do
+      render
+      expect(rendered).to have_button('refresh', value: 'delete keyword 2')
     end
   end
 end


### PR DESCRIPTION
This change refactors and generalizes the code to add field values to also allow values to be deleted.

## BEFORE
<img width="825" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/51896837-f6f1-4970-ad44-c6bec4caa2ab">

## AFTER
<img width="824" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/8022ee8d-8698-421d-b5ff-2d61526e6f51">
