### PR TITLE
Add ActionCable support for Custom Domains

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,12 @@ Style/FrozenStringLiteralComment:
 Style/HashSyntax:
   EnforcedShorthandSyntax: never
 
+Style/NumericLiterals:
+  # Permit integers representing timestamps
+  # ex. 2023_08_13_19_05_25 (for comparing ActiveRecord Migration versions)
+  AllowedPatterns:
+    - '\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2}'
+
 Style/OpenStructUse:
   Exclude:
     - 'spec/helpers/t3_form_builder_spec.rb'

--- a/config/initializers/certbot.rb
+++ b/config/initializers/certbot.rb
@@ -1,0 +1,10 @@
+# Load custom domains from the Let's Encrypt certificate
+Rails.application.config.after_initialize do
+  # Make sure we're running a Schema version that has the CustomDomain table
+  if ActiveRecord::Migrator.current_version > 2023_08_13_19_05_25
+    cert_client = CustomDomain.new.certbot_client
+    cert_client.hosts.each do |host|
+      CustomDomain.find_or_create_by(host: host)
+    end
+  end
+end


### PR DESCRIPTION
**ISSUE**
ActionCable was previously configured to only accept connections via the primary hostname and would disregard requests made using custom domain names.

**SOLUTION**
Update the certificate manager to upate the ActionCable host list to match the current list of primary and custom domain names.