### PR TITLE
Clean up Vocabulary listing view

### DIFF
--- a/app/assets/stylesheets/admin/blueprints.scss
+++ b/app/assets/stylesheets/admin/blueprints.scss
@@ -1,7 +1,3 @@
-#dashboard-content {
-  margin-top: 1.5rem;
-}
-
 #blueprint_fields {
   th, td {
     padding-right: 1rem;

--- a/app/assets/stylesheets/admin/dashboard.scss
+++ b/app/assets/stylesheets/admin/dashboard.scss
@@ -1,4 +1,8 @@
 #dashboard-content {
+  width: 100%;
+  margin-right: 2rem;
+  margin-top: 1.5rem;
+
   a {
     color: #000099;
     &.btn {

--- a/app/assets/stylesheets/admin/vocabularies.scss
+++ b/app/assets/stylesheets/admin/vocabularies.scss
@@ -1,0 +1,36 @@
+#vocabularies {
+  .vocabulary_row:nth-of-type(even) {
+    background-color: white;
+  }
+
+  .vocabulary_row {
+    width: auto;
+    display: flex;
+  }
+
+  .vocabulary_header {
+    font-weight: bold;
+    border-bottom-color: black;
+    border-bottom-style: solid;
+  }
+
+  .vocabulary_label {
+    width: 18rem;
+    flex-shrink: 0;
+  }
+
+  .vocabulary_term_count {
+    width: 4rem;
+    text-align: center;
+    flex-shrink: 0;
+  }
+
+  .vocabulary_note {
+    margin-right: 0;
+    width: auto;
+  }
+
+  #add_vocab {
+    margin-top: .75rem;
+  }
+}

--- a/app/views/admin/vocabularies/index.html.erb
+++ b/app/views/admin/vocabularies/index.html.erb
@@ -1,12 +1,30 @@
-<h1>Vocabularies</h1>
-
 <div id="vocabularies">
+  <h1>Vocabularies</h1>
+  <div class="vocabulary_row vocabulary_header">
+    <div class="vocabulary_label">
+      Vocabulary
+    </div>
+    <div class="vocabulary_term_count">
+      Terms
+    </div>
+    <div class="vocabulary_note">
+      Note
+    </div>
+  </div>
   <% @vocabularies.each do |vocabulary| %>
-    <%= render vocabulary %>
-    <p>
-      <%= link_to "Show this vocabulary", vocabulary %>
-    </p>
+    <div class="vocabulary_row" id=<%= dom_id(vocabulary) -%> >
+      <div class="vocabulary_label">
+        <%= link_to vocabulary.label, vocabulary, id: dom_id(vocabulary, :show) %>
+      </div>
+      <div class="vocabulary_term_count">
+        <%= vocabulary.terms.count -%>
+      </div>
+      <div class="vocabulary_note">
+        <%= vocabulary.note -%>
+      </div>
+    </div>
   <% end %>
+
+  <%= link_to "Add a vocabulary", new_vocabulary_path, id: 'add_vocab', class: 'btn btn-sm btn-primary' %>
 </div>
 
-<%= link_to "New vocabulary", new_vocabulary_path %>

--- a/spec/factories/vocabularies.rb
+++ b/spec/factories/vocabularies.rb
@@ -1,6 +1,9 @@
 FactoryBot.define do
   factory :vocabulary do
     label { Faker::Lorem.unique.words.join(' ').titleize }
-    note { 'A vocaublary for use when testing' }
+
+    factory(:vocabulary_with_note) do
+      note { Faker::Lorem.sentence }
+    end
   end
 end

--- a/spec/views/admin/vocabularies/index.html.erb_spec.rb
+++ b/spec/views/admin/vocabularies/index.html.erb_spec.rb
@@ -1,14 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/vocabularies/index' do
-  let(:vocabularies) { FactoryBot.create_list(:vocabulary, 2) }
+  let(:vocabularies) { FactoryBot.create_list(:vocabulary_with_note, 2) }
 
   before { assign(:vocabularies, vocabularies) }
 
-  it 'renders a list of admin/vocabularies' do
+  it 'renders a list of admin/vocabularies', :aggregate_failures do
     render
-    cell_selector = Rails::VERSION::STRING >= '7' ? 'div>p' : 'tr>td'
-    assert_select cell_selector, text: Regexp.new('Label'.to_s), count: 2
-    assert_select cell_selector, text: Regexp.new('Note'.to_s), count: 2
+    expect(rendered).to have_selector(id: dom_id(vocabularies[0]))
+    expect(rendered).to have_selector(id: dom_id(vocabularies[1]))
+  end
+
+  it 'displays the vocabulary labels' do
+    vocabulary_labels = vocabularies.map(&:label)
+    render
+    expect(rendered).to include(*vocabulary_labels)
+  end
+
+  it 'displays the vocabulary notes' do
+    vocabulary_notes = vocabularies.map(&:note)
+    render
+    expect(rendered).to include(*vocabulary_notes)
+  end
+
+  it 'provides links to each vocabulary' do
+    render
+    expect(rendered).to have_link(href: url_for(vocabularies[1]))
+  end
+
+  it 'has a link to add vocabularies' do
+    render
+    expect(rendered).to have_link(href: new_vocabulary_path)
   end
 end


### PR DESCRIPTION
**RATIONALE**
We've been using the views built by the scaffold generator which are functional, but not tailored to our use needs.

This commit updates the index view to give a cleaner and more concise presentation of the relevant data.

**BEFORE**
<img width="766" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/76038819-8e88-4674-88c6-4f6ca2bf562c">


**AFTER**
<img width="777" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/0586b260-204a-4b3d-b8db-fd0135dd4f68">
