### PR TITLE
Add a relationship between Fields and Vocabularies

### DIFF
--- a/app/views/admin/fields/_field.json.jbuilder
+++ b/app/views/admin/fields/_field.json.jbuilder
@@ -1,3 +1,3 @@
-json.extract! field, :sequence, :id, :name, :data_type, :source_field, :active, :required,
+json.extract! field, :sequence, :id, :name, :data_type, :vocabulary_id, :source_field, :active, :required,
               :multiple, :list_view, :item_view, :searchable, :facetable, :created_at, :updated_at
 json.url field_url(field, format: :json)

--- a/db/migrate/20240708144104_add_vocabulary_to_fields.rb
+++ b/db/migrate/20240708144104_add_vocabulary_to_fields.rb
@@ -1,0 +1,5 @@
+class AddVocabularyToFields < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :fields, :vocabulary, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_03_214102) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_08_144104) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -83,8 +83,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_214102) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "sequence"
+    t.bigint "vocabulary_id"
     t.index ["name"], name: "index_fields_on_name", unique: true
     t.index ["sequence"], name: "index_fields_on_sequence"
+    t.index ["vocabulary_id"], name: "index_fields_on_vocabulary_id"
   end
 
   create_table "ingests", force: :cascade do |t|
@@ -213,6 +215,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_214102) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "fields", "vocabularies"
   add_foreign_key "ingests", "users"
   add_foreign_key "resources", "blueprints"
   add_foreign_key "roles_users", "roles"

--- a/spec/models/blueprint_spec.rb
+++ b/spec/models/blueprint_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Blueprint, :aggregate_failures do
   describe 'fields' do
     it 'defaults to all active fields' do
       FactoryBot.create_list(:field, 2)
-      expect(blueprint.fields).to match_array Field.active
+      expect(blueprint.fields).to match_array Field.active_in_sequence
     end
   end
 end


### PR DESCRIPTION
**ISSUE**
The `vocabulary` data type in fields is currently hard-coded to map to the "Collections" vocabulary. We want to permit admisitrators to select which vocabulary they want to use.

This change begins that process by allowing the Field --> Vocabulary relationship to be persisted in the data models.