### PR TITLE
Update header and link names for managing collections

### DIFF
--- a/app/views/admin/items/_item.html.erb
+++ b/app/views/admin/items/_item.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id item %>">
   <p>
     <strong>Blueprint:</strong>
-    <%= item.blueprint_id %>
+    <%= item.blueprint.name %>
   </p>
 
   <p>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,10 +1,10 @@
-<h1>Editing item</h1>
+<h1>Editing <%= @item.class -%></h1>
 
 <%= render "form", item: @item %>
 
 <br>
 
 <div>
-  <%= link_to "Show this item", @item %> |
-  <%= link_to "Back to items", items_path %>
+  <%= link_to "Show this #{@item.class}", @item %> |
+  <%= link_to "Back to #{@item.class.name.pluralize}", url_for(@item.class) %>
 </div>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,14 +1,14 @@
-<p style="color: green"><%= notice %></p>
+<h1><%= controller_name.titleize -%></h1>
 
-<h1>Items</h1>
-
-<div id="items">
+<div id="resources">
   <% @items.each do |item| %>
-    <%= render item %>
-    <p>
-      <%= link_to "Show this item", item %>
-    </p>
+    <div class="resource">
+      <%= render item %>
+      <p>
+        <%= link_to "Show this #{item.class}", item %>
+      </p>
+    </div>
   <% end %>
 </div>
 
-<%= link_to "New item", new_item_path %>
+<%= link_to "New #{controller_name.singularize}", url_for(controller: controller_name, action: :new) %>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New item</h1>
+<h1>New <%= @item.class -%></h1>
 
 <% if @item.blueprint %>
   <%= render 'form', item: @item %>
@@ -9,5 +9,5 @@
 <br>
 
 <div>
-  <%= link_to "Back to items", items_path %>
+  <%= link_to "Back to #{@item.class.name.pluralize}", url_for(@item.class) %>
 </div>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -3,8 +3,8 @@
 <%= render @item %>
 
 <div>
-  <%= link_to "Edit this item", edit_item_path(@item) %> |
-  <%= link_to "Back to items", items_path %>
+  <%= link_to "Edit this #{@item.class}", url_for([:edit, @item]) %> |
+  <%= link_to "Back to #{@item.class.name.pluralize}", url_for(@item.class) %>
 
-  <%= button_to "Destroy this item", @item, method: :delete %>
+  <%= button_to "Destroy this #{@item.class}", @item, method: :delete, id: dom_id(@item, :delete) %>
 </div>

