### PR TITLE
[REFACTOR] Standardize Vocabulary attribute names

### DIFF
--- a/app/controllers/admin/terms_controller.rb
+++ b/app/controllers/admin/terms_controller.rb
@@ -70,7 +70,7 @@ module Admin
 
     # Use callbacks to share common setup or constraints between actions.
     def set_vocabulary
-      @vocabulary = Vocabulary.find_by(slug: params[:vocabulary_slug])
+      @vocabulary = Vocabulary.find_by(key: params[:vocabulary_key])
     end
 
     def set_term

--- a/app/controllers/admin/vocabularies_controller.rb
+++ b/app/controllers/admin/vocabularies_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   # Coordinate creation and management of controlled vocabularies
   class VocabulariesController < ApplicationController
-    load_and_authorize_resource(find_by: :slug, id_param: :slug)
+    load_and_authorize_resource(find_by: :key, id_param: :key)
 
     # GET /admin/vocabularies or /admin/vocabularies.json
     def index
@@ -61,7 +61,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def vocabulary_params
-      params.require(:vocabulary).permit(:name, :slug, :description)
+      params.require(:vocabulary).permit(:label, :key, :note)
     end
   end
 end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -13,7 +13,7 @@ class Config
   def settings
     { context:      context_for_export,
       fields:       Field.in_sequence,
-      vocabularies: Vocabulary.order(:slug).as_json(include: :terms) }
+      vocabularies: Vocabulary.order(:key).as_json(include: :terms) }
   end
   # rubocop:enable Layout/HashAlignment:
 
@@ -74,7 +74,7 @@ class Config
     return if vocabularies.blank?
 
     vocabularies.each do |json_attrs|
-      vocab = Vocabulary.find_by(slug: json_attrs['slug'])
+      vocab = Vocabulary.find_by(key: json_attrs['key'])
       create_or_update_from_json(Term, json_attrs['terms'], vocab)
     end
   end
@@ -85,7 +85,7 @@ class Config
     when 'Field'
       Field.find_or_initialize_by(name: json_attrs['name'])
     when 'Vocabulary'
-      Vocabulary.find_or_initialize_by(slug: json_attrs['slug'])
+      Vocabulary.find_or_initialize_by(key: json_attrs['key'])
     when 'Term'
       Term.find_or_initialize_by(slug: json_attrs['slug'], vocabulary: vocab)
     end

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -1,19 +1,19 @@
 # Controlled Vocabulary
 class Vocabulary < ApplicationRecord
-  validates :name, presence: true
-  validates :name, uniqueness: { case_sensitive: false, message: '"%<value>s" is already in use' }
+  validates :label, presence: true
+  validates :label, uniqueness: { case_sensitive: false, message: '"%<value>s" is already in use' }
 
-  validates :slug, presence: true
-  validates :slug, uniqueness: { case_sensitive: false, message: '"%<value>s" is already in use' }
-  validates :slug, format: { with: /\A[a-z0-9]+(-[a-z0-9]+)*\z/,
-                             message: '"%<value>s" can only contain letters and numbers separated by single dashes' }
+  validates :key, presence: true
+  validates :key, uniqueness: { case_sensitive: false, message: '"%<value>s" is already in use' }
+  validates :key, format: { with: /\A[a-z0-9]+(-[a-z0-9]+)*\z/,
+                            message: '"%<value>s" can only contain letters and numbers separated by single dashes' }
 
-  before_validation :set_slug
+  before_validation :set_key
 
   has_many :terms, dependent: :destroy
 
   def to_param
-    slug
+    key
   end
 
   def to_partial_path
@@ -27,7 +27,7 @@ class Vocabulary < ApplicationRecord
   # * lowercase only
   # * alphabetic characters only
   # * whitespace and other characters collapsed into single underscores
-  def set_slug
-    self.slug = name&.gsub('_', '-')&.parameterize if slug.blank?
+  def set_key
+    self.key = label&.gsub('_', '-')&.parameterize if key.blank?
   end
 end

