### PR TITLE
Allow the importer to cast scalars to multi-valued fields

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -110,7 +110,7 @@ class Resource < ApplicationRecord
   def prune_blank_values
     blueprint.fields.each do |field|
       value = metadata[field.name]
-      metadata[field.name] = field.multiple ? (value || []).compact_blank : value.presence
+      metadata[field.name] = field.multiple ? [*value].compact_blank : value.presence
     end
   end
 

--- a/spec/models/resource_shared_examples.rb
+++ b/spec/models/resource_shared_examples.rb
@@ -131,6 +131,14 @@ RSpec.shared_examples 'a resource' do
       resource.save!
       expect(resource.metadata['Author']).to eq ['Author', 'Co-Author', 'Editor']
     end
+
+    it 'casts scalars for multi-valued fields' do
+      allow(blueprint)
+        .to receive(:fields).and_return([FactoryBot.build(:field, name: 'Author', multiple: true)])
+      resource.metadata['Author'] = 'scalar'
+      resource.save!
+      expect(resource.metadata['Author']).to be_an(Array)
+    end
   end
 
   describe '#update_index', :solr do


### PR DESCRIPTION
**ISSUE**
Sometimes we want to import data from an external source that has scalar values (e.g. strings, numbers) for a field that we have defined as being multi-valued.

**FIX**
When a field is defined as being multi-valued, cast any inbound scalars to a single element array before saving.