### PR TITLE
Include Vocabularies and Terms in configuration exports

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -10,15 +10,13 @@ class Config
     instance
   end
 
+  # rubocop:disable Layout/HashAlignment:
   def settings
-    { context: {
-        description: 'T3 Configuration export',
-        host: Certbot::V2::Client.default_host,
-        timestamp: Time.current.iso8601,
-        field_count: Field.count
-      },
-      fields: Field.in_sequence }
+    { context:      context_for_export,
+      fields:       Field.in_sequence,
+      vocabularies: vocabularies_for_export }
   end
+  # rubocop:enable Layout/HashAlignment:
 
   # treat the config as always being persisted
   # to support form helpers
@@ -31,6 +29,27 @@ class Config
     import_fields = data['fields']
 
     create_or_update_fields(import_fields)
+  end
+
+  private
+
+  # Returns high-level metadata to provide internally identifying information
+  # to distnquish config files from one another.
+  def context_for_export
+    {
+      description: 'T3 Configuration export',
+      host: Certbot::V2::Client.default_host,
+      timestamp: Time.current.iso8601,
+      field_count: Field.count,
+      vocabulary_count: Vocabulary.count
+    }
+  end
+
+  # Returns a hash structure describing vocabuaries and included terms
+  def vocabularies_for_export
+    Vocabulary.order(:slug).to_h do |vocab|
+      [vocab.slug, { attributes: vocab, terms: vocab.terms.order(:slug) }]
+    end
   end
 
   def create_or_update_fields(fields)

--- a/spec/models/config_spec.rb
+++ b/spec/models/config_spec.rb
@@ -28,5 +28,24 @@ RSpec.describe Config do
       expect(described_class.current.settings)
         .to include(fields: a_collection_including(field))
     end
+
+    context 'with multiple vocabularies' do
+      let(:short_list) { FactoryBot.create(:vocabulary, name: 'Shorter List') }
+      let(:long_list) { FactoryBot.create(:vocabulary, name: 'Longer List') }
+
+      before do
+        FactoryBot.create_list(:term, 1, vocabulary: short_list)
+        FactoryBot.create_list(:term, 3, vocabulary: long_list)
+      end
+
+      it 'returns the current voabularies & terms' do
+        expect(described_class.current.settings).to(
+          include({ vocabularies: {
+                    'longer-list' => a_hash_including(terms: satisfying { |array| array.count == 3 }),
+                    'shorter-list' => a_hash_including(terms: satisfying { |array| array.count == 1 })
+                  } })
+        )
+      end
+    end
   end
 end

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe '/admin/configs' do
       json = response.parsed_body
       expect(json).to include(
         'url' => 'http://www.example.com/admin/config.json',
-        'context' => a_hash_including('description' => 'T3 Configuration export')
+        'context' => a_hash_including('description' => 'T3 Configuration export'),
+        'fields' => a_kind_of(Array),
+        'vocabularies' => a_kind_of(Hash)
       )
     end
   end


### PR DESCRIPTION
When displaying or exporting the configuration as JSON, include the current vocabulary configuration with terms nested under each vocabulary.