### PR TITLE
Add UI elements to manage Collections

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -1,0 +1,6 @@
+module Admin
+  # Controller for UI to manage Collections stored in the repository
+  class CollectionsController < ItemsController
+    load_resource class: Collection, instance_name: :item, param_method: :item_params
+  end
+end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,13 +1,10 @@
 module Admin
   # Controller for UI to manage individual Items stored in the repository
   class ItemsController < ApplicationController
-    before_action :set_item, only: %i[show edit update destroy]
     load_and_authorize_resource
 
     # GET /items or /items.json
-    def index
-      @items = Item.all
-    end
+    def index; end
 
     # GET /items/1 or /items/1.json
     def show; end
@@ -22,11 +19,9 @@ module Admin
 
     # POST /items or /items.json
     def create
-      @item = Item.new(item_params)
-
       respond_to do |format|
         if @item.save
-          format.html { redirect_to item_url(@item), notice: 'Item was successfully created.' }
+          format.html { redirect_to @item }
           format.json { render :show, status: :created, location: @item }
         else
           format.html { render :new, status: :unprocessable_entity }
@@ -49,24 +44,19 @@ module Admin
       @item.destroy
 
       respond_to do |format|
-        format.html { redirect_to items_url, notice: 'Item was successfully destroyed.' }
+        format.html { redirect_to @item.class, notice: "#{@item.class} was successfully destroyed" }
         format.json { head :no_content }
       end
     end
 
     private
 
-    # Use callbacks to share common setup or constraints between actions.
-    def set_item
-      @item = Item.find(params[:id])
-    end
-
     # Only allow a list of trusted parameters through.
     def item_params
       params.require(:item).permit(:blueprint_id, metadata: {})
     end
 
-    # Parse refresh parameteres when present
+    # Parse refresh parameters when present
     # @return Array = [action, field, index]
     def refresh_params
       return unless params['refresh']
@@ -114,7 +104,7 @@ module Admin
     def update_item
       respond_to do |format|
         if @item.update(item_params)
-          format.html { redirect_to item_url(@item) }
+          format.html { redirect_to @item }
           format.json { render :show, status: :ok, location: @item }
         else
           format.html { render :edit, status: :unprocessable_entity }

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -3,4 +3,10 @@
 class Collection < Item
   # To inherit without using STI, we need to set the table name explicitly
   self.table_name = 'collections'
+
+  # Use items partials instead of looking for separate collection partials
+  def to_partial_path
+    # self.class.superclass.new.to_partial_path
+    'admin/items/item'
+  end
 end

--- a/app/views/admin/_sidebar.html.erb
+++ b/app/views/admin/_sidebar.html.erb
@@ -10,6 +10,11 @@
           <%= link_to t('t3.admin.items'), items_path, class: 'nav-link' + active_controller_class('items') %>
         </li>
       <% end %>
+      <% if can? :read, Collection %>
+        <li class='nav-item'>
+          <%= link_to t('t3.admin.collections'), collections_path, class: 'nav-link' + active_controller_class('collections') %>
+        </li>
+      <% end %>
       <% if can? :read, Ingest %>
         <li class='nav-item'>
           <%= link_to t('t3.admin.ingests'), ingests_path, class: 'nav-link' + active_controller_class('ingests') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,9 @@ Rails.application.routes.draw do
     resources :items do
       get 'new/:blueprint', on: :collection, action: :new, as: :new_blueprinted
     end
+    resources :collections do
+      get 'new/:blueprint', on: :collection, action: :new, as: :new_blueprinted
+    end
     resources :users
     resources :roles
     resources :blueprints

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :collection do
+    blueprint
+    metadata do
+      {
+        'Title' => 'Unremarkable Collection'
+      }
+    end
+  end
+end

