### PR TITLE
[REFACTOR] Leverage Field caching in other classes

### DIFF
--- a/app/controllers/admin/fields_controller.rb
+++ b/app/controllers/admin/fields_controller.rb
@@ -7,7 +7,7 @@ module Admin
 
     # GET /fields or /fields.json
     def index
-      @fields = Field.order(:sequence)
+      @fields = Field.in_sequence
     end
 
     # GET /fields/1 or /fields/1.json
@@ -53,7 +53,7 @@ module Admin
     def move # rubocop:disable Metrics/AbcSize
       respond_to do |format|
         if @field.move(params[:move])
-          @fields = Field.order(:sequence)
+          @fields = Field.in_sequence
           format.html { render :index }
           format.json { render :show, status: :ok, location: @field }
         else

--- a/app/models/blueprint.rb
+++ b/app/models/blueprint.rb
@@ -13,7 +13,7 @@ class Blueprint < ApplicationRecord
   end
 
   def self.fields
-    Field.active.order(:sequence)
+    Field.active_in_sequence
   end
 
   # Returns a reverse mapping of source_field ==> field name

--- a/app/models/solr_service.rb
+++ b/app/models/solr_service.rb
@@ -5,7 +5,7 @@ class SolrService < ApplicationRecord
                      solr_version: 'checked' }.freeze
 
   validates :solr_host, presence: true
-  validate :host_responsive, on: :create
+  validate :host_responsive
   validates :solr_version, presence: true, on: :update
   validates :solr_core, presence: true
 
@@ -91,7 +91,7 @@ class SolrService < ApplicationRecord
   def blacklight_fields_from_config
     config = Blacklight::Configuration.new
     # NOTE: skip the first field because it's always used as the main title field for Blacklight
-    Field.active.order(:sequence)[1..]&.each do |field|
+    Field.active_in_sequence[1..]&.each do |field|
       update_field(config, field)
     end
     config.add_show_field 'files_ssm', label: 'Files', helper_method: :file_links
@@ -105,7 +105,7 @@ class SolrService < ApplicationRecord
   end
 
   def title_field_from_config
-    Field.active.order(:sequence).first&.solr_field
+    Field.active_in_sequence.first&.solr_field
   end
 
   def solr_connection_from_config

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -221,6 +221,7 @@ RSpec.describe Field do
     it 'gets set to the end of the list' do
       previous = FactoryBot.create(:field, sequence: 10)
       FactoryBot.create(:field)
+      previous.reload # because sequence numbers may have been consolidated
       expect(described_class.last.sequence).to be > previous.sequence
     end
   end
@@ -319,14 +320,8 @@ RSpec.describe Field do
     before do
       # Run these tests against an empty blacklight configuration
       allow(CatalogController).to receive(:blacklight_config).and_return(blacklight_config)
-      # Stub Fields.active and Fields.active.order
-      relation = described_class.where(id: nil) # empty relation
-      allow(relation).to receive(:records).and_return(sample_fields)
-      allow(relation).to receive(:order).and_return(sample_fields)
-      allow(relation).to receive(:order).with(:sequence).and_return(relation)
-      allow(relation).to receive(:find_by).and_return(nil)
-      allow(relation).to receive(:first).and_return(sample_fields[0])
-      allow(described_class).to receive(:active).and_return(relation)
+      # Stub Field#in_seqeuence
+      allow(described_class).to receive(:in_sequence).and_return(sample_fields)
     end
 
     it 'updates index fields', :aggregate_failures do

--- a/spec/requests/admin/collections_spec.rb
+++ b/spec/requests/admin/collections_spec.rb
@@ -124,9 +124,7 @@ RSpec.describe '/admin/collections' do
       let(:blueprint) { FactoryBot.build(:blueprint) }
 
       before do
-        active = instance_double(ActiveRecord::Relation)
-        allow(Field).to receive(:active).and_return(active)
-        allow(active).to receive(:order).and_return(
+        allow(Field).to receive(:active_in_sequence).and_return(
           [FactoryBot.build(:field, name: 'Author', multiple: true)]
         )
       end
@@ -171,8 +169,8 @@ RSpec.describe '/admin/collections' do
       end
 
       it 'handles field names that include spaces', :aggregate_failures do
-        allow(Field.active).to receive(:order).and_return([FactoryBot.build(:field, name: 'Resource Type',
-                                                                                    multiple: true)])
+        allow(Field).to receive(:active_in_sequence).and_return([FactoryBot.build(:field, name: 'Resource Type',
+                                                                                          multiple: true)])
         patch collection_url(collection), params: {
           refresh: 'add Resource Type -1', item: { metadata: collection.metadata }
         }

--- a/spec/system/catalog_config_spec.rb
+++ b/spec/system/catalog_config_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe 'Catalog Config' do
     field_seeds.each do |seed|
       Field.create!(seed)
     end
-    SolrService.current
   end
 
   it 'sets CatalogController title field to the first active field' do


### PR DESCRIPTION
This change replaces live database calls for `Field.order(:sequence)` or `Field.active.order(:sequence)` with the equivalent class-level cached values.

In a number of cases, this simplifies test set up as well.