### PR TITLE
Display Field configuration in JSON format

### DIFF
--- a/app/views/admin/fields/_field.json.jbuilder
+++ b/app/views/admin/fields/_field.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract! field, :id, :name, :data_type, :source_field, :active, :required, :multiple, :list_view, :item_view,
-              :searchable, :facetable, :created_at, :updated_at
+json.extract! field, :sequence, :id, :name, :data_type, :source_field, :active, :required,
+              :multiple, :list_view, :item_view, :searchable, :facetable, :created_at, :updated_at
 json.url field_url(field, format: :json)

--- a/app/views/admin/fields/index.json.jbuilder
+++ b/app/views/admin/fields/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @fields, partial: 'fields/field', as: :field
+json.array! @fields, partial: 'admin/fields/field', as: :field

--- a/spec/views/admin/fields/index.jbuilder_spec.rb
+++ b/spec/views/admin/fields/index.jbuilder_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/fields/index.json.jbuilder' do
+  let(:fields) { FactoryBot.create_list(:field, 3) }
+  let(:json) { JSON.parse(render) }
+
+  before { assign(:fields, fields) }
+
+  it 'lists each field' do
+    expect(json.pluck('name')).to eq [fields[0]['name'], fields[1]['name'], fields[2]['name']]
+  end
+
+  it 'includes all the attributes for each field' do
+    expect(json[0].keys).to include(*Field.attribute_names)
+  end
+end


### PR DESCRIPTION
**STORY**
We want to be able to easily export the Field configuration from one repository instance to another, so that we can quickly configure a new environment to match an existing one.

**SOLUTION**
Allow Field configuration to be exported in JSON format, so that we can later use it to configure a different repository instance.