### PR TITLE
Use slugs instead of ids in Vocabulary routes

### DIFF
--- a/app/controllers/admin/vocabularies_controller.rb
+++ b/app/controllers/admin/vocabularies_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   # Coordinate creation and management of controlled vocabularies
   class VocabulariesController < ApplicationController
-    before_action :set_vocabulary, only: %i[show edit update destroy]
+    load_and_authorize_resource(find_by: :slug, id_param: :slug)
 
     # GET /admin/vocabularies or /admin/vocabularies.json
     def index
@@ -59,14 +59,9 @@ module Admin
 
     private
 
-    # Use callbacks to share common setup or constraints between actions.
-    def set_vocabulary
-      @vocabulary = Vocabulary.find(params[:id])
-    end
-
     # Only allow a list of trusted parameters through.
     def vocabulary_params
-      params.require(:vocabulary).permit(:name, :description, :slug)
+      params.require(:vocabulary).permit(:name, :slug, :description)
     end
   end
 end

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -11,6 +11,10 @@ class Vocabulary < ApplicationRecord
 
   before_validation :set_slug
 
+  def to_param
+    slug
+  end
+
   def to_partial_path
     'admin/'.concat(super)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
     resources :fields do
       patch 'move', on: :member
     end
-    resources :vocabularies
+    resources :vocabularies, param: :slug
     resources :themes do
       patch 'activate', on: :member
     end

--- a/db/migrate/20240626170147_populate_slugs_in_vocabularies.rb
+++ b/db/migrate/20240626170147_populate_slugs_in_vocabularies.rb
@@ -1,0 +1,15 @@
+class PopulateSlugsInVocabularies < ActiveRecord::Migration[7.1]
+  def up
+    # Ensure each vocabluary has a valid slug
+    Vocabulary.all.each do |vocabulary|
+      # Calling the validation will populate the slug if it's missing
+      if vocabulary.invalid?
+        # If the validation fails (presumably because the name can't be converted into a valid tag),
+        # Create a tag based on only the alpha characters in the name
+        # adding a prefix to flag and disambiguate the new slugs
+        vocabulary.tag = vocabulary.name.gsub(/[^[[:alpha:]] -]/, '-').parameterize.prepend('migrated-')
+      end
+      vocabulary.save! # will save if the tag has been updated through validation or explicit assignment
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_25_221515) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_26_170147) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"

--- a/spec/requests/admin/vocabularies_spec.rb
+++ b/spec/requests/admin/vocabularies_spec.rb
@@ -130,13 +130,13 @@ RSpec.describe '/admin/vocabularies' do
   describe 'resctricts access' do
     example 'for guest users' do
       logout
-      get ingests_url
+      get vocabularies_url
       expect(response).to be_not_found
     end
 
     example 'for non-admin users' do
       login_as regular_user
-      get ingests_url
+      get vocabularies_url
       expect(response).to be_unauthorized
     end
   end

--- a/spec/routing/admin/vocabularies_routing_spec.rb
+++ b/spec/routing/admin/vocabularies_routing_spec.rb
@@ -11,11 +11,12 @@ RSpec.describe Admin::VocabulariesController do
     end
 
     it 'routes to #show' do
-      expect(get: '/admin/vocabularies/1').to route_to('admin/vocabularies#show', id: '1')
+      expect(get: '/admin/vocabularies/my-vocabulary').to route_to('admin/vocabularies#show', slug: 'my-vocabulary')
     end
 
     it 'routes to #edit' do
-      expect(get: '/admin/vocabularies/1/edit').to route_to('admin/vocabularies#edit', id: '1')
+      expect(get: '/admin/vocabularies/my-vocabulary/edit').to route_to('admin/vocabularies#edit',
+                                                                        slug: 'my-vocabulary')
     end
 
     it 'routes to #create' do
@@ -23,15 +24,16 @@ RSpec.describe Admin::VocabulariesController do
     end
 
     it 'routes to #update via PUT' do
-      expect(put: '/admin/vocabularies/1').to route_to('admin/vocabularies#update', id: '1')
+      expect(put: '/admin/vocabularies/my-vocabulary').to route_to('admin/vocabularies#update', slug: 'my-vocabulary')
     end
 
     it 'routes to #update via PATCH' do
-      expect(patch: '/admin/vocabularies/1').to route_to('admin/vocabularies#update', id: '1')
+      expect(patch: '/admin/vocabularies/my-vocabulary').to route_to('admin/vocabularies#update', slug: 'my-vocabulary')
     end
 
     it 'routes to #destroy' do
-      expect(delete: '/admin/vocabularies/1').to route_to('admin/vocabularies#destroy', id: '1')
+      expect(delete: '/admin/vocabularies/my-vocabulary').to route_to('admin/vocabularies#destroy',
+                                                                      slug: 'my-vocabulary')
     end
   end
 end


### PR DESCRIPTION
This change updates routing and controller logic to use slugs, e.g. "resource-type", instead of ids, e.g. "3" when displaying Vocabulary URLS.

This commit also includes a migration that populates slugs for any Vocabulary records that were initially created without a slug.