### PR TITLE
Add vocabulary support in item and collection edit forms

### DIFF
--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -29,15 +29,18 @@
             <% item_detail.object[field.name] ||= [nil] %>
             <% item_detail.object[field.name].each.with_index(1) do |value, index| %>
               <%= item_detail.send(field.form_helper, field.name,
-                                   value: value, id: item_detail.field_id(field.name, index),
-                                   multiple: field.multiple, aria: {label: field.name + " #{index}",
-                                                                    required: field.required}) %>
+                                   value: value,
+                                   multiple: true,
+                                   id: item_detail.field_id(field.name, index),
+                                   vocabulary: field.vocabulary,
+                                   aria: {label: field.name + " #{index}", required: field.required}) %>
               <%= form.button t('t3.item.delete_entry', field: field.name, index: index), name: 'refresh', value: ['delete', field.name, index], class: 'delete_value' %>
               <br/>
             <% end %>
             <%= form.button t('t3.item.add_entry', field: field.name), name: 'refresh', value: ['add', field.name, -1], class: 'add_value' %>
           <% else %>
-            <%= item_detail.send(field.form_helper, field.name, multiple: field.multiple,
+            <%= item_detail.send(field.form_helper, field.name,
+                                 vocabulary: field.vocabulary,
                                  aria: {label: field.name, required: field.required}) %>
           <% end %>
         </label>

--- a/spec/helpers/t3_form_builder_spec.rb
+++ b/spec/helpers/t3_form_builder_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe T3FormBuilder do
     end
 
     it 'displays a prompt when no value is selected' do
-      expect(collection_helper).to have_selector('select option[selected]', text: 'Select one')
+      expect(collection_helper).to have_selector('select option', text: 'Select one')
     end
 
     context 'with options {multipe: true}' do
@@ -30,23 +30,22 @@ RSpec.describe T3FormBuilder do
     end
 
     describe 'displays options' do
-      let(:tag_options) { { value: 'Green' } }
-
       before do
         collections = [
           instance_double(Collection, { label: 'Red', id: 5 }),
           instance_double(Collection, { label: 'Green', id: 20 }),
           instance_double(Collection, { label: 'Blue', id: 25 })
         ]
-        allow(Collection).to receive(:order).and_return(collections)
+        allow(Collection).to receive(:all).and_return(collections)
       end
 
       example 'showing available collections' do
         select_options = collection_helper.all('option').map(&:text)
-        expect(select_options).to eq ['Select one', 'Red', 'Green', 'Blue']
+        expect(select_options).to eq ['Select one', 'Blue', 'Green', 'Red']
       end
 
       example 'with a selection' do
+        tag_options[:selected] = 'Green'
         expect(collection_helper).to have_selector('select option[selected]', text: 'Green')
       end
     end

--- a/spec/views/admin/collections/edit.html.erb_spec.rb
+++ b/spec/views/admin/collections/edit.html.erb_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe 'admin/items/edit', :solr do
         instance_double(Collection, { id: 2, label: 'Magenta' }),
         instance_double(Collection, { id: 4, label: 'Yellow' })
       ]
-      allow(Collection).to receive(:order).and_return(collections)
+      allow(Collection).to receive(:all).and_return(collections)
     end
 
     it 'renders a slection list' do

--- a/spec/views/admin/items/edit.html.erb_spec.rb
+++ b/spec/views/admin/items/edit.html.erb_spec.rb
@@ -120,6 +120,24 @@ RSpec.describe 'admin/items/edit', :solr do
     end
   end
 
+  describe 'a vocabualry field' do
+    let(:vocabulary) { FactoryBot.build(:vocabulary) }
+    let(:vocab_field) do
+      FactoryBot.build(:field, name: 'list', data_type: 'vocabulary', vocabulary: vocabulary, multiple: false)
+    end
+
+    before do
+      FactoryBot.create(:term, label: 'Draft', vocabulary: vocabulary)
+      FactoryBot.create(:term, label: 'Published', vocabulary: vocabulary)
+    end
+
+    it 'renders as a vocabulary selection field' do
+      allow(blueprint).to receive(:fields).and_return([vocab_field])
+      render
+      expect(rendered).to have_select('item_metadata_list', options: ['Select one', 'Draft', 'Published'])
+    end
+  end
+
   describe 'a multivalue field' do
     let(:string_field) { FactoryBot.build(:field, name: 'keyword', data_type: 'string', multiple: true) }
     let(:item) do


### PR DESCRIPTION
Makes the changes necessary to support vocabulary fields in the new and edit forms for Items and Collections.