### PR TITLE
Store a URL-friendly 'slug' for each vocabulary

### DIFF
--- a/app/controllers/admin/vocabularies_controller.rb
+++ b/app/controllers/admin/vocabularies_controller.rb
@@ -66,7 +66,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def vocabulary_params
-      params.require(:vocabulary).permit(:name, :description)
+      params.require(:vocabulary).permit(:name, :description, :slug)
     end
   end
 end

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -2,11 +2,27 @@
 class Vocabulary < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: { case_sensitive: false, message: '"%<value>s" is already in use' }
-  validates :name, format: { with: /\A([a-z0-9](_|-)?)+\z/i,
-                             message: '"%<value>s" can only contain letters and numbers, ' \
-                                      'separated by single underscores or dashes' }
+
+  validates :slug, presence: true
+  validates :slug, uniqueness: { case_sensitive: false, message: '"%<value>s" is already in use' }
+  validates :slug, format: { with: /\A([[:lower:]]+-?)+[[:lower:]]\z/i,
+                             message: '"%<value>s" can only contain letters, ' \
+                                      'separated by single dashes' }
+
+  before_validation :set_slug
 
   def to_partial_path
     'admin/'.concat(super)
+  end
+
+  private
+
+  # Set the slug attribute if it is blank
+  # slugs are a url-friendly version of the name with the following characteristics
+  # * lovercase only
+  # * alphabetic characters only
+  # * whitespace and other characters collapsed into single underscores
+  def set_slug
+    self.slug ||= name&.gsub('_', '-')&.parameterize
   end
 end

--- a/db/migrate/20240625221515_add_slug_to_vocabularies.rb
+++ b/db/migrate/20240625221515_add_slug_to_vocabularies.rb
@@ -1,0 +1,7 @@
+class AddSlugToVocabularies < ActiveRecord::Migration[7.1]
+  def change
+    enable_extension :citext
+    add_column :vocabularies, :slug, :citext
+    add_index :vocabularies, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_24_220344) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_25_221515) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -192,7 +193,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_24_220344) do
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.citext "slug"
     t.index ["name"], name: "index_vocabularies_on_name", unique: true
+    t.index ["slug"], name: "index_vocabularies_on_slug", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/factories/vocabularies.rb
+++ b/spec/factories/vocabularies.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :vocabulary do
-    name { Faker::Lorem.unique.words.join('_') }
+    name { Faker::Lorem.unique.words.join(' ').titleize }
     description { 'A vocaublary for use when testing' }
   end
 end

--- a/spec/models/vocabulary_spec.rb
+++ b/spec/models/vocabulary_spec.rb
@@ -17,11 +17,37 @@ RSpec.describe Vocabulary do
       another.validate
       expect(another.errors.where(:name, :taken)).to be_present
     end
+  end
 
-    it 'can only contain alphanumerics, dashes, or underscores' do
-      vocab.name = 'invalid^chars'
+  describe '#slug' do
+    it 'is required' do
+      # Temporarily stub method that ensures slug is set before validations
+      allow(vocab).to receive(:set_slug)
+
+      vocab.slug = nil
       vocab.validate
-      expect(vocab.errors.where(:name, :invalid)).to be_present
+      expect(vocab.errors.where(:slug, :blank)).to be_present
+    end
+
+    it 'gets set from the name when missing' do
+      vocab.name = 'Kontrollü Terimler -- Sözlük!'
+      vocab.slug = nil
+      vocab.save!
+      expect(vocab.slug).to eq 'kontrollu-terimler-sozluk'
+    end
+
+    it 'must be unique' do
+      vocab.slug = 'my-test-vocabulary'
+      vocab.save!
+      another = FactoryBot.build(:vocabulary, slug: 'my-test-vocabulary')
+      another.validate
+      expect(another.errors.where(:slug, :taken)).to be_present
+    end
+
+    it 'can only contain letters or dashes' do
+      vocab.slug = '5 invalid^chars__OH_No!'
+      vocab.validate
+      expect(vocab.errors.where(:slug, :invalid)).to be_present
     end
   end
 

--- a/spec/requests/admin/vocabularies_spec.rb
+++ b/spec/requests/admin/vocabularies_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe '/admin/vocabularies' do
   # Vocabulary. As you add validations to Vocabulary, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) { FactoryBot.attributes_for(:vocabulary) }
-  let(:invalid_attributes) { { name: '<Invalid Vocabulary!>' } }
+  let(:invalid_attributes) { { slug: '<Invalid $lug!>' } }
   let(:super_admin)  { FactoryBot.create(:super_admin) }
   let(:regular_user) { FactoryBot.create(:user) }
 
@@ -85,14 +85,14 @@ RSpec.describe '/admin/vocabularies' do
   describe 'PATCH /update' do
     context 'with valid parameters' do
       let(:new_attributes) do
-        { name: 'updated_vocabulary_name' }
+        { name: 'Updated Vocabulary Name' }
       end
 
       it 'updates the requested vocabulary' do
         vocabulary = Vocabulary.create! valid_attributes
         patch vocabulary_url(vocabulary), params: { vocabulary: new_attributes }
         vocabulary.reload
-        expect(vocabulary.name).to eq 'updated_vocabulary_name'
+        expect(vocabulary.name).to eq 'Updated Vocabulary Name'
       end
 
       it 'redirects to the vocabulary' do


### PR DESCRIPTION
**ISSUE**
We want to reference vocabularies by a user-friendly (semantic) URL instead of using an opaque ID in the URL. As a first step, this commit generates and stores a "slug" for each Vocabulary based on it's name.