### PR TITLE
Improve Vocabulary show and edit views

### DIFF
--- a/app/assets/stylesheets/admin/dashboard.scss
+++ b/app/assets/stylesheets/admin/dashboard.scss
@@ -3,10 +3,5 @@
   margin-right: 2rem;
   margin-top: 1.5rem;
 
-  a {
-    color: #000099;
-    &.btn {
-      color: var(--bs-btn-color);
-    }
-  }
+  --bs-link-color-rgb: 0, 0, 175;
 }

--- a/app/assets/stylesheets/admin/vocabularies.scss
+++ b/app/assets/stylesheets/admin/vocabularies.scss
@@ -3,6 +3,74 @@
     background-color: white;
   }
 
+  a:link, a:visited { text-decoration: none; }
+  a:hover { text-decoration: underline}
+
+  max-width: 70rem;
+
+  .title_row {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+
+    h1 {
+      display: inline-block;
+      width: max-content;
+    }
+
+    .vocabulary_title {
+      flex-grow: 10;
+    }
+
+    .delete_action, .cancel_action {
+      width: max-content;
+    }
+
+  }
+
+  form {
+    label {
+      width: 5rem;
+      padding-right: 0.5rem;
+      text-align: right;
+    }
+    textarea {
+
+    }
+  }
+
+  .form_flex {
+    display: flex;
+    flex-wrap: wrap;
+
+    .form_buttons {
+      width: 10rem;
+
+    }
+
+    .form_fields {
+      flex-grow: 10;
+      a, input[type="submit"] {
+        margin-top: 0.5rem;
+        margin-left: 5.25rem;
+      }
+
+      div {
+        display: flex;
+        flex-wrap: wrap;
+        margin-bottom: 0.25rem;
+      }
+
+      input[type=text], textarea {
+        flex-grow: 10;
+      }
+
+
+    }
+  }
+
   .vocabulary_row {
     width: auto;
     display: flex;
@@ -32,5 +100,34 @@
 
   #add_vocab {
     margin-top: .75rem;
+  }
+
+  .vocabulary_terms {
+    margin-top: 0.5rem;
+    .term:nth-of-type(odd) {
+      background-color: white;
+    }
+
+
+    .term {
+      display: flex;
+      //flex-wrap: nowrap;
+      flex-wrap: wrap;
+
+      a {
+        display: inline-block;
+        min-width: 14.5rem;
+        margin-left: 0.5rem;
+      }
+
+      .note {
+        //max-width: 50%;
+        width: calc(100% - 18rem);
+        min-width: 15rem;
+        flex-shrink: 10;
+        margin-left: 0.5rem;
+      }
+
+    }
   }
 }

--- a/app/assets/stylesheets/tenejo.scss
+++ b/app/assets/stylesheets/tenejo.scss
@@ -58,3 +58,7 @@ footer {
   background-color: white;
   border-radius: 0.3em;
 }
+
+.validation_errors {
+  color: red;
+}

--- a/app/views/admin/terms/show.html.erb
+++ b/app/views/admin/terms/show.html.erb
@@ -1,11 +1,11 @@
 <div id="<%= dom_id(@term) -%>" class="term">
-    <h1 id="vocabulary_label"><%= @vocabulary.label -%></h1>
-    <h2 id="term_label"><%= @term.label -%></h2>
+    <h1 id="vocabulary_label"><%= link_to "Vocabularies", vocabularies_path %> > <%= @vocabulary.label -%></h1>
+    <h2 id="term_label"><%= link_to "Terms", vocabulary_terms_path(@vocabulary) %> > <%= @term.label -%></h2>
   <%= render @term %>
 
   <div>
     <%= link_to "Edit this term", edit_term_path(@term) %> |
-    <%= link_to "Back to terms", vocabulary_terms_path(@term.vocabulary) %>
+    <%= link_to "Back to vocabulary", @term.vocabulary %>
 
     <%= button_to "Destroy this term", [@term.vocabulary, @term], method: :delete %>
   </div>

--- a/app/views/admin/vocabularies/_form.html.erb
+++ b/app/views/admin/vocabularies/_form.html.erb
@@ -1,6 +1,6 @@
-<%= form_with(model: vocabulary) do |form| %>
+<%= form_with(model: vocabulary, class: 'card-body') do |form| %>
   <% if vocabulary.errors.any? %>
