### PR TITLE
[DEVELOPER] Keep Solr index when stopping and restarting

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -5,3 +5,4 @@ download_dir: ./tmp
 collection:
   dir: solr/conf/
   name: blacklight-core
+  persist: true

--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -58,9 +58,9 @@ class ImportJob < ApplicationJob
   # Save a new Item, rescuing & capturing exceptions
   def save_record(blueprint, metadata)
     attachables = fetch_files(metadata)
-    item = Item.create(blueprint: blueprint, metadata: metadata, files: attachables)
+    item = Item.create!(blueprint: blueprint, metadata: metadata, files: attachables)
     { id: item.id, status: 'created', timestamp: Time.current.iso8601(3) }
-  rescue RuntimeError => e
+  rescue StandardError => e
     logger.error { "#{e}: #{e.message}" }
     { id: nil, status: 'error', timestamp: Time.current.iso8601(3), error_class: e.class, message: e.message,
       ref: metadata[:ingest_snippet] }
@@ -125,7 +125,7 @@ class ImportJob < ApplicationJob
                       })
       report = { context: @context, items: @statuses }
       @ingest.report.attach(
-        io: StringIO.open(report.to_json),
+        io: StringIO.open(JSON.pretty_generate(report)),
         filename: "import#{@ingest.id}.json",
         content_type: 'application/json'
       )

--- a/spec/jobs/import_job_spec.rb
+++ b/spec/jobs/import_job_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe ImportJob do
     context 'with errors' do
       before do
         # Simulate an error on creating one of two records
-        allow(Item).to receive(:create) do |params|
-          raise 'Testing exception handling' if params[:metadata]['title_ssi'].match?(/Admiral/)
+        allow(Item).to receive(:create!) do |params|
+          raise NoMethodError, 'Testing exception handling' if params[:metadata]['title_ssi'].match?(/Admiral/)
 
           Item.new(id: 1)
         end


### PR DESCRIPTION
**ISSUE**
By default, solr_wrapper deletes the Solr index each time it shuts down. This cuases us to have to re-index data in our development environment every time we restart solr_wrapper (i.e. system updates and reboots). :We would rather the default behavior be to persist data with the exception being a call to explicitly purge the index.

**FIX**
Add `persist: true` to the solr_wrapper config file. If we want to delete the index, we can explicitly call:
```
solr_wrapper --clean
```