### PR TITLE
[REFACTOR] Make dashboard status more consistent with other models

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -48,6 +48,6 @@ class Ability
     # Assign authorizations based on system roles
     authorized_resources = ROLE_MAPPER.select { |_resource, role| user&.role_name?(role) }
     authorized_resources.each_key { |resource| can :manage, resource }
-    can :read, :dashboard if authorized_resources.any?
+    can :read, [:dashboard, Status] if authorized_resources.any?
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,0 +1,7 @@
+# Placeholder singleton for Dashboard Status code
+class Status
+  extend ActiveModel::Naming
+
+  model_name.plural = 'status'
+  model_name.route_key = 'status'
+end

--- a/app/views/admin/_sidebar.html.erb
+++ b/app/views/admin/_sidebar.html.erb
@@ -2,11 +2,7 @@
   <nav id='admin_sidebar' class='d-flex flex-column flex-shrink-0 p-3'>
     <h2>Admin Tools</h2>
     <ul class='nav nav-pills flex-column mb-auto'>
-      <li class='nav-item'>
-        <%= link_to t('t3.admin.status'), status_path, class: ['nav-link', controller_name == 'status' ? 'active' : '' ]%>
-      </li>
-
-      <% [Item, Collection, Ingest, User, Role, Blueprint, Field, Theme, CustomDomain].each do |menu_area|  %>
+      <% [Status, Item, Collection, Ingest, User, Role, Blueprint, Field, Theme, CustomDomain].each do |menu_area|  %>
         <% if can? :read, menu_area %>
           <li class='nav-item'>
             <%= link_to t("t3.admin.#{menu_area.model_name.plural}"), menu_area, class: ['nav-link', active_class(menu_area)] %>

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -55,8 +55,12 @@ RSpec.describe Ability do
         expect(authz.can?(:manage, Role)).to be true
       end
 
-      it 'can read dashboard status' do
+      it 'can read dashboard' do
         expect(authz.can?(:read, :dashboard)).to be true
+      end
+
+      it 'can read Status' do
+        expect(authz.can?(:read, Status)).to be true
       end
 
       it 'cannot manage Themes' do
@@ -107,8 +111,12 @@ RSpec.describe Ability do
         expect(authz.can?(:manage, Collection)).to be true
       end
 
-      it 'can read dashboard status' do
+      it 'can read dashboard' do
         expect(authz.can?(:read, :dashboard)).to be true
+      end
+
+      it 'can read Status' do
+        expect(authz.can?(:read, Status)).to be true
       end
 
       it 'cannot manage Users' do

--- a/spec/views/admin/_sidebar.html.erb_spec.rb
+++ b/spec/views/admin/_sidebar.html.erb_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'admin/_sidebar' do
   end
 
   it 'has a status link' do
+    allow(view.controller.current_ability).to receive(:can?).with(:read, Status).and_return(true)
     render
     expect(rendered).to have_link(href: status_path)
   end


### PR DESCRIPTION
This change adds a Status class that behaves like the other administrative classes.  This allows us to remove conditionals and custom formatting from dashboard views.