### PR TITLE
Display a download link for each file attached to an Item

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -1,0 +1,15 @@
+# Local helpers to extend document display capabilities for
+# Blacklight Catalog Controller based views
+# e.g. Solr document show and related partials
+module DocumentHelper
+  def file_links(options)
+    files = options[:value]
+    tag.div(id: 'file_links', escape: false) do
+      links = files.map do |signed_id|
+        file = ActiveStorage::Blob.find_signed!(signed_id)
+        link_to file.filename, url_for(file)
+      end
+      to_sentence(links)
+    end
+  end
+end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -106,7 +106,7 @@ class Config < ApplicationRecord
       config.add_index_field f.solr_field, label: f.name if f.list_view
       config.add_show_field f.solr_field, label: f.name if f.item_view
     end
-    config.add_show_field 'files_ssm', label: 'Files' # , helper_method: :file_links
+    config.add_show_field 'files_ssm', label: 'Files', helper_method: :file_links
     config
   end
 

--- a/spec/helpers/document_helper_spec.rb
+++ b/spec/helpers/document_helper_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe DocumentHelper do
+  let(:options) { { value: [this.signed_id, the_other.signed_id] } }
+  let(:this) { ActiveStorage::Blob.create_before_direct_upload!(filename: 'image.jpg', byte_size: 0, checksum: 0) }
+  let(:the_other) do
+    ActiveStorage::Blob.create_before_direct_upload!(filename: 'document.pdf', byte_size: 0, checksum: 0)
+  end
+
+  before do
+    ActiveStorage::Current.url_options = { protocol: request.protocol, host: request.host, port: request.port }
+  end
+
+  describe '#file_links' do
+    let(:file_links) { helper.file_links(options) }
+
+    it 'wraps the links in a div with a unique id' do
+      expect(file_links).to have_selector('div#file_links')
+    end
+
+    it 'renders a link for each attached file', :aggregate_failures do
+      expect(file_links).to have_link('image.jpg', href: url_for(this))
+      expect(file_links).to have_link('document.pdf', href: url_for(the_other))
+    end
+
+    it 'raises an exception on invalid signed_ids' do
+      expect do
+        helper.file_links({ value: ['invalid_signature'] })
+      end.to raise_exception ActiveSupport::MessageVerifier::InvalidSignature
+    end
+  end
+end


### PR DESCRIPTION
This change renders a download link for each indexed file attachment (i.e. blob signed_id) instead of displaying the signed_id itself.

## BEFORE
<img width="808" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/9e758bdd-17ea-4e82-ac68-2d499fb76481">

## AFTER
<img width="807" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/f686d2a4-4004-44b2-8871-b7c827fb84ea">

