### PR TITLE
Fix flaky request test

### DIFF
--- a/spec/requests/admin/themes_spec.rb
+++ b/spec/requests/admin/themes_spec.rb
@@ -84,6 +84,8 @@ RSpec.describe '/admin/themes' do
 
     context 'with invalid parameters' do
       it 'does not create a new Theme' do
+        # Stub out Theme.current so we don't accidentally create a current theme in this test
+        allow(Theme).to receive(:current).and_return(FactoryBot.build(:theme))
         expect do
           post themes_url, params: { theme: invalid_attributes }
         end.not_to change(Theme, :count)
@@ -164,8 +166,7 @@ RSpec.describe '/admin/themes' do
 
   describe 'PATCH /activate' do
     it 'updates the current theme' do
-      old_theme = FactoryBot.create(:theme)
-      old_theme.activate!
+      old_theme = Theme.current
       new_theme = FactoryBot.create(:theme)
       expect { patch activate_theme_url(new_theme) }.to change(Theme, :current).from(old_theme).to(new_theme)
     end


### PR DESCRIPTION
Depending on the test order, there may not be a current Theme defined yet, casuing any request to create one as part of the application's layout and CSS rendering process.

If tests that test Theme counts are run without a current theme defined, a new current theme will be created. This typically throws off the expectect count in the test.