### PR TITLE
Add foreman support in development environment

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+solr: bundle exec solr_wrapper
+web: env RUBY_DEBUG_OPEN=true bin/rails server

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+if gem list --no-installed --exact --silent foreman; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
Update the application to follow the development environment launch process provided in Rails 7.1+ by adding a `dev` command in the bin directory. This command uses [foreman](https://github.com/ddollar/foreman) to launch solr and the web server in development mode.

USAGE:
% ` bin/dev`