--- a/spec/requests/admin/collections_spec.rb
+++ b/spec/requests/admin/collections_spec.rb
@@ -1,0 +1,227 @@
+require 'rails_helper'
+
+RSpec.describe '/admin/collections' do
+  # This should return the minimal set of attributes required to create a valid
+  # Collection. As you add validations to Collection, be sure to
+  # adjust the attributes here as well.
+  let(:valid_attributes) { { 'metadata' => { 'title' => 'My Collection' }, 'blueprint_id' => Blueprint.first.id } }
+  let(:invalid_attributes) { valid_attributes.except('blueprint_id') }
+  let(:super_admin) { FactoryBot.create(:super_admin) }
+
+  before do
+    login_as super_admin
+
+    # Fake a minimal Solr server
+    solr_client = RSolr::Client.new(nil)
+    allow(RSolr::Client).to receive(:new).and_return(solr_client)
+    allow(solr_client).to receive(:get).and_return({ 'lucene' => { 'solr-spec-version' => '9.4.0' } })
+    allow(solr_client).to receive(:update)
+  end
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      Collection.create(valid_attributes)
+      get collections_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a successful response' do
+      collection = Collection.create(valid_attributes)
+      get collection_url(collection)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /new' do
+    context 'without a blueprint selected' do
+      it 'renders a parital completion response' do
+        get new_collection_url
+        expect(response).to be_successful
+      end
+
+      it 'renders the _choose_blueprint selection partial' do
+        get new_collection_url
+        expect(response.body).to include('id="choose_blueprint"')
+      end
+    end
+
+    context 'with a blueprint selected' do
+      it 'renders a successful response' do
+        get new_blueprinted_collections_path(Blueprint.first.name)
+        expect(response).to be_successful
+      end
+
+      it 'renders the _form fields partial' do
+        get new_blueprinted_collections_path(Blueprint.first.name)
+        expect(response.body).to include('id="item_fields"')
+      end
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'renders a successful response' do
+      collection = Collection.create! valid_attributes
+      get edit_collection_url(collection)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new Collection' do
+        expect do
+          post collections_url, params: { item: valid_attributes }
+        end.to change(Collection, :count).by(1)
+      end
+
+      it 'redirects to the created Collection' do
+        post collections_url, params: { item: valid_attributes }
+        expect(response).to redirect_to(collection_url(Collection.last))
+      end
+    end
+
+    context 'with invalid parameters' do
+      let(:invalid_attributes) { valid_attributes.except('blueprint_id') }
+
+      it 'does not create a new Collection' do
+        expect do
+          post collections_url, params: { item: invalid_attributes }
+        end.not_to change(Collection, :count)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        post collections_url, params: { item: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do
+      let(:new_attributes) do
+        { metadata: valid_attributes['metadata'].merge({ 'alternate_title' => 'Weiterer Titel' }) }
+      end
+
+      it 'updates the requested collection' do
+        collection = Collection.create! valid_attributes
+        patch collection_url(collection), params: { item: new_attributes }
+        collection.reload
+        expect(collection.metadata['alternate_title']).to eq 'Weiterer Titel'
+      end
+
+      it 'redirects to the Collection' do
+        collection = Collection.create! valid_attributes
+        patch collection_url(collection), params: { item: new_attributes }
+        collection.reload
+        expect(response).to redirect_to(collection_url(collection))
+      end
+    end
+
+    context 'with a field refresh' do
+      let(:collection) { FactoryBot.create(:collection, blueprint: blueprint) }
+      let(:blueprint) { FactoryBot.build(:blueprint) }
+
+      before do
+        active = instance_double(ActiveRecord::Relation)
+        allow(Field).to receive(:active).and_return(active)
+        allow(active).to receive(:order).and_return(
+          [FactoryBot.build(:field, name: 'Author', multiple: true)]
+        )
+      end
+
+      it 'extends requested fields', :aggregate_failures do
+        collection.metadata.merge!({ 'Author' => ['Bronte, Charlotte', 'Bell, Currer'] })
+        patch collection_url(collection), params: { refresh: 'add Author -1', item: { metadata: collection.metadata } }
+        body = Capybara.string(response.body)
+        expect(body).to have_field('collection_metadata_Author_2', with: 'Bell, Currer')
+        expect(body).to have_field('collection_metadata_Author_3') # field exists
+        # expect(body).not_to have_field('collection_metadata_Author_3', with: /.*/) # and field is empty
+      end
+
+      it 'deletes requested fields', :aggregate_failures do
+        collection.metadata.merge!({ 'Author' => ['Bronte, Charlotte', 'Bell, Currer'] })
+        patch collection_url(collection), params:
+          { refresh: 'delete Author 1', item: { metadata: collection.metadata } }
+        body = Capybara.string(response.body)
+        expect(body).to have_field('collection_metadata_Author_1', with: 'Bell, Currer')
+        expect(body).to have_field('collection[metadata][Author][]', count: 1)
+      end
+
+      it 'refreshes data without saving' do
+        patch collection_url(collection), params:
+          { refresh: ['add', 'Author', '-1'].join(' '), item: { metadata: collection.metadata } }
+        expect(response).to have_http_status(:accepted)
+      end
+
+      it 'handles delete on empty fields', :aggregate_failures do
+        patch collection_url(collection),
+              params: { refresh: ['delete', 'Author', '1'].join(' '),
+                        item: { metadata: collection.metadata.except('Author') } }
+        body = Capybara.string(response.body)
+        expect(body).to have_button('refresh', value: 'delete Author 1')
+        expect(response).to have_http_status(:accepted)
+      end
+
+      it 'rejects bad requests' do
+        patch collection_url(collection),
+              params: { refresh: ['delete', 'Author', '40'].join(' '), item: { metadata: collection.metadata } }
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'handles field names that include spaces', :aggregate_failures do
+        allow(Field.active).to receive(:order).and_return([FactoryBot.build(:field, name: 'Resource Type',
+                                                                                    multiple: true)])
+        patch collection_url(collection), params: {
+          refresh: 'add Resource Type -1', item: { metadata: collection.metadata }
+        }
+        body = Capybara.string(response.body)
+        expect(body).to have_selector('input#collection_metadata_Resource\ Type_2') # by id
+        expect(body).to have_field('collection[metadata][Resource Type][]', count: 2) # by name
+      end
+    end
+
+    context 'with invalid parameters' do
+      let(:collection) { Collection.create! valid_attributes }
+
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        allow(collection).to receive(:update).and_return false
+        allow(Collection).to receive(:find).and_return collection
+        patch collection_url(collection), params: { item: valid_attributes.merge { 'metadata' => '' } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested collection' do
+      collection = FactoryBot.create(:collection)
+      expect do
+        delete collection_url(collection)
+      end.to change(Collection, :count).by(-1)
+    end
+
+    it 'redirects to the Collections list' do
+      collection = FactoryBot.create(:collection)
+      delete collection_url(collection)
+      expect(response).to redirect_to(collections_url)
+    end
+  end
+
+  describe 'resctricts access' do
+    let(:regular_user) { FactoryBot.create(:user) }
+
+    example 'for guest users' do
+      logout
+      get collections_url
+      expect(response).to be_not_found
+    end
+
+    example 'for non-admin users' do
+      login_as regular_user
+      get collections_url
+      expect(response).to be_unauthorized
+    end
+  end
+end

--- a/spec/views/admin/_sidebar.html.erb_spec.rb
+++ b/spec/views/admin/_sidebar.html.erb_spec.rb
@@ -26,6 +26,20 @@ RSpec.describe 'admin/_sidebar' do
     end
   end
 
+  describe 'collections link' do
+    it 'renders for authorized users' do
+      allow(view.controller.current_ability).to receive(:can?).with(:read, Collection).and_return(true)
+      render
+      expect(rendered).to have_link(href: collections_path)
+    end
+
+    it 'is hidden from unauthorized users' do
+      allow(view.controller.current_ability).to receive(:can?).with(:read, Collection).and_return(false)
+      render
+      expect(rendered).not_to have_link(href: collections_path)
+    end
+  end
+
   describe 'users link' do
     it 'renders for authorized users' do
       allow(view.controller.current_ability).to receive(:can?).with(:read, User).and_return(true)


### PR DESCRIPTION
This change
* Adds the route, controller, and views necessary to manage Collections from the browser
* Adds a navigation item in the admin dashboard for Collections

NOTES:
Collections and Items intentionally share most behavior so that administrators don't have to learn or remember different user interfaces for similar functionality in different parts of the application.

However, because we always anticipate the total collection count to be an order of magnitude or more smaller than the number of items in the repository (i.e. collections often number in the 10s while even a small respository will likely have thousands of items), we prefer to store collection data in a separate table from items.