--- a/spec/views/admin/collections/edit.html.erb_spec.rb
+++ b/spec/views/admin/collections/edit.html.erb_spec.rb
@@ -1,0 +1,171 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/items/edit', :solr do
+  let(:blueprint) { FactoryBot.build(:blueprint, name: 'Simple Blueprint') }
+
+  let(:collection) do
+    FactoryBot.build(:collection,
+                     id: 10,
+                     blueprint: blueprint,
+                     metadata: { 'Title' => '1 Print', 'keyword' => ['multivalue', 'test example'] })
+  end
+
+  before do
+    stub_solr
+    assign(:item, collection)
+    allow(controller).to receive(:action_name).and_return('edit')
+    allow(collection).to receive(:persisted?).and_return(true)
+  end
+
+  it 'displays a heading' do
+    render
+    expect(rendered).to have_selector('h1', text: 'Editing Collection')
+  end
+
+  it 'has a link to show the collection' do
+    render
+    expect(rendered).to have_link(href: collection_path(collection), text: /collection/i)
+  end
+
+  it 'has a link to return to the index listing' do
+    render
+    expect(rendered).to have_link(href: collections_path, text: /collections/i)
+  end
+
+  it 'renders an update form' do
+    render
+    expect(rendered).to have_selector("form[action='#{collection_path(collection)}'][method='post']")
+  end
+
+  it 'displays the (disabled) blueprint name' do
+    # Imitate saving our blueprint
+    allow(Blueprint).to receive(:order).and_return([blueprint])
+
+    render
+    expect(rendered).to have_field('item_blueprint_id', text: 'Simple Blueprint', disabled: true)
+  end
+
+  it 'displays fields in order' do
+    allow(blueprint).to receive(:fields).and_return([
+                                                      FactoryBot.build(:field, name: 'Title'),
+                                                      FactoryBot.build(:field, name: 'Author'),
+                                                      FactoryBot.build(:field, name: 'Format')
+                                                    ])
+    render
+    input_fields = Capybara.string(rendered).all('input[@type!="submit"], textarea')
+    field_ids = input_fields.pluck(:id)
+    expect(field_ids).to eq ['item_metadata_Title', 'item_metadata_Author', 'item_metadata_Format']
+  end
+
+  it 'indiicates required inputs' do
+    allow(blueprint).to receive(:fields).and_return([
+                                                      FactoryBot.build(:field, name: 'Title', required: true),
+                                                      FactoryBot.build(:field, name: 'Author'),
+                                                      FactoryBot.build(:field, name: 'Format', required: true)
+                                                    ])
+    render
+    input_fields = Capybara.string(rendered).all('label:has(span.required) input')
+    field_ids = input_fields.pluck(:id)
+    expect(field_ids).to eq ['item_metadata_Title', 'item_metadata_Format']
+  end
+
+  describe 'a text field' do
+    let(:text_field) do
+      FactoryBot.build(:field, name: 'abstract', data_type: 'text_en', multiple: false, id: 1, sequence: 1)
+    end
+
+    it 'renders as a textarea input' do
+      allow(blueprint).to receive(:fields).and_return([text_field])
+      render
+      expect(rendered).to have_selector('textarea#item_metadata_abstract')
+    end
+  end
+
+  describe 'a string field' do
+    let(:string_field) do
+      FactoryBot.build(:field, name: 'genre', data_type: 'string', multiple: true, id: 1, sequence: 1)
+    end
+
+    it 'renders as a text_field input' do
+      allow(blueprint).to receive(:fields).and_return([string_field])
+      render
+      expect(rendered).to have_selector('input#item_metadata_genre_1[@type="text"]')
+    end
+  end
+
+  describe 'a date field' do
+    let(:date_field) { FactoryBot.build(:field, name: 'date', data_type: 'date', multiple: false, id: 1, sequence: 1) }
+
+    it 'renders as a date_field input' do
+      allow(blueprint).to receive(:fields).and_return([date_field])
+      render
+      expect(rendered).to have_selector('input#item_metadata_date[@type="date"]')
+    end
+  end
+
+  describe 'a boolean field' do
+    let(:boolean_field) do
+      FactoryBot.build(:field, name: 'special_collections', data_type: 'boolean', multiple: false, id: 1, sequence: 1)
+    end
+
+    it 'renders as a checkbox' do
+      allow(blueprint).to receive(:fields).and_return([boolean_field])
+      render
+      expect(rendered).to have_selector('input#item_metadata_special_collections[@type="checkbox"]')
+    end
+  end
+
+  describe 'an integer field' do
+    let(:integer_field) do
+      FactoryBot.build(:field, name: 'year', data_type: 'integer', multiple: false, id: 1, sequence: 1)
+    end
+
+    it 'renders as a numeric field' do
+      allow(blueprint).to receive(:fields).and_return([integer_field])
+      render
+      expect(rendered).to have_selector('input#item_metadata_year[@type="number"]')
+    end
+  end
+
+  describe 'a float field' do
+    let(:float_field) do
+      FactoryBot.build(:field, name: 'score', data_type: 'float', multiple: false, id: 1, sequence: 1)
+    end
+
+    it 'renders as a numeric field' do
+      allow(blueprint).to receive(:fields).and_return([float_field])
+      render
+      expect(rendered).to have_selector('input#item_metadata_score[@type="number"]')
+    end
+  end
+
+  describe 'a multivalue field' do
+    before do
+      allow(collection.blueprint).to receive(:fields).and_return(
+        [FactoryBot.build(:field, name: 'keyword', data_type: 'string', multiple: true)]
+      )
+    end
+
+    # If the parameter name ends with an empty set of square brackets [] then they will be accumulated in an array
+    # see https://guides.rubyonrails.org/form_helpers.html#basic-structures
+    it 'returns values as an array' do
+      render
+      expect(rendered).to have_field('item[metadata][keyword][]', count: 2)
+    end
+
+    it 'renders each value in a separate input field' do
+      render
+      expect(rendered).to have_field('item_metadata_keyword_2', with: 'test example')
+    end
+
+    it 'has a button to add additional values' do
+      render
+      expect(rendered).to have_button('refresh', value: 'add keyword -1')
+    end
+
+    it 'has a button to delete each existing value' do
+      render
+      expect(rendered).to have_button('refresh', value: 'delete keyword 2')
+    end
+  end
+end