-    <div style="color: red">
+    <div class="validation_errors">
       <h2><%= pluralize(vocabulary.errors.count, "error") %> prohibited this vocabulary from being saved:</h2>
 
       <ul>
@@ -11,22 +11,37 @@
     </div>
   <% end %>
 
-  <div>
-    <%= form.label :label, style: "display: block" %>
-    <%= form.text_field :label %>
-  </div>
+  <div class="form_flex">
+    <div class="form_buttons">
+      <% if action_name == 'show' %>
+        <%= link_to "Edit this vocabulary", edit_vocabulary_path(@vocabulary), class: 'edit-action btn btn-sm btn-outline-primary' %>
+      <% end %>
+    </div>
 
-  <div>
-    <%= form.label :key, style: "display: block" %>
-    <%= form.text_field :key %>
-  </div>
+    <div class="form_fields">
+      <fieldset <%= 'disabled' if controller.action_name == 'show' -%>>
+        <div>
+          <%= form.label :label %>
+          <%= form.text_field :label %>
+        </div>
 
-  <div>
-    <%= form.label :note, style: "display: block" %>
-    <%= form.text_field :note %>
-  </div>
+        <div>
+          <%= form.label :key %>
+          <%= form.text_field :key %>
+        </div>
 
-  <div>
-    <%= form.submit %>
+        <div>
+          <%= form.label :note %>
+          <%= form.text_area :note %>
+        </div>
+
+        <% if action_name != 'show' %>
+          <%= form.submit "Save changes", class: 'btn btn-primary' %><br>
+          <%= link_to " Cancel changes", @vocabulary, class: 'cancel_action btn btn-sm btn-outline-info bi bi-x-square' %>
+        <% end %>
+
+      </fieldset>
+    </div>
+
   </div>
 <% end %>

--- a/app/views/admin/vocabularies/_vocabulary.html.erb
+++ b/app/views/admin/vocabularies/_vocabulary.html.erb
@@ -1,7 +1,12 @@
-<div id="<%= dom_id vocabulary %>">
+<div id="<%= dom_id vocabulary %>" class="card">
   <p>
     <strong>Label:</strong>
     <%= vocabulary.label %>
+  </p>
+
+  <p>
+    <strong>Key:</strong>
+    <span id="vocabulary_key"><%= vocabulary.key %></span>
   </p>
 
   <p>

--- a/app/views/admin/vocabularies/edit.html.erb
+++ b/app/views/admin/vocabularies/edit.html.erb
@@ -1,10 +1,10 @@
-<h1>Editing vocabulary</h1>
+<div id="vocabularies">
+  <div class="title_row">
+    <h1><%= link_to "Vocabularies", vocabularies_path %> > </h1>
+    <h1 class="vocabulary_title"> <%= @vocabulary.label %> (edit)</h1>
+  </div>
 
-<%= render "form", vocabulary: @vocabulary %>
-
-<br>
-
-<div>
-  <%= link_to "Show this vocabulary", @vocabulary %> |
-  <%= link_to "Back to vocabularies", vocabularies_path %>
+  <div class="card">
+    <%= render "form", vocabulary: @vocabulary %>
+  </div>
 </div>

--- a/app/views/admin/vocabularies/show.html.erb
+++ b/app/views/admin/vocabularies/show.html.erb
@@ -1,10 +1,26 @@
-<p style="color: green"><%= notice %></p>
+<div id="vocabularies">
+  <div class="title_row">
+    <h1><%= link_to "Vocabularies", vocabularies_path %> > </h1><h1 class="vocabulary_title"> <%= @vocabulary.label %> </h1>
+    <%= button_to " Delete this vocabulary", @vocabulary, method: :delete, class: 'delete_action btn btn-outline-danger bi bi-trash3-fill' %>
+  </div>
 
-<%= render @vocabulary %>
+  <div class="card">
+    <%= render "form", vocabulary: @vocabulary %>
+  </div>
 