--- a/app/views/admin/terms/_form.html.erb
+++ b/app/views/admin/terms/_form.html.erb
@@ -14,7 +14,7 @@
   <div>
     <%= form.label :vocabulary, style: "display: block" %>
     <%= form.hidden_field :vocabulary_id, value: term.vocabulary.id %>
-    <%= form.text_field term.vocabulary.name, disabled: true %>
+    <%= form.text_field term.vocabulary.label, disabled: true %>
   </div>
 
   <div>

--- a/app/views/admin/terms/index.html.erb
+++ b/app/views/admin/terms/index.html.erb
@@ -1,5 +1,5 @@
 <div id="terms">
-  <h1 id="vocabulary_name"><%= @vocabulary.name %></h1>
+  <h1 id="vocabulary_label"><%= @vocabulary.label %></h1>
   <h2>Vocabulary Terms</h2>
 
 

--- a/app/views/admin/terms/show.html.erb
+++ b/app/views/admin/terms/show.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= dom_id(@term) -%>" class="term">
-    <h1 id="vocabulary_name"><%= @vocabulary.name -%></h1>
+    <h1 id="vocabulary_label"><%= @vocabulary.label -%></h1>
     <h2 id="term_label"><%= @term.label -%></h2>
   <%= render @term %>
 

--- a/app/views/admin/vocabularies/_admin_vocabulary.json.jbuilder
+++ b/app/views/admin/vocabularies/_admin_vocabulary.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! vocabulary, :id, :name, :description, :created_at, :updated_at
+json.extract! vocabulary, :id, :label, :note, :created_at, :updated_at
 json.url vocabulary_url(vocabulary, format: :json)

--- a/app/views/admin/vocabularies/_form.html.erb
+++ b/app/views/admin/vocabularies/_form.html.erb
@@ -12,13 +12,18 @@
   <% end %>
 
   <div>
-    <%= form.label :name, style: "display: block" %>
-    <%= form.text_field :name %>
+    <%= form.label :label, style: "display: block" %>
+    <%= form.text_field :label %>
   </div>
 
   <div>
-    <%= form.label :description, style: "display: block" %>
-    <%= form.text_field :description %>
+    <%= form.label :key, style: "display: block" %>
+    <%= form.text_field :key %>
+  </div>
+
+  <div>
+    <%= form.label :note, style: "display: block" %>
+    <%= form.text_field :note %>
   </div>
 
   <div>

--- a/app/views/admin/vocabularies/_vocabulary.html.erb
+++ b/app/views/admin/vocabularies/_vocabulary.html.erb
@@ -1,12 +1,12 @@
 <div id="<%= dom_id vocabulary %>">
   <p>
-    <strong>Name:</strong>
-    <%= vocabulary.name %>
+    <strong>Label:</strong>
+    <%= vocabulary.label %>
   </p>
 
   <p>
-    <strong>Description:</strong>
-    <%= vocabulary.description %>
+    <strong>Note:</strong>
+    <%= vocabulary.note %>
   </p>
 
 </div>

--- a/app/views/admin/vocabularies/index.html.erb
+++ b/app/views/admin/vocabularies/index.html.erb
@@ -1,5 +1,3 @@
-<p style="color: green"><%= notice %></p>
-
 <h1>Vocabularies</h1>
 
 <div id="vocabularies">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
     resources :fields do
       patch 'move', on: :member
     end
-    resources :vocabularies, param: :slug do
+    resources :vocabularies, param: :key do
       resources :terms, param: :slug
     end
     resources :themes do
@@ -57,16 +57,16 @@ Rails.application.routes.draw do
 
   direct :term do |term|
     if term.slug
-      { controller: 'admin/terms', action: :show, vocabulary_slug: term.vocabulary.slug, slug: term.slug }
+      { controller: 'admin/terms', action: :show, vocabulary_key: term.vocabulary.key, slug: term.slug }
     else
