### PR TITLE
Separate collection support from vocabulary support

### DIFF
--- a/app/helpers/t3_form_builder.rb
+++ b/app/helpers/t3_form_builder.rb
@@ -12,4 +12,5 @@ class T3FormBuilder < ActionView::Helpers::FormBuilder
     option_tags = @template.options_from_collection_for_select(Collection.order(:created_at), :label, :label, selected)
     select(method, option_tags, { prompt: 'Select one', selected: '', disabled: true }, select_options)
   end
+  alias collection_field vocabulary_field
 end

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -10,7 +10,8 @@ class Field < ApplicationRecord
     float: 4,
     date: 5,
     boolean: 6,
-    vocabulary: 7
+    collection: 7,
+    vocabulary: 8
   }, validate: true
 
   TYPE_TO_SOLR = {
@@ -20,6 +21,7 @@ class Field < ApplicationRecord
     'float' => 'dbt',
     'date' => 'dt',
     'boolean' => 'b',
+    'collection' => 's',
     'vocabulary' => 's'
   }.freeze
 
@@ -30,6 +32,7 @@ class Field < ApplicationRecord
     'float' => :number_field,
     'date' => :date_field,
     'boolean' => :check_box,
+    'collection' => :collection_field,
     'vocabulary' => :vocabulary_field
   }.freeze
 

--- a/spec/views/admin/collections/edit.html.erb_spec.rb
+++ b/spec/views/admin/collections/edit.html.erb_spec.rb
@@ -170,8 +170,8 @@ RSpec.describe 'admin/items/edit', :solr do
   end
 
   describe 'a vocabulary field' do
-    let(:vocabulary_field) do
-      FactoryBot.build(:field, name: 'collection', data_type: 'vocabulary', multiple: false, id: 1, sequence: 1)
+    let(:collection_field) do
+      FactoryBot.build(:field, name: 'collection', data_type: 'collection', multiple: false, id: 1, sequence: 1)
     end
 
     before do
@@ -184,13 +184,13 @@ RSpec.describe 'admin/items/edit', :solr do
     end
 
     it 'renders a slection list' do
-      allow(blueprint).to receive(:fields).and_return([vocabulary_field])
+      allow(blueprint).to receive(:fields).and_return([collection_field])
       render
       expect(rendered).to have_select('item[metadata][collection]')
     end
 
     it 'lists available values' do
-      allow(blueprint).to receive(:fields).and_return([vocabulary_field])
+      allow(blueprint).to receive(:fields).and_return([collection_field])
       render
       select_options = Capybara.string(rendered).all('select option').map(&:text)
       expect(select_options).to include('Cyan', 'Magenta', 'Yellow')


### PR DESCRIPTION
**ISSUE**
We initially built the Collection UI behavior assuming that collection labels would be handled as a kind of vocabulary.

While we want the UI for Collections and Vocabularies to be as similar as possible if not identical; their differences under-the-hood are too large to abrstract away right now.

In order to simplify implementing the Vocabulary UI, we're splitting out the data_type and UI support for Collections, so the two aren't fighting to overload the same methods.