### PR TITLE
Display signed_ids for files on the Item show page

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -106,6 +106,7 @@ class Config < ApplicationRecord
       config.add_index_field f.solr_field, label: f.name if f.list_view
       config.add_show_field f.solr_field, label: f.name if f.item_view
     end
+    config.add_show_field 'files_ssm', label: 'Files' # , helper_method: :file_links
     config
   end
 

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe Field do
       # NOTE: the first active field is used as the title field and already displays in index and show views
       expect { field.send(:update_catalog_controller) }
         .to change { CatalogController.blacklight_config.show_fields.values.map(&:label) }
-        .from([]).to(['field3'])
+        .from([]).to(array_including('field3'))
     end
 
     it 'updates facet fields', :aggregate_failures do

--- a/spec/system/catalog_config_spec.rb
+++ b/spec/system/catalog_config_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Catalog Config' do
      { name: 'Creator',     data_type: 'text_en', list_view: true,  item_view: true, multiple: true, facetable: true },
      { name: 'Keywords',    data_type: 'string',  list_view: false, item_view: true, multiple: true, facetable: true },
      { name: 'Usage Notes', data_type: 'text_en', list_view: false, item_view: true, multiple: true }]
+    # NOTE: 'Files' --> 'files_ssm' is injected automatically to handle file attachments
   end
 
   # Stub out a minimal solr server
@@ -46,7 +47,8 @@ RSpec.describe 'Catalog Config' do
                                 ['description_tesim', 'Description'],
                                 ['creator_tesim', 'Creator'],
                                 ['keywords_ssim', 'Keywords'],
-                                ['usage_notes_tesim', 'Usage Notes']
+                                ['usage_notes_tesim', 'Usage Notes'],
+                                ['files_ssm', 'Files']
                               ])
   end
 

--- a/spec/system/field_order_spec.rb
+++ b/spec/system/field_order_spec.rb
@@ -20,7 +20,8 @@ describe 'Field Order' do
 
     # Check Catalog configuration reflects updated field order
     # NOTE: first field is used as the title field and suppressed from index_fields and show_fields
-    show_fields = CatalogController.blacklight_config.show_fields.values.map(&:label)
+    # NOTE: 'Files' is injected by the Config object and we want to disregard it for this test
+    show_fields = CatalogController.blacklight_config.show_fields.values.map(&:label).without('Files')
     expect(show_fields).to eq ['Alpha', 'Gamma']
   end
 end


### PR DESCRIPTION
This commit causes Blacklight to pass the file signed_ids returned from Solr to the view. This is not very user friendly by itself, but it provides the data source that will allow us to build a helper that shows links to our attached files.