-      { controller: 'admin/terms', vocabulary_slug: term.vocabulary }
+      { controller: 'admin/terms', vocabulary_key: term.vocabulary.key }
     end
   end
   direct :edit_term do |term|
-    { controller: 'admin/terms', action: :edit, vocabulary_slug: term.vocabulary.slug, slug: term.slug }
+    { controller: 'admin/terms', action: :edit, vocabulary_key: term.vocabulary.key, slug: term.slug }
   end
   direct :terms do |term|
-    { controller: 'admin/terms', vocabulary_slug: term.vocabulary }
+    { controller: 'admin/terms', vocabulary_key: term.vocabulary.key }
   end
 
   # When app is firt booted and no Solr config exists, use this as the application root

--- a/db/migrate/20240703161757_rename_vocabularies_name_to_label.rb
+++ b/db/migrate/20240703161757_rename_vocabularies_name_to_label.rb
@@ -1,0 +1,7 @@
+class RenameVocabulariesNameToLabel < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :vocabularies, :name, :label
+    rename_column :vocabularies, :slug, :key
+    rename_column :vocabularies, :description, :note
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_28_173658) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_03_161757) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -202,13 +202,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_28_173658) do
   end
 
   create_table "vocabularies", force: :cascade do |t|
-    t.string "name"
-    t.string "description"
+    t.string "label"
+    t.string "note"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.citext "slug"
-    t.index ["name"], name: "index_vocabularies_on_name", unique: true
-    t.index ["slug"], name: "index_vocabularies_on_slug", unique: true
+    t.citext "key"
+    t.index ["key"], name: "index_vocabularies_on_key", unique: true
+    t.index ["label"], name: "index_vocabularies_on_label", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/factories/vocabularies.rb
+++ b/spec/factories/vocabularies.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :vocabulary do
-    name { Faker::Lorem.unique.words.join(' ').titleize }
-    description { 'A vocaublary for use when testing' }
+    label { Faker::Lorem.unique.words.join(' ').titleize }
+    note { 'A vocaublary for use when testing' }
   end
 end

--- a/spec/fixtures/files/config/empty_vocabulary.json
+++ b/spec/fixtures/files/config/empty_vocabulary.json
@@ -1,11 +1,11 @@
 {"vocabularies": [
   {
     "id": 2,
-    "name": "Vocab fixture for Import",
-    "description": "Simple test vocabulary",
+    "label": "Vocab fixture for Import",
+    "note": "Simple test vocabulary",
     "created_at": "2024-06-26T17:20:25.240Z",
     "updated_at": "2024-06-26T17:20:25.240Z",
-    "slug": "vocab-fixture-for-import",
+    "key": "vocab-fixture-for-import",
     "terms": []
   }
 ]}

