### PR TITLE
Speed up screen refresh when reordering fields

### DIFF
--- a/app/controllers/admin/fields_controller.rb
+++ b/app/controllers/admin/fields_controller.rb
@@ -53,7 +53,8 @@ module Admin
     def move # rubocop:disable Metrics/AbcSize
       respond_to do |format|
         if @field.move(params[:move])
-          format.html { redirect_to fields_url }
+          @fields = Field.order(:sequence)
+          format.html { render :index }
           format.json { render :show, status: :ok, location: @field }
         else
           format.html { redirect_to fields_url, status: :unprocessable_entity, alert: @field.errors.full_messages }

--- a/app/views/admin/fields/index.html.erb
+++ b/app/views/admin/fields/index.html.erb
@@ -1,5 +1,5 @@
 <h1>Fields</h1>
-
+<%= turbo_frame_tag 'field_order' do -%>
 <table id="fields">
   <thead>
     <tr>
@@ -13,12 +13,12 @@
   </thead>
   <tbody>
     <% @fields.each do |field| %>
-      <tr>
+      <tr id="<%= dom_id(field) %>">
         <td class="order">
           <%= button_to '🔼', move_field_path(field, move: :up), id: dom_id(field, :move_up), class: 'up', method: :patch, disabled: field.sequence == 1 %>
           <%= button_to '🔽', move_field_path(field, move: :down), id: dom_id(field, :move_down), class: 'down', method: :patch, disabled: field.sequence == Field.count %>
         </td>
-        <td class="name"><%= link_to field.name, field -%></td>
+        <td class="name"><%= link_to field.name, field, data: {turbo: false} -%></td>
         <td class="data_type"><%= field.data_type -%><%= ' (multiple)' if field.multiple -%></td>
         <td class="settings">
           <% settings = field.active ? ['active'] : ['disabled'] %>
@@ -47,7 +47,7 @@
     </tr>
   </tfoot>
 </table>
-
+<% end %>
 
 <br>
 <%= link_to "Add field", new_field_path, class: 'btn btn-outline-primary' %>

--- a/spec/requests/admin/fields_spec.rb
+++ b/spec/requests/admin/fields_spec.rb
@@ -118,10 +118,17 @@ RSpec.describe '/admin/fields' do
         expect(field).to have_received(:move).with('up')
       end
 
-      it 'redirects to the index view' do
-        field = Field.create! valid_attributes
-        patch move_field_path(field), params: { move: :up }
-        expect(response).to redirect_to fields_url
+      it 'renders the updated list', :aggregate_failures do
+        field1, field2 = FactoryBot.create_list(:field, 2)
+
+        # Confirm field2 comes after field1 in sequence order
+        expect(field2.sequence).to be > field1.sequence
+
+        # Send request to reorder fields
+        patch move_field_path(field2), params: { move: :up }
+
+        # Sequence should be reordered and field2 should now come first in the sequence
+        expect(response.body).to match(/<tr id="field_#{field2.id}">.*<tr id="field_#{field1.id}">/m)
       end
     end
 


### PR DESCRIPTION
This change uses turbo frames to update only the fields table when re-ordering fields instead of re-drawing the entire page. This results in a slightly faster refresh.

Turbo retains the broswer scroll state so we don't scroll back to the top of the page when re-ordering fields at the end of the list. This helps provide a less distracting user experience than having the page unexpectedly jump away from the fields the user is viewing.