### PR TITLE
Add form helper to render local vocabulary terms

### DIFF
--- a/app/helpers/t3_form_builder.rb
+++ b/app/helpers/t3_form_builder.rb
@@ -1,7 +1,7 @@
 # Custom form controls to support T3 field-specific data types
 # e.g. #vacabulary provides a customized select populated with a defined vocabulary
 class T3FormBuilder < ActionView::Helpers::FormBuilder
-  def vocabulary_field(method, options = {})
+  def collection_field(method, options = {})
     multiple = options.delete(:multiple)
     selected = options.delete(:value) || ''
     select_options = options.except(:multiple)
@@ -12,5 +12,21 @@ class T3FormBuilder < ActionView::Helpers::FormBuilder
     option_tags = @template.options_from_collection_for_select(Collection.order(:created_at), :label, :label, selected)
     select(method, option_tags, { prompt: 'Select one', selected: '', disabled: true }, select_options)
   end
-  alias collection_field vocabulary_field
+
+  # Render a slect box with options populated from a local vocabulary
+  # @param options [Hash] primary options include
+  #   :vocabualry - the vocabulary to display
+  #   :selected - the current value for the input (must match the key of one of the vocabulary terms)
+  #   :multiple - flag whether this form parameter should be named as an individual field or part of an array []
+  #   :prompt - defaults to 'Select one', accepts an alternate string, or pass `false` to suppress
+  #   see Rails FormBuilder#select for additional options
+  def vocabulary_field(method, options = {}, html_options = {})
+    vocabulary = options.delete(:vocabulary)
+    multiple = options.delete(:multiple)
+    html_options[:name] ||= @template.field_name(@object_name, method, multiple: multiple)
+    options[:prompt] ||= 'Select one'
+    choices = vocabulary.terms.order(:label, :key).map { |term| [term.label, term.key] }
+
+    select(method, choices, options, html_options)
+  end
 end

--- a/spec/helpers/t3_form_builder_spec.rb
+++ b/spec/helpers/t3_form_builder_spec.rb
@@ -10,22 +10,22 @@ RSpec.describe T3FormBuilder do
   end
   let(:tag_options) { {} }
 
-  describe '#vocabulary' do
-    let(:vocabulary_helper) { Capybara.string(form_builder.vocabulary_field(:collection, tag_options)) }
+  describe '#collection' do
+    let(:collection_helper) { Capybara.string(form_builder.collection_field(:collection, tag_options)) }
 
     it 'renders a select with the expected id' do
-      expect(vocabulary_helper).to have_select('item[metadata][collection]')
+      expect(collection_helper).to have_select('item[metadata][collection]')
     end
 
     it 'displays a prompt when no value is selected' do
-      expect(vocabulary_helper).to have_selector('select option[selected]', text: 'Select one')
+      expect(collection_helper).to have_selector('select option[selected]', text: 'Select one')
     end
 
     context 'with options {multipe: true}' do
       let(:tag_options) { { multiple: true } }
 
       it 'renders as an array instead of a multi-select' do
-        expect(vocabulary_helper).to have_select('item[metadata][collection][]')
+        expect(collection_helper).to have_select('item[metadata][collection][]')
       end
     end
 
@@ -42,12 +42,52 @@ RSpec.describe T3FormBuilder do
       end
 
       example 'showing available collections' do
-        select_options = vocabulary_helper.all('option').map(&:text)
+        select_options = collection_helper.all('option').map(&:text)
         expect(select_options).to eq ['Select one', 'Red', 'Green', 'Blue']
       end
 
       example 'with a selection' do
-        expect(vocabulary_helper).to have_selector('select option[selected]', text: 'Green')
+        expect(collection_helper).to have_selector('select option[selected]', text: 'Green')
+      end
+    end
+  end
+
+  describe '#vocabulary' do
+    let(:vocabulary) { FactoryBot.create(:vocabulary) }
+    let(:tag_options) { { vocabulary: vocabulary } }
+    let(:vocabulary_helper) { Capybara.string(form_builder.vocabulary_field('Resource Type', tag_options)) }
+
+    it 'renders a select with the expected id' do
+      expect(vocabulary_helper).to have_select('item[metadata][Resource Type]')
+    end
+
+    it 'displays a prompt when no value is selected' do
+      expect(vocabulary_helper).to have_selector('select option', text: 'Select one')
+    end
+
+    context 'with options {multipe: true}' do
+      let(:tag_options) { { vocabulary: vocabulary, multiple: true } }
+
+      it 'renders as an array instead of a multi-select' do
+        expect(vocabulary_helper).to have_select('item[metadata][Resource Type][]')
+      end
+    end
+
+    describe 'displays options' do
+      before do
+        FactoryBot.create(:term, label: 'γάμμα', key: 'gamma', vocabulary: vocabulary)
+        FactoryBot.create(:term, label: 'άλφα', key: 'alpha', vocabulary: vocabulary)
+        FactoryBot.create(:term, label: 'βήτα་', key: 'beta', vocabulary: vocabulary)
+      end
+
+      example 'for each vocabulary term sorted lexically' do
+        select_options = vocabulary_helper.all('option').map(&:text)
+        expect(select_options).to eq ['Select one', 'άλφα', 'βήτα་', 'γάμμα']
+      end
+
+      example 'with a term selected' do
+        tag_options[:selected] = 'beta'
+        expect(vocabulary_helper).to have_selector('select option[selected]', text: 'βήτα')
       end
     end
   end


### PR DESCRIPTION
Previously, we had used the terminology 'voczbulary' for the list of collection names and had a corresponding FormBuilder helper.

We want to separate code to support collecitons in the UI from code to support vocabularies. This change adds a separate helper that renders a selection list of the terms associated with a specific vocabulary.