### PR TITLE
[REFACTOR] Rename Config #update to #upload

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -13,7 +13,6 @@ module Admin
       # We're explicitly raising an error here to make it obvious that we don't want to
       # default to the default ActionController behavior.
       raise NoMethodError
-      # @configs = Config.all
     end
 
     # GET /configs/1 or /configs/1.json
@@ -35,23 +34,13 @@ module Admin
       # We're explicitly raising an error here to make it obvious that we don't want to
       # default to the default ActionController behavior.
       raise NoMethodError
-      # @config = Config.new(config_params)
-      #
-      # respond_to do |format|
-      #   if @config.save
-      #     format.html { redirect_to config_url(@config), notice: 'Config was successfully created.' }
-      #     format.json { render :show, status: :created, location: @config }
-      #   else
-      #     format.html { render :new, status: :unprocessable_entity }
-      #     format.json { render json: @config.errors, status: :unprocessable_entity }
-      #   end
-      # end
     end
 
     # PATCH/PUT /configs/1 or /configs/1.json
+    # Upload configuration changes from a JSON configuration file
     def update
       respond_to do |format|
-        if @config.update(config_params)
+        if @config.upload(config_file)
           format.html { redirect_to config_url(@config), notice: 'Config was successfully updated.' }
           format.json { render :show, status: :ok, location: @config }
         else
@@ -66,12 +55,6 @@ module Admin
       # We're explicitly raising an error here to make it obvious that we don't want to
       # default to the default ActionController behavior.
       raise NoMethodError
-      # @config.destroy!
-      #
-      # respond_to do |format|
-      #   format.html { redirect_to configs_url, notice: 'Config was successfully destroyed.' }
-      #   format.json { head :no_content }
-      # end
     end
 
     private
@@ -82,7 +65,7 @@ module Admin
     end
 
     # Only allow a list of trusted parameters through.
-    def config_params
+    def config_file
       params.fetch(:config_file)
     end
   end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -23,7 +23,8 @@ class Config
     true
   end
 
-  def update(config_file)
+  # Update configuration settings from a JSON file
+  def upload(config_file)
     errors.clear
     data = JSON.parse(config_file.read)
     import_fields = data['fields']

--- a/spec/models/config_spec.rb
+++ b/spec/models/config_spec.rb
@@ -44,24 +44,24 @@ RSpec.describe Config do
     end
   end
 
-  describe '#update from a file' do
+  describe '#upload from a file' do
     it 'creates new vocabularies' do
       cfg_import_file = fixture_file_upload('config/empty_vocabulary.json')
-      expect { config.update(cfg_import_file) }.to(
+      expect { config.upload(cfg_import_file) }.to(
         change(Vocabulary, :count).by(1)
       )
     end
 
     it 'creates new vocabulary terms' do
       cfg_import_file = fixture_file_upload('config/short_vocabulary.json')
-      expect { config.update(cfg_import_file) }.to(
+      expect { config.upload(cfg_import_file) }.to(
         change(Term, :count).by(2)
       )
     end
 
     it 'creates new fields' do
       cfg_import_file = fixture_file_upload('config/minimal_field.json')
-      expect { config.update(cfg_import_file) }.to(
+      expect { config.upload(cfg_import_file) }.to(
         change(Field, :count).by(1)
       )
     end
@@ -69,7 +69,7 @@ RSpec.describe Config do
     it 'updates existing vocabularies' do
       FactoryBot.create(:vocabulary, name: 'Vocab fixture for Import', description: 'TBD')
       cfg_import_file = fixture_file_upload('config/empty_vocabulary.json')
-      expect { config.update(cfg_import_file) }.to(
+      expect { config.upload(cfg_import_file) }.to(
         change { Vocabulary.last.description }.from('TBD').to('Simple test vocabulary')
       )
     end
@@ -78,14 +78,14 @@ RSpec.describe Config do
       vocab = FactoryBot.create(:vocabulary, name: 'Resource Type')
       term = FactoryBot.create(:term, vocabulary: vocab, label: 'Article', note: 'TBD')
       cfg_import_file = fixture_file_upload('config/short_vocabulary.json')
-      config.update(cfg_import_file)
+      config.upload(cfg_import_file)
       expect(term.reload.note).to eq 'Textual works included in a serialized publication'
     end
 
     it 'updates existing fields' do
       FactoryBot.create(:field, name: 'New Field', source_field: 'TBD')
       cfg_import_file = fixture_file_upload('config/minimal_field.json')
-      expect { config.update(cfg_import_file) }.to(
+      expect { config.upload(cfg_import_file) }.to(
         change { Field.last.source_field }.from('TBD').to('new_field_tesim')
       )
     end


### PR DESCRIPTION
**RATIONALE**
We initially built the configuration upload feature using Rails scaffolding, so using the method name provided by the scaffold was the fastest way to implement the feature.

This method has a very different signature and behaves somewhat differently than the `#update` method for a typical Active Record based class. This change makes that difference much more obvious by changing the method name to `#upload` to more explicitly describe its behavior.

NOTE: This change also removes unused scaffold code that was previously just commented out.