-<div>
-  <%= link_to "Edit this vocabulary", edit_vocabulary_path(@vocabulary) %> |
-  <%= link_to "Back to vocabularies", vocabularies_path %>
+  <div class="vocabulary_terms card">
+    <div class="card-body">
+      <h2>Terms (<span id="term_count"><%= @vocabulary.terms.count -%></span>)</h2>
+      <% @vocabulary.terms.order(:label).each do |term| %>
+        <div class="term">
+          <div><%= link_to term.label, term %></div>
+          <div class="note"><%= term.note -%></div>
+        </div>
+      <% end %>
 
-  <%= button_to "Destroy this vocabulary", @vocabulary, method: :delete %>
+    </div>
+  </div>
+
+
 </div>
+

--- a/spec/factories/vocabularies.rb
+++ b/spec/factories/vocabularies.rb
@@ -2,6 +2,9 @@ FactoryBot.define do
   factory :vocabulary do
     label { Faker::Lorem.unique.words.join(' ').titleize }
 
+    # sets the key if it hasn't been provided
+    after(:build, &:validate)
+
     factory(:vocabulary_with_note) do
       note { Faker::Lorem.sentence }
     end

--- a/spec/views/admin/vocabularies/edit.html.erb_spec.rb
+++ b/spec/views/admin/vocabularies/edit.html.erb_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'admin/vocabularies/edit' do
     assert_select 'form[action=?][method=?]', vocabulary_path(vocabulary), 'post' do
       assert_select 'input[name=?]', 'vocabulary[label]'
 
-      assert_select 'input[name=?]', 'vocabulary[note]'
+      assert_select 'textarea[name=?]', 'vocabulary[note]'
     end
   end
 end

--- a/spec/views/admin/vocabularies/new.html.erb_spec.rb
+++ b/spec/views/admin/vocabularies/new.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'admin/vocabularies/new' do
     assert_select 'form[action=?][method=?]', vocabularies_path, 'post' do
       assert_select 'input[name=?]', 'vocabulary[label]'
 
-      assert_select 'input[name=?]', 'vocabulary[note]'
+      assert_select 'textarea[name=?]', 'vocabulary[note]'
     end
   end
 end

--- a/spec/views/admin/vocabularies/show.html.erb_spec.rb
+++ b/spec/views/admin/vocabularies/show.html.erb_spec.rb
@@ -1,16 +1,41 @@
 require 'rails_helper'
 
 RSpec.describe 'admin/vocabularies/show' do
-  before do
-    assign(:vocabulary, Vocabulary.create!(
-                          label: 'Name',
-                          note: 'Description'
-                        ))
+  let(:vocabulary) { FactoryBot.build(:vocabulary_with_note) }
+
+  before { assign(:vocabulary, vocabulary) }
+
+  it 'displays the vocabulary label' do
+    render
+    expect(rendered).to include(vocabulary.label)
   end
 
-  it 'renders attributes in <p>', :aggregate_failures do
+  it 'displays the vocabulary key' do
     render
-    expect(rendered).to match(/Label/)
-    expect(rendered).to match(/Note/)
+    expect(rendered).to have_field('vocabulary_key', with: vocabulary.key)
+  end
+
+  it 'displays the vocabulary note' do
+    render
+    expect(rendered).to include(vocabulary.note)
+  end
+
+  context 'with terms' do
+    let!(:terms) { FactoryBot.create_list(:term, 2, vocabulary: vocabulary) }
+
+    it 'displays the term count' do
+      render
+      expect(rendered).to have_selector('#term_count', text: '2')
+    end
+
+    it 'displays a list of terms' do
+      render
+      expect(rendered).to have_selector('div.term', count: 2)
+    end
+
+    it 'has a link to each term' do
+      render
+      expect(rendered).to have_link(href: url_for(terms[1]))
+    end
   end
 end


### PR DESCRIPTION
This commit starts to refine some of the scaffold UI into something tuned for our application. This commit shows the desired direction that we'll need to apply to other views (new) and term views as well.

**BEFORE**
<img width="984" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/e9a51640-2a80-4e67-b926-3b5428049fd9">

<img width="988" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/54492efb-4d97-474c-92d6-8b722b91f4dc">


**AFTER**
<img width="1150" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/3803c31c-904c-4a53-8d80-bd8a44444b29">

<img width="977" alt="image" src="https://github.com/curationexperts/t3/assets/3064318/e4bba5b5-1fa1-48f2-ab96-da431c8750d6">
