### PR TITLE
Allow administrators to import Vocabulary Terms from a JSON file

### DIFF
--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -3,10 +3,10 @@ class Term < ApplicationRecord
   belongs_to :vocabulary
 
   validates :label, presence: true
-  validates :label, uniqueness: { scope: :vocabulary }
+  validates :label, uniqueness: { scope: :vocabulary, message: 'Label: "%<value>s" is already in use' }
 
   validates :slug, presence: true
-  validates :slug, uniqueness: { scope: :vocabulary }
+  validates :slug, uniqueness: { scope: :vocabulary, message: 'Slug: "%<value>s" is already in use' }
   validates :slug, format: { with: /\A[0-9A-Za-z]+([_\-][0-9A-Za-z]+)*\z/,
                              message: '"%<value>s" can only contain letters and numbers separated by single dashes' }
 

--- a/spec/fixtures/files/config/empty_vocabulary.json
+++ b/spec/fixtures/files/config/empty_vocabulary.json
@@ -1,0 +1,11 @@
+{"vocabularies": [
+  {
+    "id": 2,
+    "name": "Vocab fixture for Import",
+    "description": "Simple test vocabulary",
+    "created_at": "2024-06-26T17:20:25.240Z",
+    "updated_at": "2024-06-26T17:20:25.240Z",
+    "slug": "vocab-fixture-for-import",
+    "terms": []
+  }
+]}

--- a/spec/fixtures/files/config/minimal_field.json
+++ b/spec/fixtures/files/config/minimal_field.json
@@ -1,0 +1,1 @@
+{ "fields": [{"name": "New Field", "source_field": "new_field_tesim"}] }

--- a/spec/fixtures/files/config/short_vocabulary.json
+++ b/spec/fixtures/files/config/short_vocabulary.json
@@ -1,0 +1,33 @@
+{"vocabularies": [
+  {
+    "id": 1,
+    "name": "Resource Type",
+    "description": "High-level types",
+    "created_at": "2024-06-25T21:51:41.621Z",
+    "updated_at": "2024-06-26T17:16:36.846Z",
+    "slug": "resource-type",
+    "terms": [
+      {
+        "id": 3,
+        "vocabulary_id": 1,
+        "label": "Article",
+        "slug": "article",
+        "value": "",
+        "note": "Textual works included in a serialized publication",
+        "created_at": "2024-06-28T23:52:33.357Z",
+        "updated_at": "2024-06-28T23:52:33.357Z"
+      },
+      {
+        "id": 1,
+        "vocabulary_id": 1,
+        "label": "Book",
+        "slug": "book",
+        "value": "",
+        "note": "Published (or unpublished) bound work",
+        "created_at": "2024-06-28T23:52:05.831Z",
+        "updated_at": "2024-06-29T21:19:51.096Z"
+      }
+    ]
+  }
+  ]
+}

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe '/admin/configs' do
         'url' => 'http://www.example.com/admin/config.json',
         'context' => a_hash_including('description' => 'T3 Configuration export'),
         'fields' => a_kind_of(Array),
-        'vocabularies' => a_kind_of(Hash)
+        'vocabularies' => a_kind_of(Array)
       )
     end
   end
@@ -66,9 +66,7 @@ RSpec.describe '/admin/configs' do
 
   describe 'PATCH /update' do
     context 'with valid parameters' do
-      let(:valid_config) do
-        fixture_file_upload('config/minimal_valid_config.json')
-      end
+      let(:valid_config) { fixture_file_upload('config/minimal_valid_config.json') }
 
       it 'updates the requested config' do
         patch config_url, params: { config_file: valid_config }


### PR DESCRIPTION
**STORY**
As an administrator, I want to be able to quickly populate default vocabulary settings and terms, so that I don't have to manually enter each vocabulary term via the user interface.

**SOLUTION**
Allow the import of vocabulary and term data from a JSON file with the same structure as the config file export format.