### PR TITLE
[REFACTOR] Rename Config --> SolrService

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -242,5 +242,5 @@ class CatalogController < ApplicationController
   end
 
   # Apply any dynamic field configurations from the current configuration record
-  Config.current.update_catalog_controller
+  SolrService.current.update_catalog_controller
 end

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -114,7 +114,7 @@ class Field < ApplicationRecord
   end
 
   def update_catalog_controller
-    Config.current.update_catalog_controller
+    SolrService.current.update_catalog_controller
   end
 
   # Put the field at the end of the sequence if it's sequence order has not ben set

--- a/app/views/admin/status/index.html.erb
+++ b/app/views/admin/status/index.html.erb
@@ -1,6 +1,6 @@
 <h1>System Status</h1>
 
 <h2>&nbsp;</h2>
-<h3>Solr Status: <%= Config&.current&.solr_version&.present? ? "connected" : "down" -%></h3>
-<h3>Solr Version: <%= Config.current.solr_version -%></h3>
+<h3>Solr Status: <%= SolrService.current.solr_version.present? ? "connected" : "down" -%></h3>
+<h3>Solr Version: <%= SolrService.current.solr_version -%></h3>
 <h3>Users: <%= User.count -%></h3>

--- a/db/migrate/20240611174159_rename_config_to_solr_service.rb
+++ b/db/migrate/20240611174159_rename_config_to_solr_service.rb
@@ -1,0 +1,5 @@
+class RenameConfigToSolrService < ActiveRecord::Migration[7.1]
+  def change
+    rename_table :configs, :solr_services
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_27_000656) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_11_174159) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -59,14 +59,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_27_000656) do
     t.datetime "updated_at", precision: nil, null: false
     t.index ["document_id"], name: "index_bookmarks_on_document_id"
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
-  end
-
-  create_table "configs", force: :cascade do |t|
-    t.string "solr_host"
-    t.string "solr_core"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "solr_version"
   end
 
   create_table "custom_domains", force: :cascade do |t|
@@ -138,6 +130,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_27_000656) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["user_id"], name: "index_searches_on_user_id"
+  end
+
+  create_table "solr_services", force: :cascade do |t|
+    t.string "solr_host"
+    t.string "solr_core"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "solr_version"
   end
 
   create_table "themes", force: :cascade do |t|

--- a/spec/factories/solr_services.rb
+++ b/spec/factories/solr_services.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :config do
+  factory :solr_service do
     solr_host { 'http://localhost:8983' }
     solr_core { 'blacklight-core' }
     solr_version { '3.2.1' }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Ability do
         expect(authz.can?(:read, User)).to be false
         expect(authz.can?(:read, Role)).to be false
         expect(authz.can?(:read, Theme)).to be false
-        expect(authz.can?(:read, Config)).to be false
+        expect(authz.can?(:read, SolrService)).to be false
         expect(authz.can?(:read, Blueprint)).to be false
         expect(authz.can?(:read, Field)).to be false
         expect(authz.can?(:read, Ingest)).to be false

--- a/spec/models/solr_service_spec.rb
+++ b/spec/models/solr_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe Config, :aggregate_failures do
-  let(:config) { FactoryBot.build(:config) }
+RSpec.describe SolrService, :aggregate_failures do
+  let(:service) { FactoryBot.build(:solr_service) }
 
   let(:solr_client) { RSolr::Client.new(nil) }
 
@@ -31,18 +31,18 @@ RSpec.describe Config, :aggregate_failures do
 
   describe 'is a singleton that' do
     it 'has a valid factory' do
-      expect(FactoryBot.build(:config)).to be_valid
+      expect(FactoryBot.build(:solr_service)).to be_valid
     end
 
     it 'does not allow another record to be created' do
-      FactoryBot.create(:config)
-      second_config = FactoryBot.build(:config)
+      FactoryBot.create(:solr_service)
+      second_config = FactoryBot.build(:solr_service)
 
       expect(second_config.save).to be_falsey
     end
 
     it 'does not allow destruction of the record' do
-      config = FactoryBot.create(:config)
+      config = FactoryBot.create(:solr_service)
 
       expect do
         config.destroy
@@ -53,7 +53,7 @@ RSpec.describe Config, :aggregate_failures do
   describe '.current' do
     context 'when a configuration record exists' do
       it 'returns it' do
-        config = FactoryBot.create(:config)
+        config = FactoryBot.create(:solr_service)
 
         expect(described_class.current).to eq(config)
       end
