### PR TITLE
Restrict access to manage configs

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -1,7 +1,8 @@
 module Admin
   # Controller for dumping and loading singleton Config class
   class ConfigsController < ApplicationController
-    before_action :set_config, only: %i[show edit update destroy]
+    before_action :set_config, only: %i[show edit update]
+    authorize_resource
 
     # GET /configs or /configs.json
     def index

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,7 +8,7 @@ class Ability
     'Super Admin' => [:all],
     'User Manager' => [User, Role],
     'Brand Manager' => [Theme],
-    'System Manager' => [Blueprint, Field, Ingest, Item, Collection]
+    'System Manager' => [Blueprint, Field, Config, Ingest, Item, Collection]
   }.freeze
 
   def initialize(user)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Ability do
         expect(authz.can?(:read, Ingest)).to be false
         expect(authz.can?(:read, Item)).to be false
         expect(authz.can?(:read, Collection)).to be false
+        expect(authz.can?(:read, Config)).to be false
       end
     end
 
@@ -97,6 +98,10 @@ RSpec.describe Ability do
 
       it 'can manage Fields' do
         expect(authz.can?(:manage, Field)).to be true
+      end
+
+      it 'can manage Config' do
+        expect(authz.can?(:manage, Config)).to be true
       end
 
       it 'can manage Ingests' do

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe '/admin/configs' do
   # This should return the minimal set of attributes required to create a valid
   # Config. As you add validations to Config, be sure to
   # adjust the attributes here as well.
-  let(:valid_attributes) do
-    skip('Add a hash of attributes valid for your model')
-  end
+  let(:super_admin)  { FactoryBot.create(:super_admin) }
+  let(:regular_user) { FactoryBot.create(:user) }
+
+  before { login_as super_admin }
 
   describe 'GET /index' do
     it 'is not implemented' do
@@ -90,6 +91,20 @@ RSpec.describe '/admin/configs' do
       expect do
         Admin::ConfigsController.new.destroy
       end.to raise_exception(NoMethodError)
+    end
+  end
+
+  describe 'resctricts access' do
+    example 'for guest users' do
+      logout
+      get edit_config_url
+      expect(response).to be_not_found
+    end
+
+    example 'for non-admin users' do
+      login_as regular_user
+      get edit_config_url
+      expect(response).to be_unauthorized
     end
   end
 end


### PR DESCRIPTION
Only allow System Managers and Super Admins to view and update the system config.