### PR TITLE
Add configuration download link to admin status page

### DIFF
--- a/app/views/admin/status/index.html.erb
+++ b/app/views/admin/status/index.html.erb
@@ -4,3 +4,7 @@
 <h3>Solr Status: <%= SolrService.current.solr_version.present? ? "connected" : "down" -%></h3>
 <h3>Solr Version: <%= SolrService.current.solr_version -%></h3>
 <h3>Users: <%= User.count -%></h3>
+
+<%= link_to('Download Config', config_url(format: :json),
+            id: 'export_config', class: 'btn btn-primary btn-sm',
+            download: "#{request&.host || 't3'}-#{Time.current.strftime("%Y%m%d%H%M%S")}.json") %>

--- a/spec/views/admin/status/index.html.erb_spec.rb
+++ b/spec/views/admin/status/index.html.erb_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe 'status/index.html.erb' do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe 'admin/status/index.html.erb' do
+  it 'has a button to download the configuration' do
+    render
+    expect(rendered).to have_link('export_config', href: config_url(format: :json), class: 'btn')
+  end
 end


### PR DESCRIPTION
Allow administrators to download the system configuration from the status page.

Currently the configuration only includes field values.