### PR TITLE
Allow administrators to choose a specific vocabulary for fields

### DIFF
--- a/app/controllers/admin/fields_controller.rb
+++ b/app/controllers/admin/fields_controller.rb
@@ -82,7 +82,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def field_params
-      params.require(:field).permit(:name, :data_type, :source_field, :active, :required, :multiple, :list_view,
+      params.require(:field).permit(:name, :type_selection, :source_field, :active, :required, :multiple, :list_view,
                                     :item_view, :searchable, :facetable)
     end
   end

--- a/app/helpers/data_type_helper.rb
+++ b/app/helpers/data_type_helper.rb
@@ -1,0 +1,9 @@
+# Helpers to support selection and display of complex data types
+module DataTypeHelper
+  def data_type_options
+    {
+      'Core Types' => Field.data_types.except('vocabulary').keys.map { |k| [k, k] },
+      'Local Vocabularies' => Vocabulary.pluck(:label, :id).sort.map { |label, id| [label, "vocabulary|#{id}"] }
+    }
+  end
+end

--- a/app/views/admin/fields/_form.html.erb
+++ b/app/views/admin/fields/_form.html.erb
@@ -21,8 +21,8 @@
       </div>
       <div class="column-2">
         <div>
-          <%= form.label :data_type, style: "display: block" %>
-          <%= form.select :data_type, Field.data_types.keys %>
+          <%= form.label :type_selection, 'Data Type', style: "display: block" %>
+          <%= form.select :type_selection, data_type_options %>
         </div>
 
         <div>

--- a/spec/helpers/data_type_helper_spec.rb
+++ b/spec/helpers/data_type_helper_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe DataTypeHelper do
+  describe '#data_type_optons' do
+    let(:options) { helper.data_type_options }
+
+    it 'includes basic data types' do
+      expect(options['Core Types'].map(&:second)).to include('string', 'date', 'boolean')
+    end
+
+    it 'includes local vocabularies (alphabetized)' do
+      FactoryBot.create(:vocabulary, label: 'Resource Types')
+      FactoryBot.create(:vocabulary, label: 'Custom Terms')
+      expect(options['Local Vocabularies'].map(&:first)).to eq(['Custom Terms', 'Resource Types'])
+    end
+
+    it 'includes vocabulary ID in the option value' do
+      vocab = FactoryBot.create(:vocabulary, label: 'Custom Terms')
+      expect(options['Local Vocabularies'].map(&:second)).to include("vocabulary|#{vocab.id}")
+    end
+  end
+end

--- a/spec/views/admin/fields/edit.html.erb_spec.rb
+++ b/spec/views/admin/fields/edit.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'admin/fields/edit' do
     render
     form = Capybara.string(rendered).find("form[action=\"#{fields_path}\"][method=\"post\"]")
     expect(form).to have_field('field_name')
-    expect(form).to have_select('field_data_type')
+    expect(form).to have_select('field_type_selection')
     expect(form).to have_field('field_source_field')
     expect(form).to have_field('field_active')
     expect(form).to have_field('field_required')
@@ -23,5 +23,27 @@ RSpec.describe 'admin/fields/edit' do
     expect(form).to have_field('field_facetable')
     expect(form).to have_field('field_list_view')
     expect(form).to have_field('field_item_view')
+  end
+
+  describe 'type_selection' do
+    it 'selects basic types' do
+      field.data_type = 'date'
+      render
+      expect(rendered).to have_select('field_type_selection', selected: 'date')
+    end
+
+    it 'selects vocabularies' do
+      field.data_type = 'vocabulary'
+      field.vocabulary = FactoryBot.create(:vocabulary, label: 'Resource Type')
+      render
+      expect(rendered).to have_select('field_type_selection', selected: 'Resource Type')
+    end
+
+    it 'omits vocabulary for basic types' do
+      field.data_type = 'boolean'
+      field.vocabulary = FactoryBot.create(:vocabulary, label: 'Custom Terms')
+      render
+      expect(rendered).to have_select('field_type_selection', selected: 'boolean')
+    end
   end
 end

--- a/spec/views/admin/fields/new.html.erb_spec.rb
+++ b/spec/views/admin/fields/new.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'admin/fields/new' do
     render
     form = Capybara.string(rendered).find("form[action=\"#{fields_path}\"][method=\"post\"]")
     expect(form).to have_field('field_name')
-    expect(form).to have_select('field_data_type', options: Field.data_types.keys)
+    expect(form).to have_select('field_type_selection', with_options: ['string', 'integer', 'collection'])
     expect(form).to have_field('field_source_field')
     expect(form).to have_checked_field('field_active')
     expect(form).to have_unchecked_field('field_required')

--- a/spec/views/admin/fields/show.html.erb_spec.rb
+++ b/spec/views/admin/fields/show.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'admin/fields/show' do
     render
     form = Capybara.string(rendered).find(id: 'field_form')
     expect(form).to have_field('field_name')
-    expect(form).to have_select('field_data_type')
+    expect(form).to have_select('field_type_selection')
     expect(form).to have_field('field_source_field')
     expect(form).to have_field('field_active')
     expect(form).to have_field('field_required')


### PR DESCRIPTION
This change extends the data type selection on fields to include local vocabularies. In addition to selecting basic data types like string or integer, administrators can now specify that a field should be constrained to a specific local vocabulary.