### PR TITLE
Highlight the "Status" section when displaying Config pages

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -4,6 +4,10 @@ module Admin
     before_action :set_config, only: %i[show edit update]
     authorize_resource
 
+    def self.menu_group
+      Status
+    end
+
     # GET /configs or /configs.json
     def index
       # We're explicitly raising an error here to make it obvious that we don't want to

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,17 @@ class ApplicationController < ActionController::Base
       end
   end
 
+  # Returns the class name associated with the controller
+  # override the class method if you want a controller to group in a different navigation section
+  def self.menu_group
+    @menu_group ||= controller_name.singularize.classify.constantize
+  end
+
+  # Delegates to the class's ::menu_group
+  def menu_group
+    self.class.menu_group
+  end
+
   private
 
   def append_info_to_payload(payload)

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -3,6 +3,6 @@ module AdminHelper
   # Dynamically set admin sidebar link active class
   # @param [Class] menu_area the class being linked to
   def active_class(menu_area)
-    'active' if menu_area.model_name.plural == controller_name
+    'active' if menu_area == controller.menu_group
   end
 end

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -2,13 +2,15 @@ require 'rails_helper'
 
 RSpec.describe AdminHelper do
   describe '#active_class' do
+    let(:users_controller) { Admin::UsersController.new }
+
     it 'returns "active" when the controller name equals the passed string' do
-      allow(self).to receive(:controller_name).and_return('users')
+      allow(self).to receive(:controller).and_return(users_controller)
       expect(active_class(User)).to eq 'active'
     end
 
     it 'returns nil otherwise' do
-      allow(self).to receive(:controller_name).and_return('users')
+      allow(self).to receive(:controller).and_return(users_controller)
       expect(active_class(Role)).to be_nil
     end
   end

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -23,7 +23,13 @@ RSpec.describe '/admin/configs' do
       expect(response).to be_successful
     end
 
-    it 'renders as json' do
+    it 'appears under the status navigation menu' do
+      get config_url
+      page = Capybara.string(response.body)
+      expect(page).to have_link(href: status_path, class: 'nav-link active')
+    end
+
+    it 'can render as json' do
       get config_url(format: :json)
       json = response.parsed_body
       expect(json).to include(


### PR DESCRIPTION
This change allows us to override the menu section that should be highlighted when displaying pages for a particular controller.

We use this functionality to allow us to highlight the "Status" section of the dashboard navigation menu when diplaying or editing the Configuration settings.