### PR TITLE
Add User Interface for managing terms

### DIFF
--- a/app/controllers/admin/terms_controller.rb
+++ b/app/controllers/admin/terms_controller.rb
@@ -1,0 +1,85 @@
+module Admin
+  # Manage terms within a vocabulary
+  class TermsController < ApplicationController
+    before_action :set_vocabulary
+    before_action :set_term, only: %i[show edit update destroy]
+    authorize_resource
+
+    def self.menu_group
+      Vocabulary
+    end
+
+    # GET /admin/terms or /admin/terms.json
+    def index
+      @terms = @vocabulary.terms.order(:slug)
+    end
+
+    # GET /admin/terms/1 or /admin/terms/1.json
+    def show; end
+
+    # GET /admin/terms/new
+    def new
+      @term = Term.new(vocabulary: @vocabulary)
+    end
+
+    # GET /admin/terms/1/edit
+    def edit; end
+
+    # POST /admin/terms or /admin/terms.json
+    def create
+      @term = Term.new(term_params)
+
+      respond_to do |format|
+        if @term.save
+          format.html { redirect_to term_url(@term), notice: 'Term was successfully created.' }
+          format.json { render :show, status: :created, location: @term }
+        else
+          format.html { render :new, status: :unprocessable_entity }
+          format.json { render json: @term.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    # PATCH/PUT /admin/terms/1 or /admin/terms/1.json
+    def update
+      respond_to do |format|
+        if @term.update(term_params)
+          format.html { redirect_to term_url(@term), notice: 'Term was successfully updated.' }
+          format.json { render :show, status: :ok, location: @term }
+        else
+          format.html { render :edit, status: :unprocessable_entity }
+          format.json { render json: @term.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    # DELETE /admin/terms/1 or /admin/terms/1.json
+    def destroy
+      @term.destroy!
+
+      respond_to do |format|
+        format.html do
+          redirect_to vocabulary_terms_url(@vocabulary),
+                      notice: "Term '#{@term.label}' was successfully destroyed."
+        end
+        format.json { head :no_content }
+      end
+    end
+
+    private
+
+    # Use callbacks to share common setup or constraints between actions.
+    def set_vocabulary
+      @vocabulary = Vocabulary.find_by(slug: params[:vocabulary_slug])
+    end
+
+    def set_term
+      @term = @vocabulary.terms.find_by(slug: params[:slug])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def term_params
+      params.require(:term).permit(:vocabulary_id, :label, :slug, :value, :note)
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,7 +8,7 @@ class Ability
     'Super Admin' => [:all],
     'User Manager' => [User, Role],
     'Brand Manager' => [Theme],
-    'System Manager' => [Blueprint, Field, Config, Ingest, Item, Collection, Vocabulary]
+    'System Manager' => [Blueprint, Field, Config, Ingest, Item, Collection, Vocabulary, Term]
   }.freeze
 
   def initialize(user)

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -12,6 +12,10 @@ class Term < ApplicationRecord
 
   before_validation :set_slug
 
+  def to_param
+    slug
+  end
+
   def to_partial_path
     'admin/'.concat(super)
   end
@@ -19,6 +23,6 @@ class Term < ApplicationRecord
   private
 
   def set_slug
-    self.slug ||= label&.parameterize
+    self.slug = label&.parameterize if slug.blank?
   end
 end

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -28,6 +28,6 @@ class Vocabulary < ApplicationRecord
   # * alphabetic characters only
   # * whitespace and other characters collapsed into single underscores
   def set_slug
-    self.slug ||= name&.gsub('_', '-')&.parameterize
+    self.slug = name&.gsub('_', '-')&.parameterize if slug.blank?
   end
 end

--- a/app/views/admin/terms/_form.html.erb
+++ b/app/views/admin/terms/_form.html.erb
@@ -1,0 +1,43 @@
+<%= form_with(model: term, url: term_path(term)) do |form| %>
+  <% if term.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(term.errors.count, "error") %> prohibited this term from being saved:</h2>
+
+      <ul>
+        <% term.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :vocabulary, style: "display: block" %>
+    <%= form.hidden_field :vocabulary_id, value: term.vocabulary.id %>
+    <%= form.text_field term.vocabulary.name, disabled: true %>
+  </div>
+
+  <div>
+    <%= form.label :label, style: "display: block" %>
+    <%= form.text_field :label %>
+  </div>
+
+  <div>
+    <%= form.label :slug, style: "display: block" %>
+    <%= form.text_field :slug %>
+  </div>
+
+  <div>
+    <%= form.label :value, style: "display: block" %>
+    <%= form.text_field :value %>
+  </div>
+
+  <div>
+    <%= form.label :note, style: "display: block" %>
+    <%= form.text_field :note %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/terms/_term.html.erb
+++ b/app/views/admin/terms/_term.html.erb
@@ -1,0 +1,19 @@
+<div id="<%= dom_id term %>">
+  <div class="row term">
+    <div class="col tools">
+      <%= link_to("Show", [term.vocabulary, term]) if action_name == 'index' %>
+    </div>
+    <div class="col term_label">
+      <%= term.label %>
+    </div>
+    <div class="col term_slug">
+      <%= term.slug %>
+    </div>
+    <div class="col term_value">
+      <%= term.value %>
+    </div>
+    <div class="col term_note">
+      <%= term.note %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/terms/_vocabulary_term.json.jbuilder
+++ b/app/views/admin/terms/_vocabulary_term.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! term, :id, :vocabulary_id, :label, :slug, :value, :note, :created_at, :updated_at
+json.url term_url(term, format: :json)

--- a/app/views/admin/terms/edit.html.erb
+++ b/app/views/admin/terms/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Editing term</h1>
+
+<%= render "form", term: @term %>
+
+<br>
+
+<div>
+  <%= link_to "Show this term", [@term.vocabulary, @term] %> |
+  <%= link_to "Back to terms", vocabulary_terms_path(@term.vocabulary) %>
+</div>

--- a/app/views/admin/terms/index.html.erb
+++ b/app/views/admin/terms/index.html.erb
@@ -1,0 +1,27 @@
+<div id="terms">
+  <h1 id="vocabulary_name"><%= @vocabulary.name %></h1>
+  <h2>Vocabulary Terms</h2>
+
+
+  <div id='terms_headers' class="row term_header">
+    <div class="col tools">
+    </div>
+    <div class="col term_label">
+      <strong>Label</strong>
+    </div>
+    <div class="col term_slug">
+      <strong>Slug</strong>
+    </div>
+    <div class="col term_value">
+      <strong>Value</strong>
+    </div>
+    <div class="col term_note">
+      <strong>Note</strong>
+    </div>
+  </div>
+  <% @terms.each do |term| %>
+    <%= render term %>
+  <% end %>
+
+  <%= link_to "New term", new_vocabulary_term_path %>
+</div>

--- a/app/views/admin/terms/index.json.jbuilder
+++ b/app/views/admin/terms/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @terms, partial: 'terms/term', as: :term

--- a/app/views/admin/terms/new.html.erb
+++ b/app/views/admin/terms/new.html.erb
@@ -1,0 +1,9 @@
+<h1>New term</h1>
+
+<%= render "form", term: @term %>
+
+<br>
+
+<div>
+  <%= link_to "Back to terms", vocabulary_terms_path(@term.vocabulary) %>
+</div>

--- a/app/views/admin/terms/show.html.erb
+++ b/app/views/admin/terms/show.html.erb
@@ -1,0 +1,13 @@
+<div id="<%= dom_id(@term) -%>" class="term">
+    <h1 id="vocabulary_name"><%= @vocabulary.name -%></h1>
+    <h2 id="term_label"><%= @term.label -%></h2>
+  <%= render @term %>
+
+  <div>
+    <%= link_to "Edit this term", edit_term_path(@term) %> |
+    <%= link_to "Back to terms", vocabulary_terms_path(@term.vocabulary) %>
+
+    <%= button_to "Destroy this term", [@term.vocabulary, @term], method: :delete %>
+  </div>
+</div>
+

--- a/app/views/admin/terms/show.json.jbuilder
+++ b/app/views/admin/terms/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'terms/term', term: @term

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,9 @@ Rails.application.routes.draw do
     resources :fields do
       patch 'move', on: :member
     end
-    resources :vocabularies, param: :slug
+    resources :vocabularies, param: :slug do
+      resources :terms, param: :slug
+    end
     resources :themes do
       patch 'activate', on: :member
     end
@@ -52,6 +54,20 @@ Rails.application.routes.draw do
     resource :config, only: %i[show edit update]
   end
   resolve('Config') { [:config] }
+
+  direct :term do |term|
+    if term.slug
+      { controller: 'admin/terms', action: :show, vocabulary_slug: term.vocabulary.slug, slug: term.slug }
+    else
+      { controller: 'admin/terms', vocabulary_slug: term.vocabulary }
+    end
+  end
+  direct :edit_term do |term|
+    { controller: 'admin/terms', action: :edit, vocabulary_slug: term.vocabulary.slug, slug: term.slug }
+  end
+  direct :terms do |term|
+    { controller: 'admin/terms', vocabulary_slug: term.vocabulary }
+  end
 
   # When app is firt booted and no Solr config exists, use this as the application root
   # We'll generally only need this route once or twice, so we're placing it at the bottom

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Ability do
         expect(authz.can?(:read, Collection)).to be false
         expect(authz.can?(:read, Config)).to be false
         expect(authz.can?(:read, Vocabulary)).to be false
+        expect(authz.can?(:read, Term)).to be false
       end
     end
 
@@ -71,6 +72,10 @@ RSpec.describe Ability do
 
       it 'cannot manage Items' do
         expect(authz.can?(:read, Item)).to be false
+      end
+
+      it 'cannot manage Terms' do
+        expect(authz.can?(:read, Term)).to be false
       end
     end
 
@@ -123,6 +128,10 @@ RSpec.describe Ability do
 
       it 'can manage Vocabularies' do
         expect(authz.can?(:manage, Vocabulary)).to be true
+      end
+
+      it 'can manage Terms' do
+        expect(authz.can?(:manage, Term)).to be true
       end
 
       it 'can read dashboard' do

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Term do
 
     it 'is set from the label when blank' do
       term.label = 'First Term in Vocabulary'
-      term.slug = nil
+      term.slug = ''
       term.validate
       expect(term.slug).to eq 'first-term-in-vocabulary'
     end
@@ -57,6 +57,12 @@ RSpec.describe Term do
       term.slug = 'Invalid (Slug) with spaces & special characters'
       term.validate
       expect(term.errors.where(:slug, :invalid)).to be_present
+    end
+  end
+
+  describe '#to_param' do
+    it 'returns the slug' do
+      expect(term.to_param).to eq term.slug
     end
   end
 end

--- a/spec/models/vocabulary_spec.rb
+++ b/spec/models/vocabulary_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Vocabulary do
 
     it 'gets set from the name when missing' do
       vocab.name = 'Kontrollü Terimler -- Sözlük!'
-      vocab.slug = nil
+      vocab.slug = ''
       vocab.save!
       expect(vocab.slug).to eq 'kontrollu-terimler-sozluk'
     end
@@ -85,6 +85,12 @@ RSpec.describe Vocabulary do
         vocab.validate
         expect(vocab.errors.where(:slug, :invalid)).to be_present
       end
+    end
+  end
+
+  describe '#to_param' do
+    it 'returns the slug' do
+      expect(vocab.to_param).to eq vocab.slug
     end
   end
 

--- a/spec/requests/admin/terms_spec.rb
+++ b/spec/requests/admin/terms_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/terms' do
+  let(:test_vocab) { Vocabulary.find_or_create_by(name: 'Admin/Terms Test Vocabulary') }
+  let(:valid_attributes) { FactoryBot.attributes_for(:term, vocabulary_id: test_vocab.id) }
+  let(:invalid_attributes) do
+    FactoryBot.attributes_for(:term, vocabulary_id: test_vocab.id, slug: '<Invalid $lug!>')
+  end
+  let(:super_admin)  { FactoryBot.create(:super_admin) }
+  let(:regular_user) { FactoryBot.create(:user) }
+
+  before { login_as super_admin }
+
+  describe 'GET /index' do
+    it 'renders a successful response' do
+      Term.create! valid_attributes
+      get vocabulary_terms_url(test_vocab)
+      expect(response).to be_successful
+    end
+
+    it 'appears under the status navigation menu' do
+      get vocabulary_terms_url(test_vocab)
+      page = Capybara.string(response.body)
+      expect(page).to have_link(href: vocabularies_path, class: 'nav-link active')
+    end
+  end
+
+  describe 'GET /show' do
+    it 'renders a successful response' do
+      term = Term.create! valid_attributes
+      get term_url(term)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /new' do
+    it 'renders a successful response' do
+      get new_vocabulary_term_url(test_vocab)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET /edit' do
+    it 'renders a successful response' do
+      term = Term.create! valid_attributes
+      get edit_term_url(term)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    context 'with valid parameters' do
+      it 'creates a new Term' do
+        expect do
+          post vocabulary_terms_url(test_vocab), params: { term: valid_attributes }
+        end.to change(Term, :count).by(1)
+      end
+
+      it 'redirects to the created term' do
+        post vocabulary_terms_url(test_vocab), params: { term: valid_attributes }
+        expect(response).to redirect_to(term_url(Term.last))
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new Term' do
+        expect do
+          post vocabulary_terms_url(test_vocab), params: { term: invalid_attributes }
+        end.not_to change(Term, :count)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        post vocabulary_terms_url(test_vocab), params: { term: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /update' do
+    context 'with valid parameters' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:new_attributes) do
+        { note: 'Usage notes go here...' }
+      end
+
+      it 'updates the requested term' do
+        term = Term.create! valid_attributes
+        patch term_url(term), params: { term: new_attributes }
+        term.reload
+        expect(term.note).to eq 'Usage notes go here...'
+      end
+
+      it 'redirects to the term' do
+        term = Term.create! valid_attributes
+        patch term_url(term), params: { term: new_attributes }
+        term.reload
+        expect(response).to redirect_to(term_url(term))
+      end
+    end
+
+    context 'with invalid parameters' do
+      let(:invalid_attributes) { { slug: '<Invalid $lug!>' } }
+
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        term = Term.create! valid_attributes
+        patch term_url(term), params: { term: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the requested term' do
+      term = Term.create! valid_attributes
+      expect do
+        delete term_url(term)
+      end.to change(Term, :count).by(-1)
+    end
+
+    it 'redirects to the terms list' do
+      term = Term.create! valid_attributes
+      delete term_url(term)
+      expect(response).to redirect_to(vocabulary_terms_url(test_vocab))
+    end
+  end
+
+  describe 'resctricts access' do
+    example 'for guest users' do
+      logout
+      get vocabulary_terms_url(test_vocab)
+      expect(response).to be_not_found
+    end
+
+    example 'for non-admin users' do
+      login_as regular_user
+      get vocabulary_terms_url(test_vocab)
+      expect(response).to be_unauthorized
+    end
+  end
+end

--- a/spec/routing/admin/terms_routing_spec.rb
+++ b/spec/routing/admin/terms_routing_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Admin::TermsController do
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: '/admin/vocabularies/my-vocab/terms')
+        .to route_to('admin/terms#index', vocabulary_slug: 'my-vocab')
+    end
+
+    it 'routes to #new' do
+      expect(get: '/admin/vocabularies/my-vocab/terms/new')
+        .to route_to('admin/terms#new', vocabulary_slug: 'my-vocab')
+    end
+
+    it 'routes to #show' do
+      expect(get: '/admin/vocabularies/my-vocab/terms/first-term')
+        .to route_to('admin/terms#show', vocabulary_slug: 'my-vocab', slug: 'first-term')
+    end
+
+    it 'routes to #edit' do
+      expect(get: '/admin/vocabularies/my-vocab/terms/first-term/edit')
+        .to route_to('admin/terms#edit', vocabulary_slug: 'my-vocab', slug: 'first-term')
+    end
+
+    it 'routes to #create' do
+      expect(post: '/admin/vocabularies/my-vocab/terms')
+        .to route_to('admin/terms#create', vocabulary_slug: 'my-vocab')
+    end
+
+    it 'routes to #update via PUT' do
+      expect(put: '/admin/vocabularies/my-vocab/terms/first-term')
+        .to route_to('admin/terms#update', vocabulary_slug: 'my-vocab', slug: 'first-term')
+    end
+
+    it 'routes to #update via PATCH' do
+      expect(patch: '/admin/vocabularies/my-vocab/terms/first-term')
+        .to route_to('admin/terms#update', vocabulary_slug: 'my-vocab', slug: 'first-term')
+    end
+
+    it 'routes to #destroy' do
+      expect(delete: '/admin/vocabularies/my-vocab/terms/first-term')
+        .to route_to('admin/terms#destroy', vocabulary_slug: 'my-vocab', slug: 'first-term')
+    end
+  end
+end

--- a/spec/views/admin/terms/edit.html.erb_spec.rb
+++ b/spec/views/admin/terms/edit.html.erb_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/terms/edit' do
+  let(:vocabulary) { FactoryBot.create(:vocabulary) }
+  let(:term) { FactoryBot.build(:term, vocabulary: vocabulary, value: 'forty_two', note: 'usage note') }
+
+  before do
+    term.validate # use #validate to set the slug
+    assign(:term, term)
+    assign(:vocabulary, vocabulary)
+    request.path_parameters[:vocabulary_slug] = vocabulary.slug
+    request.path_parameters[:slug] = term.slug
+  end
+
+  it 'renders the expected form fields', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    render
+    form = Capybara.string(rendered).find("form[action=\"#{term_path(term)}\"][method=\"post\"]")
+    expect(form).to have_field('term_label', with: term.label)
+    expect(form).to have_field('term_slug', with: term.slug)
+    expect(form).to have_field('term_value', with: term.value)
+    expect(form).to have_field('term_note', with: term.note)
+    expect(form).to have_button(type: 'submit')
+  end
+end

--- a/spec/views/admin/terms/index.html.erb_spec.rb
+++ b/spec/views/admin/terms/index.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/terms/index' do
+  let(:vocabulary) { FactoryBot.create(:vocabulary) }
+  let(:terms) { FactoryBot.build_list(:term, 3, vocabulary: vocabulary) }
+
+  before do
+    assign(:terms, terms)
+    assign(:vocabulary, vocabulary)
+    request.path_parameters[:vocabulary_slug] = vocabulary.slug
+  end
+
+  it 'renders a list of vocabulary/terms' do
+    render
+    expect(rendered).to have_selector('div.term div.term_label', count: 3)
+  end
+
+  it 'displays the vocabulary name' do
+    render
+    expect(rendered).to have_selector('#vocabulary_name', text: vocabulary.name)
+  end
+end

--- a/spec/views/admin/terms/new.html.erb_spec.rb
+++ b/spec/views/admin/terms/new.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/terms/new' do
+  let(:vocabulary) { FactoryBot.create(:vocabulary) }
+  let(:term) { Term.new(vocabulary: vocabulary) }
+
+  before do
+    assign(:term, term)
+    assign(:vocabulary, vocabulary)
+    request.path_parameters[:vocabulary_slug] = vocabulary.slug
+  end
+
+  it 'renders the expected form fields', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    render
+    form = Capybara.string(rendered).find("form[action=\"#{vocabulary_terms_path(vocabulary)}\"][method=\"post\"]")
+    expect(form).to have_field('term_label')
+    expect(form).to have_field('term_slug')
+    expect(form).to have_field('term_value')
+    expect(form).to have_field('term_note')
+    expect(form).to have_button(type: 'submit')
+  end
+end

--- a/spec/views/admin/terms/show.html.erb_spec.rb
+++ b/spec/views/admin/terms/show.html.erb_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'admin/terms/show' do
+  let(:vocabulary) { FactoryBot.create(:vocabulary) }
+  let(:term) { FactoryBot.build(:term, vocabulary: vocabulary, value: 'forty_two', note: 'usage note') }
+
+  before do
+    term.validate # use #validate to set the slug
+    assign(:term, term)
+    assign(:vocabulary, vocabulary)
+    request.path_parameters[:vocabulary_slug] = vocabulary.slug
+    request.path_parameters[:slug] = term.slug
+  end
+
+  it 'displays the vocabulary name' do
+    render
+    expect(rendered).to have_selector('#vocabulary_name', text: vocabulary.name)
+  end
+
+  it 'displays other attributes' do
+    render
+    expect(rendered).to have_selector('div.term div.term_label', text: term.label)
+  end
+end


### PR DESCRIPTION
The interface comes largely from scaffold generators, so it's functional but perhaps not pretty.

Basic vocabulary and term management functions are supported including creating, editing, and deleting of vocabularies and the terms within them.

Terms are always managed within the context of a specific vocabulary. This means that the same term can exist within different vocabularies, but a single vocabulary may not contain duplicate terms.

URLs for vocabularies and terms use human-friendly slugs instead of opaque identifiers to identify objects.

This means that URLs for terms always include the corresponding vocabulary slug in their path.  e.g.

```
/vocabularies/resource-types/term/thesis-or-dissertation
/vocabularies/submission-class/terms/thesis-or-dissertation
```

Under-the-hood, objects still use traditional numeric identifiers, but all route processing is based on the human-friendly slug.