### PR TITLE
Fix gaps in sequence numbers after deletions

### DIFF
--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -43,6 +43,7 @@ class Field < ApplicationRecord
   before_save :check_sequence
   after_save :clear_solr_field
   after_save :update_catalog_controller
+  after_destroy { Field.resequence }
 
   scope :active, -> { where(active: true) }
 

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -292,6 +292,14 @@ RSpec.describe Field do
     end
   end
 
+  describe '#delete' do
+    it 'updates sequence numbers' do
+      fields = FactoryBot.create_list(:field, 3)
+
+      expect { fields[0].destroy }.to change { described_class.maximum(:sequence) }.by(-1)
+    end
+  end
+
   describe '#save' do
     it 'updates the blacklight configuration' do
       allow(field).to receive(:update_catalog_controller)


### PR DESCRIPTION
**ISSUE**
Deleting a Field in the middle of the field sequence would leave a gap in the sequence numbers. Because sequence numbers are expected to be contiguous starting at 1, some parts of the code expect the maximum sequence number to match the total field count.  However, deleting a field in the middle of the sequence could lead to sequence numbers like [1, 2, 3, 5] where the maximum sequence number (5) exceeds the field count (4).

**FIX**
Explicitly check and update the sequence numbers of the remaining fields any time a field is deleted.