### PR TITLE
SRefactor administrator sidebar menu

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,11 +1,8 @@
 # Various helpers for Admin dashboard views
 module AdminHelper
-  # Dynamically set admin sidebar link classes
-  def active_controller_class(link_name)
-    if link_name == controller_name
-      ' active'
-    else
-      ''
-    end
+  # Dynamically set admin sidebar link active class
+  # @param [Class] menu_area the class being linked to
+  def active_class(menu_area)
+    'active' if menu_area.model_name.plural == controller_name
   end
 end

--- a/app/views/admin/_sidebar.html.erb
+++ b/app/views/admin/_sidebar.html.erb
@@ -3,58 +3,16 @@
     <h2>Admin Tools</h2>
     <ul class='nav nav-pills flex-column mb-auto'>
       <li class='nav-item'>
-        <%= link_to t('t3.admin.status'), status_path, class: 'nav-link' + active_controller_class('status') %>
+        <%= link_to t('t3.admin.status'), status_path, class: ['nav-link', controller_name == 'status' ? 'active' : '' ]%>
       </li>
-      <% if can? :read, Item %>
-        <li class='nav-item'>
-          <%= link_to t('t3.admin.items'), items_path, class: 'nav-link' + active_controller_class('items') %>
-        </li>
-      <% end %>
-      <% if can? :read, Collection %>
-        <li class='nav-item'>
-          <%= link_to t('t3.admin.collections'), collections_path, class: 'nav-link' + active_controller_class('collections') %>
-        </li>
-      <% end %>
-      <% if can? :read, Ingest %>
-        <li class='nav-item'>
-          <%= link_to t('t3.admin.ingests'), ingests_path, class: 'nav-link' + active_controller_class('ingests') %>
-        </li>
-      <% end %>
-      <% if can? :read, User %>
-        <li class='nav-item'>
-          <%= link_to t('t3.admin.users'), users_path, class: 'nav-link' + active_controller_class('users') %>
-        </li>
-      <% end %>
-      <% if can? :read, Role %>
-        <li class='nav-item'>
-          <%= link_to t('t3.admin.roles'), roles_path, class: 'nav-link' + active_controller_class('roles') %>
-        </li>
-      <% end %>
-      <% if can? :read, Blueprint %>
-        <li class='nav-item'>
-          <%= link_to t('t3.admin.blueprints'), blueprints_path, class: 'nav-link' + active_controller_class('blueprints') %>
-        </li>
-      <% end %>
-      <% if can? :read, Field %>
-        <li class='nav-item'>
-          <%= link_to t('t3.admin.fields'), fields_path, class: 'nav-link' + active_controller_class('fields') %>
-        </li>
-      <% end %>
-      <% if can? :read, Theme %>
-        <li class='nav-item'>
-          <%= link_to t('t3.admin.themes'), themes_path, class: 'nav-link' + active_controller_class('themes') %>
-        </li>
-      <% end %>
-      <% if can? :read, Config %>
-        <li class='nav-item'>
-          <%= link_to t('t3.admin.configs'), config_path, class: 'nav-link' + active_controller_class('configs') %>
-        </li>
-      <% end %>
-      <% if can? :read, CustomDomain %>
-        <li class='nav-item'>
-          <%= link_to t('t3.admin.custom_domains'), custom_domains_path, class: 'nav-link' + active_controller_class('custom_domains') %>
-        </li>
+
+      <% [Item, Collection, Ingest, User, Role, Blueprint, Field, Theme, Config, CustomDomain].each do |menu_area|  %>
+        <% if can? :read, menu_area %>
+          <li class='nav-item'>
+            <%= link_to t("t3.admin.#{menu_area.model_name.plural}"), menu_area, class: ['nav-link', active_class(menu_area)] %>
+          </li>
+        <% end %>
       <% end %>
     </ul>
   </nav>
-<% end -%>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
       patch 'activate', on: :member
     end
     resource :config, only: %i[show edit update]
+    get :configs, to: 'configs#show'
     resources :custom_domains, except: %i[edit update show]
     get 'profile', to: 'users#edit', as: :edit_user_registration
   end

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe AdminHelper do
-  describe '#active_controller_class' do
-    it 'returns " active" when the controller name equals the passed string' do
+  describe '#active_class' do
+    it 'returns "active" when the controller name equals the passed string' do
       allow(self).to receive(:controller_name).and_return('users')
-      expect(active_controller_class('users')).to eq ' active'
+      expect(active_class(User)).to eq 'active'
     end
 
-    it 'returns an empty string otherwise' do
+    it 'returns nil otherwise' do
       allow(self).to receive(:controller_name).and_return('users')
-      expect(active_controller_class('roles')).to eq ''
+      expect(active_class(Role)).to be_nil
     end
   end
 end

--- a/spec/routing/admin/configs_routing_spec.rb
+++ b/spec/routing/admin/configs_routing_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe Admin::ConfigsController do
       expect(get: '/admin/config').to route_to('admin/configs#show')
     end
 
+    it 'routes conventional index path to #show' do
+      expect(get: 'admin/configs').to route_to('admin/configs#show')
+    end
+
+    it 'has a plural path alias' do
+      expect(get(configs_path)).to route_to('admin/configs#show')
+    end
+
     it 'routes to #edit' do
       expect(get: '/admin/config/edit').to route_to('admin/configs#edit')
     end

--- a/spec/views/admin/_sidebar.html.erb_spec.rb
+++ b/spec/views/admin/_sidebar.html.erb_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe 'admin/_sidebar' do
     it 'renders for authorized users' do
       allow(view.controller.current_ability).to receive(:can?).with(:read, Config).and_return(true)
       render
-      expect(rendered).to have_link(href: config_path)
+      expect(rendered).to have_link(href: configs_path)
     end
 
     it 'is hidden from unauthorized users' do


### PR DESCRIPTION
The code to produce the sidebar menu on the dashboard had grown unweildy due to significant amounts of duplication.

This change refactors the code to remove duplication in the menu generation.

We have retained similiar duplication in the test suite because:
1. It avoids abstraction or complication in the examples by keeping them very literal
2. It makes it easier to debug specific authorization or naming failues