--- a/spec/fixtures/files/config/short_vocabulary.json
+++ b/spec/fixtures/files/config/short_vocabulary.json
@@ -1,11 +1,11 @@
 {"vocabularies": [
   {
     "id": 1,
-    "name": "Resource Type",
-    "description": "High-level types",
+    "label": "Resource Type",
+    "note": "High-level types",
     "created_at": "2024-06-25T21:51:41.621Z",
     "updated_at": "2024-06-26T17:16:36.846Z",
-    "slug": "resource-type",
+    "key": "resource-type",
     "terms": [
       {
         "id": 3,

--- a/spec/models/config_spec.rb
+++ b/spec/models/config_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Config do
     end
 
     context 'with multiple vocabularies' do
-      let(:short_list) { FactoryBot.create(:vocabulary, name: 'Shorter List') }
-      let(:long_list) { FactoryBot.create(:vocabulary, name: 'Longer List') }
+      let(:short_list) { FactoryBot.create(:vocabulary, label: 'Shorter List') }
+      let(:long_list) { FactoryBot.create(:vocabulary, label: 'Longer List') }
 
       before do
         FactoryBot.create_list(:term, 1, vocabulary: short_list)
@@ -38,8 +38,8 @@ RSpec.describe Config do
 
       it 'returns the current vocabularies & terms' do
         expect(config.settings[:vocabularies])
-          .to(include(hash_including('slug' => 'longer-list', 'terms' => satisfying { |a| a.count == 3 }),
-                      hash_including('slug' => 'shorter-list', 'terms' => satisfying { |a| a.count == 1 })))
+          .to(include(hash_including('key' => 'longer-list', 'terms' => satisfying { |a| a.count == 3 }),
+                      hash_including('key' => 'shorter-list', 'terms' => satisfying { |a| a.count == 1 })))
       end
     end
   end
@@ -67,15 +67,15 @@ RSpec.describe Config do
     end
 
     it 'updates existing vocabularies' do
-      FactoryBot.create(:vocabulary, name: 'Vocab fixture for Import', description: 'TBD')
+      FactoryBot.create(:vocabulary, label: 'Vocab fixture for Import', note: 'TBD')
       cfg_import_file = fixture_file_upload('config/empty_vocabulary.json')
       expect { config.upload(cfg_import_file) }.to(
-        change { Vocabulary.last.description }.from('TBD').to('Simple test vocabulary')
+        change { Vocabulary.last.note }.from('TBD').to('Simple test vocabulary')
       )
     end
 
     it 'updates existing vocabulary terms' do
-      vocab = FactoryBot.create(:vocabulary, name: 'Resource Type')
+      vocab = FactoryBot.create(:vocabulary, label: 'Resource Type')
       term = FactoryBot.create(:term, vocabulary: vocab, label: 'Article', note: 'TBD')
       cfg_import_file = fixture_file_upload('config/short_vocabulary.json')
       config.upload(cfg_import_file)

--- a/spec/models/vocabulary_spec.rb
+++ b/spec/models/vocabulary_spec.rb
@@ -3,100 +3,100 @@ require 'rails_helper'
 RSpec.describe Vocabulary do
   let(:vocab) { FactoryBot.build(:vocabulary) }
 
-  describe '#name' do
+  describe '#label' do
     it 'is required' do
-      vocab.name = nil
+      vocab.label = nil
       vocab.validate
-      expect(vocab.errors.where(:name, :blank)).to be_present
+      expect(vocab.errors.where(:label, :blank)).to be_present
     end
 
     it 'must be unique (case insensitive)' do
-      vocab.name = 'My_TEST_Vocabulary'
+      vocab.label = 'My_TEST_Vocabulary'
       vocab.save!
-      another = FactoryBot.build(:vocabulary, name: 'my_test_vocabulary')
+      another = FactoryBot.build(:vocabulary, label: 'my_test_vocabulary')
       another.validate
-      expect(another.errors.where(:name, :taken)).to be_present
+      expect(another.errors.where(:label, :taken)).to be_present
     end
   end
 
-  describe '#slug' do
+  describe '#key' do
     it 'is required' do
-      # Temporarily stub method that ensures slug is set before validations
-      allow(vocab).to receive(:set_slug)
+      # Temporarily stub method that ensures key is set before validations
+      allow(vocab).to receive(:set_key)
 
-      vocab.slug = nil
+      vocab.key = nil
       vocab.validate
-      expect(vocab.errors.where(:slug, :blank)).to be_present
+      expect(vocab.errors.where(:key, :blank)).to be_present
     end
 
-    it 'gets set from the name when missing' do
-      vocab.name = 'Kontrollü Terimler -- Sözlük!'
-      vocab.slug = ''
+    it 'gets set from the label when missing' do
+      vocab.label = 'Kontrollü Terimler -- Sözlük!'
+      vocab.key = ''
       vocab.save!
-      expect(vocab.slug).to eq 'kontrollu-terimler-sozluk'
+      expect(vocab.key).to eq 'kontrollu-terimler-sozluk'
     end
 
     it 'must be unique' do
-      vocab.slug = 'my-test-vocabulary'
+      vocab.key = 'my-test-vocabulary'
       vocab.save!
-      another = FactoryBot.build(:vocabulary, slug: 'my-test-vocabulary')
+      another = FactoryBot.build(:vocabulary, key: 'my-test-vocabulary')
       another.validate
-      expect(another.errors.where(:slug, :taken)).to be_present
+      expect(another.errors.where(:key, :taken)).to be_present
     end
 
     describe 'patterns' do
       it 'can contain letters, numbers and dashes' do
-        vocab.slug = 'marc-9xx-extensions'
+        vocab.key = 'marc-9xx-extensions'
         expect(vocab).to be_valid
       end
 
       it 'can not include spaces' do
-        vocab.slug = 'spaces as separators'
+        vocab.key = 'spaces as separators'
         vocab.validate
-        expect(vocab.errors.where(:slug, :invalid)).to be_present
+        expect(vocab.errors.where(:key, :invalid)).to be_present
       end
 
       it 'can not include underscores' do
-        vocab.slug = 'underscores_as_separators'
+        vocab.key = 'underscores_as_separators'
         vocab.validate
-        expect(vocab.errors.where(:slug, :invalid)).to be_present
+        expect(vocab.errors.where(:key, :invalid)).to be_present
       end
 
       it 'can not include symbols' do
-        vocab.slug = 'slug-[with]-sybols'
+        vocab.key = 'key-[with]-sybols'
         vocab.validate
-        expect(vocab.errors.where(:slug, :invalid)).to be_present
+        expect(vocab.errors.where(:key, :invalid)).to be_present
       end
 
       it 'can not include leading dash' do
-        vocab.slug = '-leading-dash'
+        vocab.key = '-leading-dash'
         vocab.validate
-        expect(vocab.errors.where(:slug, :invalid)).to be_present
+        expect(vocab.errors.where(:key, :invalid)).to be_present
       end
 
       it 'can not include trailing dash' do
-        vocab.slug = 'trailing-dash-'
+        vocab.key = 'trailing-dash-'
         vocab.validate
-        expect(vocab.errors.where(:slug, :invalid)).to be_present
+        expect(vocab.errors.where(:key, :invalid)).to be_present
       end
 
       it 'can not include repeated dashes' do
-        vocab.slug = 'repeated--dashes'
+        vocab.key = 'repeated--dashes'
         vocab.validate
-        expect(vocab.errors.where(:slug, :invalid)).to be_present
+        expect(vocab.errors.where(:key, :invalid)).to be_present
       end
     end
   end
 
   describe '#to_param' do
-    it 'returns the slug' do
-      expect(vocab.to_param).to eq vocab.slug
+    it 'returns the key' do
+      expect(vocab.to_param).to eq vocab.key
     end
   end
 
-  describe '#description' do
+  describe '#note' do
     it 'is optional' do
-      vocab.description = nil
+      vocab.note = nil
       expect(vocab).to be_valid
     end
   end

--- a/spec/requests/admin/terms_spec.rb
+++ b/spec/requests/admin/terms_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/terms' do
-  let(:test_vocab) { Vocabulary.find_or_create_by(name: 'Admin/Terms Test Vocabulary') }
+  let(:test_vocab) { Vocabulary.find_or_create_by(label: 'Admin/Terms Test Vocabulary') }
   let(:valid_attributes) { FactoryBot.attributes_for(:term, vocabulary_id: test_vocab.id) }
   let(:invalid_attributes) do
     FactoryBot.attributes_for(:term, vocabulary_id: test_vocab.id, slug: '<Invalid $lug!>')

--- a/spec/requests/admin/vocabularies_spec.rb
+++ b/spec/requests/admin/vocabularies_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe '/admin/vocabularies' do
   # Vocabulary. As you add validations to Vocabulary, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) { FactoryBot.attributes_for(:vocabulary) }
-  let(:invalid_attributes) { { slug: '<Invalid $lug!>' } }
+  let(:invalid_attributes) { { key: '<Invalid $lug!>' } }
   let(:super_admin)  { FactoryBot.create(:super_admin) }
   let(:regular_user) { FactoryBot.create(:user) }
 
@@ -85,14 +85,14 @@ RSpec.describe '/admin/vocabularies' do
   describe 'PATCH /update' do
     context 'with valid parameters' do
       let(:new_attributes) do
-        { name: 'Updated Vocabulary Name' }
+        { label: 'Updated Vocabulary Label' }
       end
 
       it 'updates the requested vocabulary' do
         vocabulary = Vocabulary.create! valid_attributes
         patch vocabulary_url(vocabulary), params: { vocabulary: new_attributes }
         vocabulary.reload
-        expect(vocabulary.name).to eq 'Updated Vocabulary Name'
+        expect(vocabulary.label).to eq 'Updated Vocabulary Label'
       end
 
       it 'redirects to the vocabulary' do

--- a/spec/routing/admin/terms_routing_spec.rb
+++ b/spec/routing/admin/terms_routing_spec.rb
@@ -4,42 +4,42 @@ RSpec.describe Admin::TermsController do
   describe 'routing' do
     it 'routes to #index' do
       expect(get: '/admin/vocabularies/my-vocab/terms')
-        .to route_to('admin/terms#index', vocabulary_slug: 'my-vocab')
+        .to route_to('admin/terms#index', vocabulary_key: 'my-vocab')
     end
 
     it 'routes to #new' do
       expect(get: '/admin/vocabularies/my-vocab/terms/new')
-        .to route_to('admin/terms#new', vocabulary_slug: 'my-vocab')
+        .to route_to('admin/terms#new', vocabulary_key: 'my-vocab')
     end
 
     it 'routes to #show' do
       expect(get: '/admin/vocabularies/my-vocab/terms/first-term')
-        .to route_to('admin/terms#show', vocabulary_slug: 'my-vocab', slug: 'first-term')
+        .to route_to('admin/terms#show', vocabulary_key: 'my-vocab', slug: 'first-term')
     end
 
     it 'routes to #edit' do
       expect(get: '/admin/vocabularies/my-vocab/terms/first-term/edit')
-        .to route_to('admin/terms#edit', vocabulary_slug: 'my-vocab', slug: 'first-term')
+        .to route_to('admin/terms#edit', vocabulary_key: 'my-vocab', slug: 'first-term')
     end
 
     it 'routes to #create' do
       expect(post: '/admin/vocabularies/my-vocab/terms')
-        .to route_to('admin/terms#create', vocabulary_slug: 'my-vocab')
+        .to route_to('admin/terms#create', vocabulary_key: 'my-vocab')
     end
 
     it 'routes to #update via PUT' do
       expect(put: '/admin/vocabularies/my-vocab/terms/first-term')
-        .to route_to('admin/terms#update', vocabulary_slug: 'my-vocab', slug: 'first-term')
+        .to route_to('admin/terms#update', vocabulary_key: 'my-vocab', slug: 'first-term')
     end
 
     it 'routes to #update via PATCH' do
       expect(patch: '/admin/vocabularies/my-vocab/terms/first-term')
-        .to route_to('admin/terms#update', vocabulary_slug: 'my-vocab', slug: 'first-term')
+        .to route_to('admin/terms#update', vocabulary_key: 'my-vocab', slug: 'first-term')
     end
 
     it 'routes to #destroy' do
       expect(delete: '/admin/vocabularies/my-vocab/terms/first-term')
-        .to route_to('admin/terms#destroy', vocabulary_slug: 'my-vocab', slug: 'first-term')
+        .to route_to('admin/terms#destroy', vocabulary_key: 'my-vocab', slug: 'first-term')
     end
   end
 end

--- a/spec/routing/admin/vocabularies_routing_spec.rb
+++ b/spec/routing/admin/vocabularies_routing_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe Admin::VocabulariesController do
     end
 
     it 'routes to #show' do
-      expect(get: '/admin/vocabularies/my-vocabulary').to route_to('admin/vocabularies#show', slug: 'my-vocabulary')
+      expect(get: '/admin/vocabularies/my-vocabulary').to route_to('admin/vocabularies#show', key: 'my-vocabulary')
     end
 
     it 'routes to #edit' do
       expect(get: '/admin/vocabularies/my-vocabulary/edit').to route_to('admin/vocabularies#edit',
-                                                                        slug: 'my-vocabulary')
+                                                                        key: 'my-vocabulary')
     end
 
     it 'routes to #create' do
@@ -24,16 +24,16 @@ RSpec.describe Admin::VocabulariesController do
     end
 
     it 'routes to #update via PUT' do
-      expect(put: '/admin/vocabularies/my-vocabulary').to route_to('admin/vocabularies#update', slug: 'my-vocabulary')
+      expect(put: '/admin/vocabularies/my-vocabulary').to route_to('admin/vocabularies#update', key: 'my-vocabulary')
     end
 
     it 'routes to #update via PATCH' do
-      expect(patch: '/admin/vocabularies/my-vocabulary').to route_to('admin/vocabularies#update', slug: 'my-vocabulary')
+      expect(patch: '/admin/vocabularies/my-vocabulary').to route_to('admin/vocabularies#update', key: 'my-vocabulary')
     end
 
     it 'routes to #destroy' do
       expect(delete: '/admin/vocabularies/my-vocabulary').to route_to('admin/vocabularies#destroy',
-                                                                      slug: 'my-vocabulary')
+                                                                      key: 'my-vocabulary')
     end
   end
 end

--- a/spec/views/admin/terms/edit.html.erb_spec.rb
+++ b/spec/views/admin/terms/edit.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'admin/terms/edit' do
     term.validate # use #validate to set the slug
     assign(:term, term)
     assign(:vocabulary, vocabulary)
-    request.path_parameters[:vocabulary_slug] = vocabulary.slug
+    request.path_parameters[:vocabulary_key] = vocabulary.key
     request.path_parameters[:slug] = term.slug
   end
 

--- a/spec/views/admin/terms/index.html.erb_spec.rb
+++ b/spec/views/admin/terms/index.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'admin/terms/index' do
   before do
     assign(:terms, terms)
     assign(:vocabulary, vocabulary)
-    request.path_parameters[:vocabulary_slug] = vocabulary.slug
+    request.path_parameters[:vocabulary_key] = vocabulary.key
   end
 
   it 'renders a list of vocabulary/terms' do
@@ -17,6 +17,6 @@ RSpec.describe 'admin/terms/index' do
 
   it 'displays the vocabulary name' do
     render
-    expect(rendered).to have_selector('#vocabulary_name', text: vocabulary.name)
+    expect(rendered).to have_selector('#vocabulary_label', text: vocabulary.label)
   end
 end

--- a/spec/views/admin/terms/new.html.erb_spec.rb
+++ b/spec/views/admin/terms/new.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'admin/terms/new' do
   before do
     assign(:term, term)
     assign(:vocabulary, vocabulary)
-    request.path_parameters[:vocabulary_slug] = vocabulary.slug
+    request.path_parameters[:vocabulary_key] = vocabulary.key
   end
 
   it 'renders the expected form fields', :aggregate_failures do # rubocop:disable RSpec/ExampleLength

--- a/spec/views/admin/terms/show.html.erb_spec.rb
+++ b/spec/views/admin/terms/show.html.erb_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe 'admin/terms/show' do
     term.validate # use #validate to set the slug
     assign(:term, term)
     assign(:vocabulary, vocabulary)
-    request.path_parameters[:vocabulary_slug] = vocabulary.slug
+    request.path_parameters[:vocabulary_key] = vocabulary.key
     request.path_parameters[:slug] = term.slug
   end
 
   it 'displays the vocabulary name' do
     render
-    expect(rendered).to have_selector('#vocabulary_name', text: vocabulary.name)
+    expect(rendered).to have_selector('#vocabulary_label', text: vocabulary.label)
   end
 
   it 'displays other attributes' do

--- a/spec/views/admin/vocabularies/edit.html.erb_spec.rb
+++ b/spec/views/admin/vocabularies/edit.html.erb_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe 'admin/vocabularies/edit' do
   let(:vocabulary) do
     Vocabulary.create!(
-      name: 'MyString',
-      description: 'MyString'
+      label: 'MyString',
+      note: 'MyString'
     )
   end
 
@@ -16,9 +16,9 @@ RSpec.describe 'admin/vocabularies/edit' do
     render
 
     assert_select 'form[action=?][method=?]', vocabulary_path(vocabulary), 'post' do
-      assert_select 'input[name=?]', 'vocabulary[name]'
+      assert_select 'input[name=?]', 'vocabulary[label]'
 
-      assert_select 'input[name=?]', 'vocabulary[description]'
+      assert_select 'input[name=?]', 'vocabulary[note]'
     end
   end
 end

--- a/spec/views/admin/vocabularies/index.html.erb_spec.rb
+++ b/spec/views/admin/vocabularies/index.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'admin/vocabularies/index' do
   it 'renders a list of admin/vocabularies' do
     render
     cell_selector = Rails::VERSION::STRING >= '7' ? 'div>p' : 'tr>td'
-    assert_select cell_selector, text: Regexp.new('Name'.to_s), count: 2
-    assert_select cell_selector, text: Regexp.new('Description'.to_s), count: 2
+    assert_select cell_selector, text: Regexp.new('Label'.to_s), count: 2
+    assert_select cell_selector, text: Regexp.new('Note'.to_s), count: 2
   end
 end

--- a/spec/views/admin/vocabularies/new.html.erb_spec.rb
+++ b/spec/views/admin/vocabularies/new.html.erb_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe 'admin/vocabularies/new' do
   before do
     assign(:vocabulary, Vocabulary.new(
-                          name: 'MyString',
-                          description: 'MyString'
+                          label: 'MyString',
+                          note: 'MyString'
                         ))
   end
 
@@ -12,9 +12,9 @@ RSpec.describe 'admin/vocabularies/new' do
     render
 
     assert_select 'form[action=?][method=?]', vocabularies_path, 'post' do
-      assert_select 'input[name=?]', 'vocabulary[name]'
+      assert_select 'input[name=?]', 'vocabulary[label]'
 
-      assert_select 'input[name=?]', 'vocabulary[description]'
+      assert_select 'input[name=?]', 'vocabulary[note]'
     end
   end
 end

--- a/spec/views/admin/vocabularies/show.html.erb_spec.rb
+++ b/spec/views/admin/vocabularies/show.html.erb_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 RSpec.describe 'admin/vocabularies/show' do
   before do
     assign(:vocabulary, Vocabulary.create!(
-                          name: 'Name',
-                          description: 'Description'
+                          label: 'Name',
+                          note: 'Description'
                         ))
   end
 
   it 'renders attributes in <p>', :aggregate_failures do
     render
-    expect(rendered).to match(/Name/)
-    expect(rendered).to match(/Description/)
+    expect(rendered).to match(/Label/)
+    expect(rendered).to match(/Note/)
   end
 end


### PR DESCRIPTION
**RATIONALE**
As the application has evolved, we have ended up with diffferent names for attributes that fill the same function - e.g. both `:name` and `:label` for the human-readable title of a thing.

We also used `:slug` for the semantic identifier that gets used in URLs. This word gets used in SEO contexts, but isn't as meaningful in library and archive contexts.

The pattern going forward is:
* `:label` The human-readable title of a thing. This can include spaces and special characters
* `:key` The url-friendly identifier that can contain only as subset of printable ASCII characters
* `:note` A description, usage note, or other text that provides context for the record