### PR TITLE
[REFACTOR] Rename #solr_field_name attribute

### DIFF
--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -90,12 +90,12 @@ class Field < ApplicationRecord
   end
 
   # Generate a solr field name based onf the field name and the dynamic suffix derived from field settings
-  def solr_field
-    @solr_field ||= name.downcase.gsub(/[- ]/, '_') + solr_suffix
+  def solr_field_name
+    @solr_field_name ||= name.downcase.gsub(/[- ]/, '_') + solr_suffix
   end
 
   def solr_facet_field
-    @solr_facet_field ||= data_type == 'text_en' ? solr_field.gsub('_tesi', '_si') : solr_field
+    @solr_facet_field ||= data_type == 'text_en' ? solr_field_name.gsub('_tesi', '_si') : solr_field_name
   end
 
   # Change the field's position in the display sequence
@@ -123,7 +123,7 @@ class Field < ApplicationRecord
   private
 
   def clear_solr_field
-    @solr_field = nil
+    @solr_field_name = nil
     @solr_facet_field = nil
   end
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -85,7 +85,7 @@ class Resource < ApplicationRecord
   def to_solr
     doc = solr_base_values
     blueprint.fields.each do |field|
-      solr_field = field.solr_field
+      solr_field = field.solr_field_name
       solr_facet = field.solr_facet_field
       value = metadata[field.name]
       doc[solr_field] = value

--- a/app/models/solr_service.rb
+++ b/app/models/solr_service.rb
@@ -100,12 +100,12 @@ class SolrService < ApplicationRecord
 
   def update_field(config, field)
     config.add_facet_field field.solr_facet_field, label: field.name if field.facetable
-    config.add_index_field field.solr_field, label: field.name if field.list_view
-    config.add_show_field field.solr_field, label: field.name if field.item_view
+    config.add_index_field field.solr_field_name, label: field.name if field.list_view
+    config.add_show_field field.solr_field_name, label: field.name if field.item_view
   end
 
   def title_field_from_config
-    Field.active_in_sequence.first&.solr_field
+    Field.active_in_sequence.first&.solr_field_name
   end
 
   def solr_connection_from_config

--- a/app/views/admin/blueprints/_form.html.erb
+++ b/app/views/admin/blueprints/_form.html.erb
@@ -37,7 +37,7 @@
       <%= form.fields_for 'fields[]', field do |field_form| %>
         <tr>
           <td class='name'><%= field_form.text_field :name %></td>
-          <td class='solr_field_name'><%= field_form.text_field :solr_field %></td>
+          <td class='solr_field_name'><%= field_form.text_field :solr_field_name %></td>
           <td class='searchable'><%= field_form.check_box :searchable %></td>
           <td class='facetable'><%= field_form.check_box :facetable %></td>
           <td class='list_view'><%= field_form.check_box :list_view %></td>

--- a/app/views/admin/blueprints/show.html.erb
+++ b/app/views/admin/blueprints/show.html.erb
@@ -29,7 +29,7 @@
             <%= settings.join(', ') -%>
 
           </td>
-          <td class="solr_field"><%= field.solr_field %></td>
+          <td class="solr_field"><%= field.solr_field_name %></td>
         </tr>
       <% end %>
 

--- a/app/views/admin/fields/index.html.erb
+++ b/app/views/admin/fields/index.html.erb
@@ -30,7 +30,7 @@
           <%= settings.join(', ') -%>
 
         </td>
-        <td class="solr_field"><%= field.solr_field %></td>
+        <td class="solr_field"><%= field.solr_field_name %></td>
         <td class="source_field"><%= field.source_field -%></td>
       </tr>
     <% end %>

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -162,45 +162,45 @@ RSpec.describe Field do
     end
   end
 
-  describe '#solr_field' do
+  describe '#solr_field_name' do
     it 'returns a solr field name that matches dynamic field suffixes' do
       field.name = 'Year'
       field.data_type = 'integer'
-      expect(field.solr_field).to eq 'year_ltsi'
+      expect(field.solr_field_name).to eq 'year_ltsi'
     end
 
     it 'handles multiples' do
       field.name = 'Keyword'
       field.data_type = 'string'
       field.multiple = true
-      expect(field.solr_field).to eq 'keyword_ssim'
+      expect(field.solr_field_name).to eq 'keyword_ssim'
     end
 
     it 'replaces dashes and spaces in the name with underscores' do
       field.name = 'Additional co-authors'
       field.data_type = 'text_en'
       field.multiple = true
-      expect(field.solr_field).to eq 'additional_co_authors_tesim'
+      expect(field.solr_field_name).to eq 'additional_co_authors_tesim'
     end
 
     it 'is memoized' do
-      memo = field.solr_field
+      memo = field.solr_field_name
       field.name = 'new_name'
-      expect(field.solr_field).to eq memo
+      expect(field.solr_field_name).to eq memo
     end
 
     it 'clears memoization on save' do
-      memo = field.solr_field
+      memo = field.solr_field_name
       field.name = "#{field.name} changed"
       field.save!
-      expect(field.solr_field).not_to eq memo
+      expect(field.solr_field_name).not_to eq memo
     end
   end
 
   describe '#solr_facet_field' do
-    it 'is the same as solr_field for non-text fields' do
+    it 'is the same as solr_field_name for non-text fields' do
       field.data_type = 'integer'
-      expect(field.solr_facet_field).to eq field.solr_field
+      expect(field.solr_facet_field).to eq field.solr_field_name
     end
 
     it 'does not tokenize text fields' do


### PR DESCRIPTION
**RATIONALE**
In preparation for persisting the Solr fieldname in the database, we want to rename it more explicitly so its function in the code is (even) more obvious.