### PR TITLE
Fix file download bug in production

### DIFF
--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -1,6 +1,8 @@
 # Iterate over items in an Ingest manifest and
 # create associated repository objects
 class ImportJob < ApplicationJob
+  require 'open-uri'
+
   queue_as :default
 
   after_enqueue { arguments.first.queued! }


### PR DESCRIPTION
**ISSUE**
When we reference a HTTP or HTTPS URI for a file in an import manifest, we're seeing the following error in production:
```
private method `open' called for #<URI::HTTPS https:// ... >
```

**DIAGNOSIS**
The 'open-uri' module appears to be loaded for background workers in the defelopment environment automatically, but not for background jobs in the production environment.

**FIX**
Explicitly require the 'open-uri' module in the job class where the error is occurring.