### PR TITLE
[REFACTOR] Force dev server to start on port 3000

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
 solr: bundle exec solr_wrapper
-web: env RUBY_DEBUG_OPEN=true bin/rails server
+web: env RUBY_DEBUG_OPEN=true bin/rails server -p 3000


### PR DESCRIPTION
Foreman auto increments the PORT environment variable for each line in the Procfile. This means the rails server port becomes position dependent - i.e. putting the webserver on line 2 causes the service to launch on port 3100.

We want to start Solr first, so it has time to initialize before we start our web server. So the webserver comes on line 2 of the Procfile (which sets the environment PORT=3100). We want the server to run on port 3000, so we need to set the value explicitly instead of reading the PORT variable from the environment.