### PR TITLE
[REFACTOR] Cache the Field order

### DIFF
--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -56,6 +56,14 @@ class Field < ApplicationRecord
         field.update!(sequence: index) if field.sequence != index
       end
     end
+
+    def in_sequence
+      @in_sequence ||= reset_sequence
+    end
+
+    def reset_sequence
+      @in_sequence = Field.order(:sequence)
+    end
   end
 
   # If we call render directly on a Field object, e.g. `render field`,
@@ -111,6 +119,7 @@ class Field < ApplicationRecord
   def clear_solr_field
     @solr_field = nil
     @solr_facet_field = nil
+    self.class.reset_sequence
   end
 
   def update_catalog_controller

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -349,4 +349,19 @@ RSpec.describe Field do
         .from([]).to(['field2', 'field3'])
     end
   end
+
+  describe '.in_sequence' do
+    it 'returns fields in sequence order' do
+      fields = FactoryBot.create_list(:field, 2)
+      expect(described_class.in_sequence).to eq [fields[0], fields[1]]
+    end
+
+    it 'is updated when any field is saved', :aggregate_failures do
+      fields = FactoryBot.create_list(:field, 2)
+      fields[0].update_attribute(:sequence, 4) # i.e. move the field to the end of the list
+      expect(described_class.in_sequence).to eq [fields[1], fields[0]]
+      fields << FactoryBot.create(:field)
+      expect(described_class.in_sequence).to eq [fields[1], fields[0], fields[2]]
+    end
+  end
 end


### PR DESCRIPTION
**ISSUE**
Many places in the code require a list of Fields in their sequence order. Previously, the Fields were loaded from the database each time this list was needed. The list is *very* stable in a production environment, only changing when fields are added or re-ordered, which occurrs very rarely.

**RESOLUTION**
Implement a class method that caches the Fields in order. The only events that could invalidate the order are saves to the database. So, by reseeting the cached list on any save, we save a significant number of database read operations.