### PR TITLE
[REFACTOR] Handle resource labels for missing titles

### DIFF
--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -5,6 +5,14 @@ class Blueprint < ApplicationRecord
   validates :name, format: { with: /\A([\w _-])+\z/, message: 'can not contain special characters' }, allow_blank: true
 
   def fields
+    @fields ||= self.class.fields
+  end
+
+  def label_field
+    @label_field ||= fields.first&.name
+  end
+
+  def self.fields
     Field.active.order(:sequence)
   end
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -12,6 +12,8 @@ class Resource < ApplicationRecord
   validates :metadata, presence: true
   validate :required_fields_present
 
+  delegate :label_field, to: :blueprint
+
   class << self
     def reindex_all
       logger.measure_info('Reindexing everything', metric: "#{name}/index_all",
@@ -55,7 +57,7 @@ class Resource < ApplicationRecord
   end
 
   def label
-    metadata[label_field]
+    metadata[label_field] || "#{self.class}(#{id})"
   end
 
   # Use items partials instead of looking for separate items and collection partials
@@ -144,9 +146,5 @@ class Resource < ApplicationRecord
   def missing_value?(field_name)
     value = metadata[field_name]
     [*value].compact_blank.empty?
-  end
-
-  def label_field
-    @label_field ||= blueprint.fields.first.name
   end
 end

--- a/spec/models/resource_shared_examples.rb
+++ b/spec/models/resource_shared_examples.rb
@@ -54,6 +54,14 @@ RSpec.shared_examples 'a resource' do
       )
       expect(resource.label).to eq 'One Hundred Years of Solitude'
     end
+
+    it 'returns the id when the title field is empty' do
+      # No "title" field is defined if there are no fields
+      allow(blueprint).to receive(:fields).and_return([])
+      resource.id = 987
+
+      expect(resource.label).to eq "#{resource.class}(987)"
+    end
   end
 
   describe '#to_solr' do


### PR DESCRIPTION
It "shouldn't" happen in the wild, but there are situations in development and testing where we may have a resource with an empty title field (i.e. first field defined in the blueprint).

This refactoring ensures that #label always returns some identifiable label, either the "Title" defined by the blueprint, or the resource class and ID as a placeholder.

We've also memoized the label's field name once a blueprint is loaded since we don't want to keep having to reload Fields each time we want to look up the label value.