### PR TITLE
Allow administrators to import configuration from a file

### DIFF
--- a/app/views/admin/configs/_form.html.erb
+++ b/app/views/admin/configs/_form.html.erb
@@ -12,6 +12,11 @@
   <% end %>
 
   <div>
+    <%= form.label :config_file, style: "display: block" %>
+    <%= form.file_field :config_file, name: :config_file %>
+  </div>
+
+  <div>
     <%= form.submit %>
   </div>
 <% end %>

--- a/app/views/admin/configs/edit.html.erb
+++ b/app/views/admin/configs/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Editing config</h1>
+<h1>Update config</h1>
 
 <%= render "form", config: @config %>
 

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -1,6 +1,10 @@
-<div id="<%= dom_id @config %>">
+<div id="current_config">
   <h1>System Configuration</h1>
 
-  <pre><code><%= JSON.pretty_generate(@config.settings.as_json) %>
-  </code></pre>
+  <%= link_to('Back to Status', status_path, class: 'btn btn-primary btn-sm') %>
+
+  <div id='config_json'>
+    <pre><code><%= JSON.pretty_generate(@config.settings.as_json) %>
+    </code></pre>
+  </div>
 </div>

--- a/app/views/admin/status/index.html.erb
+++ b/app/views/admin/status/index.html.erb
@@ -3,8 +3,14 @@
 <h2>&nbsp;</h2>
 <h3>Solr Status: <%= SolrService.current.solr_version.present? ? "connected" : "down" -%></h3>
 <h3>Solr Version: <%= SolrService.current.solr_version -%></h3>
-<h3>Users: <%= User.count -%></h3>
+<h3>Users: <%= link_to(User.count, users_path) -%></h3>
+<h3>Fields: <%= link_to(Field.count, fields_path) -%></h3>
+<h3>Blueprints: <%= link_to(Blueprint.count,blueprints_path) -%></h3>
 
-<%= link_to('Download Config', config_url(format: :json),
-            id: 'export_config', class: 'btn btn-primary btn-sm',
+
+<%= link_to('Download Config', config_path(format: :json),
+            id: 'export_config', class: 'btn btn-info btn-sm',
             download: "#{request&.host || 't3'}-#{Time.current.strftime("%Y%m%d%H%M%S")}.json") %>
+
+<%= link_to('Import Config', edit_config_path,
+            id: 'import_config', class: 'btn btn-outline-info btn-sm') %>

--- a/spec/models/config_spec.rb
+++ b/spec/models/config_spec.rb
@@ -1,5 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe Config do
-  pending "add some examples to (or delete) #{__FILE__}"
+  include ActiveSupport::Testing::TimeHelpers
+
+  it 'is a singleton', :aggregate_failures do
+    expect(described_class.instance).to be_present
+    expect { described_class.new }.to raise_exception(NoMethodError)
+  end
+
+  describe '.current' do
+    it 'is an alias for .instance' do
+      expect(described_class.current.object_id).to eq described_class.instance.object_id
+    end
+  end
+
+  describe '#settings' do
+    it 'returns basic context information' do
+      travel_to Time.utc(2023, 0o3, 30, 16, 49, 44) do
+        expect(described_class.current.settings)
+          .to include(context: a_hash_including(description: 'T3 Configuration export',
+                                                timestamp: '2023-03-30T16:49:44Z'))
+      end
+    end
+
+    it 'returns the current fields' do
+      field = FactoryBot.create(:field)
+      expect(described_class.current.settings)
+        .to include(fields: a_collection_including(field))
+    end
+  end
 end

--- a/spec/views/admin/configs/edit.html.erb_spec.rb
+++ b/spec/views/admin/configs/edit.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'configs/edit' do
+RSpec.describe 'admin/configs/edit' do
   let(:config) do
     Config.current
   end
@@ -10,6 +10,17 @@ RSpec.describe 'configs/edit' do
   end
 
   it 'renders the edit config form' do
-    skip 'implement an upload feature'
+    render
+    expect(rendered).to have_selector("form[@action='#{config_path}']")
+  end
+
+  it 'accepts a json file' do
+    render
+    expect(rendered).to have_field('config_file')
+  end
+
+  it 'has a submit button' do
+    render
+    expect(rendered).to have_button(type: 'submit')
   end
 end

--- a/spec/views/admin/status/index.html.erb_spec.rb
+++ b/spec/views/admin/status/index.html.erb_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe 'admin/status/index.html.erb' do
   it 'has a button to download the configuration' do
     render
-    expect(rendered).to have_link('export_config', href: config_url(format: :json), class: 'btn')
+    expect(rendered).to have_link('export_config', href: config_path(format: :json), class: 'btn')
+  end
+
+  it 'has a button to import the configuration from a file' do
+    render
+    expect(rendered).to have_link('import_config', href: edit_config_path, class: 'btn')
   end
 end


### PR DESCRIPTION
Add the necessary user interface links to allow Super Admins and System Managers to import the Field configuration from a file.

The file is typically generated by exporting the configuration from another instance.

Currently, the feature only imports Fields. Themes and Blueprints must be added manually when setting up a new server.