### PR TITLE
Add Rake and Capistrano tasks to add new admin users

### DIFF
--- a/lib/capistrano/tasks/tenejo.rake
+++ b/lib/capistrano/tasks/tenejo.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+namespace :tenejo do
+  desc 'Create user'
+  task create_user: 'deploy:set_rails_env' do |_t, _args|
+    on roles(:app) do
+      within current_path do
+        with rails_env: fetch(:rails_env) do
+          email = ENV['email'] || 'systems@curationexperts.com'
+          execute('rake', "tenejo:create_user[#{email}]")
+        end
+      end
+    end
+  end
+
+  desc 'Invite user'
+  task invite: 'deploy:set_rails_env' do |_t, _args|
+    on roles(:app) do
+      within current_path do
+        with rails_env: fetch(:rails_env) do
+          email = ENV['email'] || 'systems@curationexperts.com'
+          execute('rake', "tenejo:invite[#{email}]")
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/tenejo.rake
+++ b/lib/tasks/tenejo.rake
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+CHARS = ('0'..'9').to_a + ('A'..'Z').to_a + ('a'..'z').to_a
+namespace :tenejo do
+  desc 'Create user'
+  task :create_user, [:email] => :environment do |_t, args|
+    r = Role.find_or_create_by(name: 'Super Admin')
+    pw = random_password
+    email = args[:email] || 'systems@curationexperts.com'
+    User.where(email: email).first&.destroy
+    User.create!(email: email, password: pw, roles: [r])
+    puts "Password: #{pw}"
+  end
+
+  desc 'Invite user'
+  task :invite, [:email] => :environment do |_t, args|
+    r = Role.find_or_create_by(name: 'Super Admin')
+    email = args[:email] || 'systems@curationexperts.com'
+    User.where(email: email).first&.destroy
+    User.invite!(email: email, roles: [r])
+  end
+
+  def random_password(length = 16)
+    CHARS.sort_by { rand }.join[0...length]
+  end
+end


### PR DESCRIPTION
This commit adds identically named Rake and Capistrano tasks to create or invite new users by e-mail. The tasks accept an optional e-mail argument, if no email is provided, the tasks will default to creating a new user with the e-mail `systems@curationexperts.com`

**RAKE TASKS**
* `rake tenejo:create_user[:email]`
* `rake tenejo:invite[:email]`

**CAPISTRANO TASKS
* `cap [:stage] tenejo:create_user email=optional@email.com`
* `cap [:stage] tenejo:invite email=optional@email.com`