### PR TITLE
[REFACTOR] Use STI for Items and Collections

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,7 +1,5 @@
 # Basic repository object, smallest unit of discovery
 class Resource < ApplicationRecord
-  self.abstract_class = true
-
   belongs_to :blueprint
 
   after_initialize :check_metadata
@@ -9,6 +7,7 @@ class Resource < ApplicationRecord
   after_save :update_index
   after_destroy_commit :delete_index
 
+  validates :type, presence: true
   validates :metadata, presence: true
   validate :required_fields_present
 

--- a/db/migrate/20240427000656_merge_items_and_collections.rb
+++ b/db/migrate/20240427000656_merge_items_and_collections.rb
@@ -1,0 +1,52 @@
+class MergeItemsAndCollections < ActiveRecord::Migration[7.0]
+  def up
+    create_table 'resources', force: false do |t|
+      t.string 'type', null: false
+      t.references :blueprint, null: false, foreign_key: true
+      t.datetime 'created_at', null: false
+      t.datetime 'updated_at', null: false
+      t.jsonb 'metadata'
+    end
+
+    # Copy Items to Resources retaining IDs - so we keep ActiveStorage associations
+    ActiveRecord::Base.connection
+                      .execute('INSERT INTO resources (id, type, blueprint_id, created_at, updated_at, metadata)' \
+                               "SELECT id, 'Item' as type, blueprint_id, created_at, updated_at, metadata FROM items;")
+    # Copy Collections to Resources - assigning new IDs
+    ActiveRecord::Base.connection
+                      .execute('INSERT INTO resources (type, blueprint_id, created_at, updated_at, metadata)' \
+                               "SELECT 'Collection' as type, blueprint_id, created_at, updated_at, metadata FROM collections;") # rubocop:disable Layout/LineLength
+
+    drop_table 'collections'
+    drop_table 'items'
+  end
+
+  def down
+    create_table 'items', force: false do |t|
+      t.references :blueprint, null: false, foreign_key: true
+      t.datetime 'created_at', null: false
+      t.datetime 'updated_at', null: false
+      t.jsonb 'metadata'
+    end
+
+    create_table 'collections', force: false do |t|
+      t.references :blueprint, null: false, foreign_key: true
+      t.datetime 'created_at', null: false
+      t.datetime 'updated_at', null: false
+      t.jsonb 'metadata'
+    end
+
+    # Copy (Item)Resources to Items retaining IDs - so we keep ActiveStorage associations
+    ActiveRecord::Base.connection
+                      .execute('INSERT INTO items (id, blueprint_id, created_at, updated_at, metadata) ' \
+                               'SELECT id, blueprint_id, created_at, updated_at, metadata FROM resources ' \
+                               "WHERE type = 'Item';")
+    # Copy ()Collection)Resources to Collections - assigning new IDs
+    ActiveRecord::Base.connection
+                      .execute('INSERT INTO collections (blueprint_id, created_at, updated_at, metadata) ' \
+                               'SELECT blueprint_id, created_at, updated_at, metadata FROM resources ' \
+                               "WHERE type = 'Collection';")
+
+    drop_table 'resources'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_05_162425) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_27_000656) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,14 +61,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_05_162425) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "collections", force: :cascade do |t|
-    t.jsonb "metadata"
-    t.bigint "blueprint_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["blueprint_id"], name: "index_collections_on_blueprint_id"
-  end
-
   create_table "configs", force: :cascade do |t|
     t.string "solr_host"
     t.string "solr_core"
@@ -113,12 +105,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_05_162425) do
     t.index ["user_id"], name: "index_ingests_on_user_id"
   end
 
-  create_table "items", force: :cascade do |t|
+  create_table "resources", force: :cascade do |t|
+    t.string "type", null: false
     t.bigint "blueprint_id", null: false
-    t.jsonb "metadata"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["blueprint_id"], name: "index_items_on_blueprint_id"
+    t.jsonb "metadata"
+    t.index ["blueprint_id"], name: "index_resources_on_blueprint_id"
   end
 
   create_table "roles", force: :cascade do |t|
@@ -197,7 +190,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_05_162425) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "ingests", "users"
-  add_foreign_key "items", "blueprints"
+  add_foreign_key "resources", "blueprints"
   add_foreign_key "roles_users", "roles"
   add_foreign_key "roles_users", "users"
 end

--- a/spec/models/resource_shared_examples.rb
+++ b/spec/models/resource_shared_examples.rb
@@ -14,9 +14,8 @@ RSpec.shared_examples 'a resource' do
     expect(resource).to be_a(Resource)
   end
 
-  it 'uses a class-specific table', :aggregate_failures do
-    expect(resource.class.table_name).to eq described_class.table_name
-    expect(resource.class.table_name).not_to eq 'resources'
+  it 'uses Single Table Inheritance' do
+    expect(resource.class.table_name).to eq 'resources'
   end
 
   describe '#metadata' do


### PR DESCRIPTION
We don't get enough benefit from separate tables for Items vs. Collections, and we want to ensure their IDs do not collide without having to namespace the IDs. Moving back to Single Table Inheritance (STI) is the simplest, most Rails-y way to ensure we keep unique IDs across all Resource subclasses.