### PR TITLE
Allow admins to choose the blueprint before entering item data

### DIFF
--- a/app/assets/stylesheets/admin/items.scss
+++ b/app/assets/stylesheets/admin/items.scss
@@ -6,3 +6,8 @@
 .item .required {
   font-style: italic;
 }
+
+#choose_blueprint button {
+  display: block;
+  margin-bottom: 0.25rem;
+}

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -14,9 +14,7 @@ module Admin
 
     # GET /items/new
     def new
-      blueprint_id = params['blueprint_id']
-      @item = Item.new(blueprint_id: blueprint_id)
-      @blueprint = Blueprint.find(blueprint_id) if blueprint_id
+      @item.blueprint = Blueprint.find_by(name: params['blueprint'])
     end
 
     # GET /items/1/edit

--- a/app/views/admin/items/_choose_blueprint.html.erb
+++ b/app/views/admin/items/_choose_blueprint.html.erb
@@ -1,9 +1,6 @@
 <h2>Choose a Blueprint</h2>
-<div id='choose_blueprint'>
+<div id="choose_blueprint">
   <% Blueprint.all.each do |blueprint| %>
-    <%= form_with(model: item) do |form| %>
-      <%= form.hidden_field :blueprint_id, value: blueprint.id %>
-        <%= form.submit blueprint.name %>
-    <% end %>
+    <%= button_to blueprint.name, "/admin/#{controller_name}/new/#{CGI.escape(blueprint.name)}", method: :get, class: 'btn btn-primary btn-sm' %>
   <% end %>
 </div>

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -13,8 +13,8 @@
 
   <div>
     <%= form.label :blueprint_id, style: "display: block" %>
-    <%= form.collection_select :blueprint_id, Blueprint.order(:name), :id, :name, {}, {disabled: controller.action_name == 'edit'} %>
     <%= form.hidden_field :blueprint_id, value: item.blueprint_id %>
+    <%= form.collection_select :blueprint_id, Blueprint.order(:name), :id, :name, {}, {disabled: true} %>
   </div>
 
   <%= form.fields_for :metadata, OpenStruct.new(item.metadata) do |item_detail| %>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,9 +1,9 @@
 <h1>New item</h1>
 
-<% if @blueprint %>
-  <%= render "form", item: @item, blueprint: @blueprint %>
+<% if @item.blueprint %>
+  <%= render 'form', item: @item %>
 <% else %>
-  <%= render "choose_blueprint", item: @item, blueprint: @blueprint %>
+  <%= render 'choose_blueprint', item: @item %>
 <% end %>
 
 <br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,9 @@ Rails.application.routes.draw do
     get :status, to: 'status#index'
     post 'users/:id/password_reset', to: 'users#password_reset', as: :user_password_reset
     resources :ingests
-    resources :items
+    resources :items do
+      get 'new/:blueprint', on: :collection, action: :new, as: :new_blueprinted
+    end
     resources :users
     resources :roles
     resources :blueprints

--- a/spec/requests/admin/items_spec.rb
+++ b/spec/requests/admin/items_spec.rb
@@ -43,20 +43,24 @@ RSpec.describe '/admin/items' do
 
       it 'renders the _choose_blueprint selection partial' do
         get new_item_url
-        expect(response.body).to include('id=\'choose_blueprint\'')
+        expect(response.body).to include('id="choose_blueprint"')
+      end
+
+      it 'has a form/button for each blueprint' do
+        # We're only checking for the first (which should always be 'Default')
+        get new_item_url
+        expect(response.body).to include('action="/admin/items/new/Default"')
       end
     end
 
     context 'with a blueprint selected' do
-      let(:blueprint) { FactoryBot.create(:blueprint) }
-
       it 'renders a successful response' do
-        get new_item_url, params: { blueprint_id: blueprint.id }
+        get new_blueprinted_items_path(Blueprint.first.name)
         expect(response).to be_successful
       end
 
       it 'renders the _form fields partial' do
-        get new_item_url, params: { blueprint_id: blueprint.id }
+        get new_blueprinted_items_path(Blueprint.first.name)
         expect(response.body).to include('id="item_fields"')
       end
     end


### PR DESCRIPTION
The item's blueprint controls which fields should be available for the item, so we want to select the blueprint before displaying the form to enter field-level metadata.

**STEP ONE**
![image](https://github.com/curationexperts/t3/assets/3064318/4b19d345-ba51-4799-a49e-b50506455b2c)

**STEP TWO**
![image](https://github.com/curationexperts/t3/assets/3064318/6ec32053-5a76-41ac-8b93-a0074c5c6be8)
