### PR TITLE
Fix production restart issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -557,4 +557,4 @@ RUBY VERSION
    ruby 3.2.1p31
 
 BUNDLED WITH
-   2.4.12
+   2.5.10


### PR DESCRIPTION
The version of bundler and base64 in the repo are not compatible with the versions on the dev and prod servers.

Passenger will not restart because of a conflict in base64 gem versions that cannot be resolved using the older bundler version.