### PR TITLE
Fix flaky search_bar_component coverage

### DIFF
--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -314,10 +314,11 @@ RSpec.describe Field do
        FactoryBot.build(:field, name: 'field2', list_view: true, item_view: false, facetable: true),
        FactoryBot.build(:field, name: 'field3', list_view: false, item_view: true, facetable: true)]
     end
+    let(:blacklight_config) { Blacklight::Configuration.new }
 
     before do
-      # Clear the catalog configuration
-      CatalogController.blacklight_config = Blacklight::Configuration.new
+      # Run these tests against an empty blacklight configuration
+      allow(CatalogController).to receive(:blacklight_config).and_return(blacklight_config)
       # Stub Fields.active and Fields.active.order
       relation = described_class.where(id: nil) # empty relation
       allow(relation).to receive(:records).and_return(sample_fields)


### PR DESCRIPTION
**ISSUE**
In a small subset of random test seeds, the search_bar_component code would not be tested, resulting in less than 100% test coverage.

**DIAGNOSIS**
One of the Field model tests was resetting the CatalogController blacklight configuration to an empty configuration.  This config includes a pointer to the header component:
https://github.com/curationexperts/t3/blob/v0.24.0/app/controllers/catalog_controller.rb#L27  
If this configuration is missing, the header component and the search bar component are never called.

**FIX**
Stub the blacklight configuration only for the example group instead of setting it to a new blank configuration that is used in all subsequent tests.