### PR TITLE
Store term IDs instead of keys in Resource records

### DIFF
--- a/app/helpers/t3_form_builder.rb
+++ b/app/helpers/t3_form_builder.rb
@@ -17,7 +17,7 @@ class T3FormBuilder < ActionView::Helpers::FormBuilder
   #   see #custom_select for other common options
   def vocabulary_field(method, options = {}, html_options = {})
     vocabulary = options.delete(:vocabulary)
-    choices = vocabulary.terms.order(:label, :key).pluck(:label, :key)
+    choices = vocabulary.terms.order(:label, :id).pluck(:label, :id)
     custom_select(method, choices, options, html_options)
   end
 

--- a/spec/helpers/t3_form_builder_spec.rb
+++ b/spec/helpers/t3_form_builder_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe T3FormBuilder do
       end
 
       example 'with a term selected' do
-        tag_options[:selected] = 'beta'
+        tag_options[:selected] = vocabulary.terms.find_by(key: 'beta').id
         expect(vocabulary_helper).to have_selector('select option[selected]', text: 'βήτα')
       end
     end


### PR DESCRIPTION
**ISSUE**
Term keys are not guaranteed to be unique across vocabularies. In order to unambiguously look up the label, we would need both the Term key and the Vocabulary key or ID. We don't currently have this stored at the Resource level; to derive it, we would need to load the Blueprint for the item, find the corresponding Field, and then look up the Vocabulary associated with the field.

**RESOLUTION**
Store the Term ID in the Resrouce record instead of the key. The ID is guaranteed to be unique across all terms and does not require a secondary key to resolve unambiguously.