### PR TITLE
Allow files to be attached to Items

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,4 +4,5 @@
 # be an easy jump to managing collections.  So both classes inherit from the
 # same parent and share controllers that provide common behavior
 class Item < Resource
+  has_many_attached :files
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -2,5 +2,23 @@ require 'rails_helper'
 require './spec/models/resource_shared_examples'
 
 RSpec.describe Item do
+  let(:new_item) { FactoryBot.build(:item) }
+
   it_behaves_like 'a resource'
+
+  describe '#files' do
+    it 'is empty by default' do
+      expect(new_item.files).not_to be_attached
+    end
+
+    it 'returns a list' do
+      expect(new_item.files.attachments).to be_an(Enumerable)
+    end
+
+    it 'can have multiple files attached' do
+      new_item.files.attach(fixture_file_upload('rocket-takeoff.svg', 'image/svg'))
+      new_item.files.attach(fixture_file_upload('sample_logo.png', 'image/png'))
+      expect(new_item.files.attachments.count).to eq 2
+    end
+  end
 end


### PR DESCRIPTION
This commit adds back-end support to allow uploaded files to be attached to Item objects and saved as ActiveStorage attachments.