### PR TITLE
Fix bug that allows Resources to be saved without required fields

### DIFF
--- a/spec/models/resource_shared_examples.rb
+++ b/spec/models/resource_shared_examples.rb
@@ -99,6 +99,14 @@ RSpec.shared_examples 'a resource' do
     end
   end
 
+  it 'validates required fields' do
+    allow(blueprint).to receive(:fields).and_return([FactoryBot.build(:field, name: 'Required', required: true)])
+
+    resource.metadata['Required'] = ['', nil, {}]
+    resource.valid?
+    expect(resource.errors.where(:metadata, :invalid)).to be_present
+  end
+
   describe '#save' do
     before do
       # Stub solr calls which are tested elsewhere
@@ -113,15 +121,6 @@ RSpec.shared_examples 'a resource' do
       resource.metadata = nil
       resource.save
       expect(resource.errors.where(:metadata, :blank)).to be_present
-    end
-
-    it 'validates required fields' do
-      allow(blueprint).to receive(:fields).and_return(
-        [FactoryBot.build(:field, name: 'Required', required: true)]
-      )
-
-      resource.save
-      expect(resource.errors.where(:required, :blank)).to be_present
     end
 
     it 'diregards empty field values' do


### PR DESCRIPTION
**ISSUE**
The Resource edit form (i.e. Items & Collections) would allow administrators to save resources without filling in required fields.

**DIAGNOSIS**
We were initially checking for the presence of the required Field's key rather than its value. In addition, for multi-value fields, we need to collapse empty input like ['', ''] that can be returned from the form.

**FIX**
Update the validation test with more robust examples of 'blank' values and update the model code to check for the various possible permutations of an empty field.