### PR TITLE
Add a basic model for controlled vocabularies

### DIFF
--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -1,0 +1,8 @@
+# Controlled Vocabulary
+class Vocabulary < ApplicationRecord
+  validates :name, presence: true
+  validates :name, uniqueness: { case_sensitive: false, message: '"%<value>s" is already in use' }
+  validates :name, format: { with: /\A([a-z0-9](_|-)?)+\z/i,
+                             message: '"%<value>s" can only contain letters and numbers, ' \
+                                      'separated by single underscores or dashes' }
+end

--- a/db/migrate/20240624220344_create_vocabularies.rb
+++ b/db/migrate/20240624220344_create_vocabularies.rb
@@ -1,0 +1,10 @@
+class CreateVocabularies < ActiveRecord::Migration[7.1]
+  def change
+    create_table :vocabularies do |t|
+      t.string :name, index: { unique: true }
+      t.string :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_11_174159) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_24_220344) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -185,6 +185,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_11_174159) do
     t.index ["provider"], name: "index_users_on_provider"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid"], name: "index_users_on_uid"
+  end
+
+  create_table "vocabularies", force: :cascade do |t|
+    t.string "name"
+    t.string "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_vocabularies_on_name", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/factories/vocabularies.rb
+++ b/spec/factories/vocabularies.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :vocabulary do
+    name { Faker::Lorem.unique.words.join('_') }
+    description { 'A vocaublary for use when testing' }
+  end
+end

--- a/spec/models/vocabulary_spec.rb
+++ b/spec/models/vocabulary_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Vocabulary do
+  let(:vocab) { FactoryBot.build(:vocabulary) }
+
+  describe '#name' do
+    it 'is required' do
+      vocab.name = nil
+      vocab.validate
+      expect(vocab.errors.where(:name, :blank)).to be_present
+    end
+
+    it 'must be unique (case insensitive)' do
+      vocab.name = 'My_TEST_Vocabulary'
+      vocab.save!
+      another = FactoryBot.build(:vocabulary, name: 'my_test_vocabulary')
+      another.validate
+      expect(another.errors.where(:name, :taken)).to be_present
+    end
+
+    it 'can only contain alphanumerics, dashes, or underscores' do
+      vocab.name = 'invalid^chars'
+      vocab.validate
+      expect(vocab.errors.where(:name, :invalid)).to be_present
+    end
+  end
+
+  describe '#description' do
+    it 'is optional' do
+      vocab.description = nil
+      expect(vocab).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
This commit begins the scaffolding for administrator managed controlled vocabularies.