### PR TITLE
Display live import updates

### DIFF
--- a/app/views/admin/ingests/_report.html.erb
+++ b/app/views/admin/ingests/_report.html.erb
@@ -1,0 +1,3 @@
+<div id="<%= dom_id(ingest, :report) -%>">
+  <%= link_to ingest.report.filename, rails_blob_path(ingest.report, disposition: "attachment") if ingest.report.attached? %>
+</div>

--- a/app/views/admin/ingests/_status.html.erb
+++ b/app/views/admin/ingests/_status.html.erb
@@ -1,0 +1,3 @@
+<div id="<%= dom_id(ingest, :status) -%>">
+  <%= progress_bar(ingest.processed, ingest.size, ingest.status, ingest.error_count) %>
+</div>

--- a/app/views/admin/ingests/index.html.erb
+++ b/app/views/admin/ingests/index.html.erb
@@ -1,3 +1,5 @@
+<%= turbo_stream_from 'ingests' -%>
+
 <div id="ingests">
   <h1>Ingests</h1>
   <%= link_to "Submit new job", new_ingest_path, id: 'new_ingest', class: 'btn btn-primary' %>
@@ -17,8 +19,8 @@
         <td class='batch_id'><%= ingest.id %> <%= link_to 'view', url_for(ingest) %> </td>
         <td class='owner'><%= ingest.user.display_name %></td>
         <td class='manifest'><%= link_to ingest.manifest.filename, rails_blob_path(ingest.manifest, disposition: "attachment") %></td>
-        <td class='report'><%= link_to ingest.report.filename, rails_blob_path(ingest.report, disposition: "attachment") if ingest.report.attached? %></td>
-        <td class='status'><%= progress_bar(ingest.processed, ingest.size, ingest.status, ingest.error_count) %></td>
+        <td class='report'><%= render 'report', ingest: ingest %></td>
+        <td class='status'><%= render 'status', ingest: ingest %></td>
       </tr>
     <% end %></tbody>
     <tfoot>
@@ -32,15 +34,3 @@
     </tfoot>
   </table>
 </div>
-
-<!--Hack to get job processing updates-->
-<!--TODO: Use Turbo streams for status badge updates-->
-<% if @ingests.map(&:status).include?('processing') %>
-  <script>
-      function autoRefresh() {
-          window.location = window.location.href;
-      }
-      setInterval('autoRefresh()', 2000);
-  </script>
-<% end %>
-


### PR DESCRIPTION
This change leverages Turbo Streams to send small targeted status updates to broswers watching the "Ingests" dashboard.

This allows us to remove the Javascript refresh from the page and gives us smoother incremental progress bar updates as each item is created.