### PR TITLE
Index file attachment signatures into Solr

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,4 +5,11 @@
 # same parent and share controllers that provide common behavior
 class Item < Resource
   has_many_attached :files
+
+  private
+
+  def solr_base_values
+    files_ssm = { 'files_ssm' => files_attachments.map { |file| file.signed_id }.presence }.compact
+    super.merge(files_ssm)
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -21,4 +21,26 @@ RSpec.describe Item do
       expect(new_item.files.attachments.count).to eq 2
     end
   end
+
+  # For convenience and performance, we want each attachment's signed_id indexed to Solr
+  describe '#to_solr' do
+    before do
+      # stub calls to Solr
+      allow(new_item).to receive(:update_index)
+    end
+
+    it 'indexes attachment signed_ids' do
+      new_item.files.attach(fixture_file_upload('rocket-takeoff.svg', 'image/svg'))
+      new_item.save!
+      signature = new_item.files_attachments.first.signed_id
+
+      expect(new_item.to_solr).to include('files_ssm' => array_including(signature))
+    end
+
+    it 'omits files_ssm when there are no attachments' do
+      new_item.save!
+
+      expect(new_item.to_solr).not_to have_key('files_ssm')
+    end
+  end
 end


### PR DESCRIPTION
When an item has file attachements, we want to be able to reference them without having to reload the original item from the database.

Indexing the signed IDs of the file attachments lets us retrieve the attachment without loading the parent object.