### PR TITLE
Add support for Puma in production to enable ActionCable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,8 @@ gem 'sprockets-rails'
 gem 'pg', '~> 1.1'
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem 'puma', '~> 5.6'
+gem 'puma', '~> 6.4'
+gem 'sd_notify', group: :production
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem 'importmap-rails'
@@ -92,8 +93,8 @@ group :development do
 
   # Use Capistrano to deploy code to production and prod-like environments
   gem 'capistrano', require: false
+  gem 'capistrano3-puma', '6.0.0.beta.1', require: false
   gem 'capistrano-bundler', require: false
-  gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', require: false
   gem 'capistrano-sidekiq', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,8 +143,6 @@ GEM
       sshkit (>= 1.9.0)
     capistrano-bundler (2.1.0)
       capistrano (~> 3.1)
-    capistrano-passenger (0.2.1)
-      capistrano (~> 3.0)
     capistrano-rails (1.6.3)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
@@ -152,6 +150,10 @@ GEM
       capistrano (>= 3.9.0)
       capistrano-bundler
       sidekiq (>= 6.0)
+    capistrano3-puma (6.0.0.beta.1)
+      capistrano (~> 3.7)
+      capistrano-bundler
+      puma (>= 5.1, < 7.0)
     capybara (3.39.2)
       addressable
       matrix
@@ -310,7 +312,7 @@ GEM
     psych (5.1.2)
       stringio
     public_suffix (5.0.3)
-    puma (5.6.8)
+    puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.9)
@@ -430,6 +432,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sd_notify (0.1.1)
     selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -515,9 +518,9 @@ DEPENDENCIES
   cancancan
   capistrano
   capistrano-bundler
-  capistrano-passenger
   capistrano-rails
   capistrano-sidekiq
+  capistrano3-puma (= 6.0.0.beta.1)
   capybara
   debug
   devise
@@ -531,7 +534,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   pg (~> 1.1)
-  puma (~> 5.6)
+  puma (~> 6.4)
   rails (~> 7.1.3)
   rails_semantic_logger
   redis (~> 4.0)
@@ -543,6 +546,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sassc-rails (~> 2.1)
+  sd_notify
   selenium-webdriver
   simplecov
   simplecov_json_formatter

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,8 +1,6 @@
 # config valid for current version and patch releases of Capistrano
 lock '~> 3.17.3'
 
-require 'capistrano/passenger'
-
 set :application, 't3'
 set :repo_url, 'https://github.com/curationexperts/t3.git'
 set :deploy_to, '/opt/t3'
@@ -54,3 +52,8 @@ append :linked_files, 'config/master.key'
 
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure
+
+# Enable Pums Systemd ingegration in production
+set :puma_service_unit_name, 'puma'
+set :puma_enable_socket_service, true
+set :puma_bind, 'unix:///opt/t3/shared/tmp/sockets/puma.sock'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
   # config.action_cable.url = "wss://example.com/cable"
-  # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
+  config.action_cable.allowed_request_origins = ["https://#{`hostname`.strip}"]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -39,5 +39,8 @@ pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 #
 # preload_app!
 
+# Set up socket location
+bind 'unix:///opt/t3/shared/tmp/sockets/puma.sock' if Dir.exist?('/opt/t3/shared/tmp/sockets')
+
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
**ISSUE**
ActionCable does not play nicely with the Apache web server due to websocket processing - see
https://www.phusionpassenger.com/library/config/apache/action_cable_integration/

**RESOLUTION**
Run puma webserver in production (behind NGINX reverse proxy)

**BENFITS**
* Dev/Prod parity for puma webserver (vs. dev: puma, prod: passenger)
* ActionCable support
* Puma runs as unprivileged user (deploy) in production