### PR TITLE
Remove blank values from multi-value fields when saving

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@
 class Item < ApplicationRecord
   belongs_to :blueprint
 
+  before_save :prune_blank_values
   after_save :update_index
   after_destroy_commit :delete_index
 
@@ -82,6 +83,13 @@ class Item < ApplicationRecord
   end
 
   private
+
+  def prune_blank_values
+    blueprint.fields.each do |field|
+      value = metadata[field.name]
+      metadata[field.name] = field.multiple ? (value || []).compact_blank : value.presence
+    end
+  end
 
   def required_fields_present
     return if blueprint&.fields.blank?

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -110,6 +110,14 @@ RSpec.describe Item do
       new_item.save
       expect(new_item.errors.where(:required, :blank)).to be_present
     end
+
+    it 'diregards empty field values' do
+      allow(blueprint)
+        .to receive(:fields).and_return([FactoryBot.build(:field, name: 'Author', multiple: true)])
+      new_item.metadata['Author'] = [nil, 'Author', {}, 'Co-Author', '', 'Editor']
+      new_item.save!
+      expect(new_item.metadata['Author']).to eq ['Author', 'Co-Author', 'Editor']
+    end
   end
 
   describe '#update_index', :solr do

--- a/spec/requests/admin/items_spec.rb
+++ b/spec/requests/admin/items_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe '/admin/items' do
       end
     end
 
-    context 'with a field action' do
+    context 'with a field refresh' do
       let(:item) { FactoryBot.create(:item, blueprint: blueprint) }
       let(:blueprint) { FactoryBot.build(:blueprint) }
 
@@ -154,6 +154,15 @@ RSpec.describe '/admin/items' do
         expect(response).to have_http_status(:accepted)
       end
 
+      it 'handles delete on empty fields', :aggregate_failures do
+        patch item_url(item),
+              params: { refresh: ['delete', 'Author', '1'].join(' '),
+                        item: { metadata: item.metadata.except('Author') } }
+        body = Capybara.string(response.body)
+        expect(body).to have_button('refresh', value: 'delete Author 1')
+        expect(response).to have_http_status(:accepted)
+      end
+
       it 'rejects bad requests' do
         patch item_url(item),
               params: { refresh: ['delete', 'Author', '40'].join(' '), item: { metadata: item.metadata } }
@@ -165,8 +174,8 @@ RSpec.describe '/admin/items' do
                                                                                     multiple: true)])
         patch item_url(item), params: { refresh: 'add Resource Type -1', item: { metadata: item.metadata } }
         body = Capybara.string(response.body)
-        expect(body).to have_selector('input#item_metadata_Resource\ Type_1') # by id
-        expect(body).to have_field('item[metadata][Resource Type][]', count: 1) # by name
+        expect(body).to have_selector('input#item_metadata_Resource\ Type_2') # by id
+        expect(body).to have_field('item[metadata][Resource Type][]', count: 2) # by name
       end
     end
 


### PR DESCRIPTION
This change allows administrators to add and remove blank fields on the input form, but ensures that blank values are removed before saving to the database.