### PR TITLE
Fix bug in solr_wrapper configuration file

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,7 +1,7 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
 # version: 8.11.1
-artifact_path: ./tmp
+download_dir: ./tmp
 collection:
   dir: solr/conf/
   name: blacklight-core


### PR DESCRIPTION
`download_dir` specifies a directory path
`artifact_path` is the full path and filename for the Solr archive file

We want to specify the directory where we capture both the arhcive file and the associated checksum file.