### PR TITLE
Fix bug preventing newly imported file from appearing in UI

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,7 +9,7 @@ class Item < Resource
   private
 
   def solr_base_values
-    files_ssm = { 'files_ssm' => files_attachments.map { |file| file.signed_id }.presence }.compact
+    files_ssm = { 'files_ssm' => files.map(&:signed_id).presence }.compact
     super.merge(files_ssm)
   end
 end


### PR DESCRIPTION
**ISSUE**
There is a subtle difference between the `files` and the `files_attached` methods during Item creation: `files_attributes` does not get set until after the Item callbacks even if there are values for `files`.

**FIX**
Make calls to `files` rather than `files_attributes` so that we are able to access any parameters passed during the creation process - especially file attachments.