@@ -73,150 +73,150 @@ RSpec.describe Config, :aggregate_failures do
   end
 
   it 'updates the catalog controller on saves' do
-    allow(config).to receive(:update_catalog_controller)
-    config.save!
-    expect(config).to have_received(:update_catalog_controller)
+    allow(service).to receive(:update_catalog_controller)
+    service.save!
+    expect(service).to have_received(:update_catalog_controller)
   end
 
   it 'validates' do
-    expect(config).to be_valid
+    expect(service).to be_valid
   end
 
   it 'solr_host exists' do
-    config.solr_host = nil
-    expect(config).not_to be_valid
-    expect(config.errors.messages[:solr_host]).to include(/can't be blank/)
+    service.solr_host = nil
+    expect(service).not_to be_valid
+    expect(service.errors.messages[:solr_host]).to include(/can't be blank/)
   end
 
   it 'solr host is a valid url' do
-    config.solr_host = 'http://😀'
-    expect(config).not_to be_valid
-    expect(config.errors.messages[:solr_host]).to include(/does not appear to be a valid url/)
+    service.solr_host = 'http://😀'
+    expect(service).not_to be_valid
+    expect(service.errors.messages[:solr_host]).to include(/does not appear to be a valid url/)
   end
 
   it 'solr_host is responding' do
     allow(solr_client).to receive(:get).and_raise(RSolr::Error::ConnectionRefused)
 
-    expect(config).not_to be_valid
-    expect(config.errors.messages[:solr_host]).to include(/is not responding/)
+    expect(service).not_to be_valid
+    expect(service.errors.messages[:solr_host]).to include(/is not responding/)
   end
 
   it 'solr_host responds without errors' do
     allow(solr_client).to receive(:get).and_call_original
     allow(solr_client.connection).to receive(:send).and_raise(Faraday::Error, 'Gateway Timeout')
 
-    expect(config).not_to be_valid
-    expect(config.errors.messages[:solr_host]).to include(/unexpected HTTP error/)
+    expect(service).not_to be_valid
+    expect(service.errors.messages[:solr_host]).to include(/unexpected HTTP error/)
   end
 
   it 'sets solr_version when solr_host is valid' do
-    config.solr_version = nil
-    config.validate(:create)
-    expect(config.solr_version).to eq '9.2.1'
+    service.solr_version = nil
+    service.validate(:create)
+    expect(service.solr_version).to eq '9.2.1'
   end
 
   it 'solr_version must be present' do
-    config.solr_version = nil
-    expect(config).not_to be_valid(:update)
-    expect(config.errors.messages[:solr_version]).to include("can't be blank")
+    service.solr_version = nil
+    expect(service).not_to be_valid(:update)
+    expect(service.errors.messages[:solr_version]).to include("can't be blank")
   end
 
   it 'requires solr_core' do
-    config.solr_core = nil
-    expect(config).not_to be_valid
-    expect(config.errors.messages[:solr_core]).to include("can't be blank")
+    service.solr_core = nil
+    expect(service).not_to be_valid
+    expect(service.errors.messages[:solr_core]).to include("can't be blank")
   end
 
   describe '#verified?' do
     it 'proxies solr_version' do
-      config.solr_version = nil
-      expect(config.verified?).to be false
-      config.solr_version = '9.2.1'
-      expect(config.verified?).to be true
+      service.solr_version = nil
+      expect(service.verified?).to be false
+      service.solr_version = '9.2.1'
+      expect(service.verified?).to be true
     end
   end
 
   describe '#solr_host_looks_valid' do
     it 'returns false for nil urls' do
-      config.solr_host = nil
-      expect(config.solr_host_looks_valid).to be false
+      service.solr_host = nil
+      expect(service.host_looks_valid).to be false
     end
 
     it 'returns false for blank urls' do
-      config.solr_host = ''
-      expect(config.solr_host_looks_valid).to be false
+      service.solr_host = ''
+      expect(service.host_looks_valid).to be false
     end
 
     it 'returns false for non-http urls' do
-      config.solr_host = 'ftp://ftp.example.org'
-      expect(config.solr_host_looks_valid).to be false
+      service.solr_host = 'ftp://ftp.example.org'
+      expect(service.host_looks_valid).to be false
     end
 
     it 'returns false for malformed urls' do
-      config.solr_host = 'http//:my_domain.com'
-      expect(config.solr_host_looks_valid).to be false
+      service.solr_host = 'http//:my_domain.com'
+      expect(service.host_looks_valid).to be false
     end
 
     it 'returns false for invalid uris' do
-      config.solr_host = 'http://😀'
-      expect(config.solr_host_looks_valid).to be false
+      service.solr_host = 'http://😀'
+      expect(service.host_looks_valid).to be false
     end
 
     it 'returns true for well-formed http urls' do
-      config.solr_host = 'http://localhost:8983'
-      expect(config.solr_host_looks_valid).to be true
+      service.solr_host = 'http://localhost:8983'
+      expect(service.host_looks_valid).to be true
     end
 
     it 'returns true for well-formed https urls' do
-      config.solr_host = 'https://my_server.my_domain.com/solr'
-      expect(config.solr_host_looks_valid).to be true
+      service.solr_host = 'https://my_server.my_domain.com/solr'
+      expect(service.host_looks_valid).to be true
     end
   end
 
   describe '#solr_host_responsive' do
     it 'returns true if Solr returns a version number' do
-      allow(config).to receive(:fetch_solr_version).and_return('9.2.1')
-      expect(config.solr_host_responsive).to be true
+      allow(service).to receive(:fetch_solr_version).and_return('9.2.1')
+      expect(service.host_responsive).to be true
     end
 
     it 'returns false if Solr does not give version number', :aggregate_failures do
-      allow(config).to receive(:fetch_solr_version).and_return(nil)
-      expect(config.solr_host_responsive).to be false
-      expect(config.errors.messages[:solr_host]).to include 'did not return a valid Solr version'
+      allow(service).to receive(:fetch_solr_version).and_return(nil)
+      expect(service.host_responsive).to be false
+      expect(service.errors.messages[:solr_host]).to include 'did not return a valid Solr version'
     end
   end
 
   describe '#available_cores' do
     it 'returns a list of core names' do
-      expect(config.available_cores).to contain_exactly('blacklight-core', 'tenejo', 'catalog-core')
+      expect(service.available_cores).to contain_exactly('blacklight-core', 'tenejo', 'catalog-core')
     end
 
     it 'returns an empty list when the host is not verified' do
-      allow(config).to receive(:verified?).and_return(false)
-      expect(config.available_cores).to eq []
+      allow(service).to receive(:verified?).and_return(false)
+      expect(service.available_cores).to eq []
     end
 
     it 'gracefully degrades during unexpected connection errors' do
       allow(solr_client).to receive(:get).and_raise(rsolr_error)
-      allow(config).to receive(:verified?).and_return(true)
-      expect(config.available_cores).to eq []
+      allow(service).to receive(:verified?).and_return(true)
+      expect(service.available_cores).to eq []
     end
   end
 
   describe '#available_fields' do
     it 'returns a list of fields indexed in the core' do
-      config.solr_core = 'tenejo'
-      expect(config.available_fields).to include('title_sim', 'description_tesim')
+      service.solr_core = 'tenejo'
+      expect(service.available_fields).to include('title_sim', 'description_tesim')
     end
 
     it 'includes configuration info for each field' do
-      config.solr_core = 'tenejo'
-      expect(config.available_fields.values.first.keys).to include('type', 'schema', 'docs')
+      service.solr_core = 'tenejo'
+      expect(service.available_fields.values.first.keys).to include('type', 'schema', 'docs')
     end
 
     it 'returns an empty list when there is a connection problem or misconfiguration' do
-      config.solr_core = '- not - a - valid - core -'
-      expect(config.available_fields).to eq []
+      service.solr_core = '- not - a - valid - core -'
+      expect(service.available_fields).to eq []
     end
   end
 end

--- a/spec/requests/admin/items_spec.rb
+++ b/spec/requests/admin/items_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe '/admin/items' do
 
     # Fake a minimal Solr server
     solr_client = instance_double(RSolr::Client, { update: :stubbed })
-    allow(Config).to receive(:solr_connection).and_return(solr_client)
+    allow(SolrService).to receive(:solr_connection).and_return(solr_client)
   end
 
   describe 'GET /index' do

--- a/spec/system/catalog_config_spec.rb
+++ b/spec/system/catalog_config_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Catalog Config' do
     field_seeds.each do |seed|
       Field.create!(seed)
     end
-    Config.current
+    SolrService.current
   end
 
   it 'sets CatalogController title field to the first active field' do


### PR DESCRIPTION
The Config model is primarily concerned with managing the connection to a Solr service. We want to add functionality to import and export the system "configuration" which more broadly includes all administrative settings. To avoid conceptual and naming conflicts going forward, we're renaming the class to better match it's specific use and functionality.