--- a/spec/views/admin/collections/index.html.erb_spec.rb
+++ b/spec/views/admin/collections/index.html.erb_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+# The CollectionsController inherits from ItemsController, so uses
+# the items/views, but with a different controller name
+RSpec.describe 'admin/items/index' do
+  let(:collections) do
+    FactoryBot.build_list(:collection, 3) { |coll, i| coll.id = i }
+  end
+
+  before do
+    allow(view).to receive(:controller_name).and_return('collections')
+    collections.each { |coll| allow(coll).to receive(:persisted?).and_return(true) }
+  end
+
+  # An empty repository on initialization
+  context 'with no collections' do
+    before do
+      assign(:items, [])
+    end
+
+    it 'displays the Collections heading' do
+      render
+      expect(rendered).to have_selector('h1', text: 'Collections')
+    end
+
+    it 'has a link to create a collection' do
+      render
+      expect(rendered).to have_link(href: new_collection_path, text: 'New collection')
+    end
+  end
+
+  context 'with existing collections' do
+    before do
+      assign(:items, collections)
+    end
+
+    it 'renders a list of collections' do
+      render
+      expect(rendered).to have_selector('div.resource', count: 3)
+    end
+
+    it 'provides a link to each collection', :aggregate_failures do
+      render
+      expect(rendered).to have_selector('.resource a', count: 3)
+      expect(rendered).to have_link(href: collection_path(collections[2]))
+    end
+  end
+end

--- a/spec/views/admin/collections/new.html.erb_spec.rb
+++ b/spec/views/admin/collections/new.html.erb_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+# The CollectionsController inherits from ItemsController, so uses
+# the items/views, but with a different controller name
+RSpec.describe 'admin/items/new' do
+  before do
+    assign(:item, collection)
+    allow(view).to receive(:controller_name).and_return('collections')
+  end
+
+  context 'without a blueprint' do
+    let(:collection) { Collection.new }
+
+    it 'prompts for blueprint selection' do
+      render
+      expect(rendered).to have_selector('#choose_blueprint')
+    end
+  end
+
+  context 'with a blueprint' do
+    let(:collection) { Collection.new(blueprint: Blueprint.first) }
+
+    before do
+      allow(collection.blueprint).to receive(:fields).and_return(
+        [FactoryBot.build(:field, name: 'Title')]
+      )
+    end
+
+    it 'displays a heading' do
+      render
+      expect(rendered).to have_selector('h1', text: 'New Collection')
+    end
+
+    it 'renders a creation form' do
+      render
+      expect(rendered).to have_selector("form[action='#{collections_path}'][method='post']")
+    end
+
+    it 'renders individual field inputs' do
+      render
+      expect(rendered).to have_field('item_metadata_Title')
+    end
+
+    it 'has a link to return to the index listing' do
+      render
+      expect(rendered).to have_link(href: collections_path, text: /collections/i)
+    end
+  end
+end

--- a/spec/views/admin/collections/show.html.erb_spec.rb
+++ b/spec/views/admin/collections/show.html.erb_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+# The CollectionsController inherits from ItemsController, so uses
+# the items/views, but with a different controller name
+RSpec.describe 'admin/items/show' do
+  let(:collection) { FactoryBot.build(:collection, id: 1) }
+
+  before do
+    assign(:item, collection)
+    allow(collection).to receive(:persisted?).and_return(true)
+    allow(collection.blueprint).to receive(:fields).and_return(
+      [FactoryBot.build(:field, name: 'Title')]
+    )
+  end
+
+  it 'renders the metadata' do
+    render
+    expect(rendered).to include 'Unremarkable Collection' # see collection factory
+  end
+
+  it 'displays the blueprint name' do
+    render
+    expect(rendered).to match(/basic_blueprint/) # see blueprint factory
+  end
+
+  it 'has a link to edit the collection' do
+    render
+    expect(rendered).to have_link(href: edit_collection_path(collection), text: /collection/i)
+  end
+
+  it 'has a link to return to the index listing' do
+    render
+    expect(rendered).to have_link(href: collections_path, text: /collections/i)
+  end
+
+  it 'has a button to delete the collection' do
+    render
+    expect(rendered).to have_button(dom_id(collection, :delete), text: /collection/i)
+  end
+end

--- a/spec/views/admin/items/index.html.erb_spec.rb
+++ b/spec/views/admin/items/index.html.erb_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe 'admin/items/index' do
                id: 'not-persisted-2'
              )
            ])
+
+    allow(view).to receive(:controller_name).and_return('items')
   end
 
   it 'renders a list of items' do

--- a/spec/views/admin/items/show.html.erb_spec.rb
+++ b/spec/views/admin/items/show.html.erb_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/items/show' do
+  let(:item) { FactoryBot.build(:item, id: 1) }
+
   before do
-    assign(:item, Item.new(
-                    blueprint: Blueprint.first,
-                    metadata: {},
-                    id: 'not-persisted'
-                  ))
+    assign(:item, item)
+    allow(item).to receive(:persisted?).and_return(true)
+    allow(item.blueprint).to receive(:fields).and_return(
+      [FactoryBot.build(:field, name: 'Title')]
+    )
   end
 
   it 'renders attributes in <p>' do


### PR DESCRIPTION
**ISSUE**
Because collections inherit behavior and views from items, page headers and links in many collections views incorrectly referenced 'Item' instead of 'Collection'.

**FIX**
Refactor views to dynamically generate header names, links, and link text based on the current controller.