### PR TITLE
[REFACTOR] Move solrization code into Field model

### DIFF
--- a/app/models/concerns/solrization.rb
+++ b/app/models/concerns/solrization.rb
@@ -1,0 +1,43 @@
+# Solr naming and conversion support
+module Solrization
+  extend ActiveSupport::Concern
+
+  TYPE_TO_SOLR = {
+    'string' => 's',
+    'text_en' => 'te',
+    'integer' => 'lt',
+    'float' => 'dbt',
+    'date' => 'dt',
+    'boolean' => 'b',
+    'collection' => 's',
+    'vocabulary' => 's'
+  }.freeze
+
+  # Render a solr field key => value pair based on the field configuration
+  # @return Hash solr field names mapped to metadata values
+  def to_solr(value)
+    {}.tap do |doc|
+      doc[solr_field_name] = value
+      doc[solr_facet_field] = value if facetable
+    end
+  end
+
+  # Transform definition into a dynamic field suffix for Solr
+  # see solr/conf/schema.xml
+  def solr_suffix
+    suffix = '_'
+    suffix += TYPE_TO_SOLR[data_type]
+    suffix += 'si' # store and index all fields (until we have a clear reason not to)
+    suffix += 'm' if multiple?
+    suffix
+  end
+
+  # Generate a solr field name based onf the field name and the dynamic suffix derived from field settings
+  def solr_field_name
+    @solr_field_name ||= name.downcase.gsub(/[- ]/, '_') + solr_suffix
+  end
+
+  def solr_facet_field
+    @solr_facet_field ||= data_type == 'text_en' ? solr_field_name.gsub('_tesi', '_si') : solr_field_name
+  end
+end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -85,11 +85,8 @@ class Resource < ApplicationRecord
   def to_solr
     doc = solr_base_values
     blueprint.fields.each do |field|
-      solr_field = field.solr_field_name
-      solr_facet = field.solr_facet_field
       value = metadata[field.name]
-      doc[solr_field] = value
-      doc[solr_facet] = value if field.facetable
+      doc.merge!(field.to_solr(value))
     end
     doc
   end


### PR DESCRIPTION
**ISSUE**
The #to_solr method in the `Resource` model needs to know about a number of different `Field` methods to produce a desired Solr document. We'd like to encapsulate that knowlege in the `Field` class.

**RESOLUTION**
Refactor the solrization call to be a single method call to the field with the value to solrize as the method parameter. This simplifies the interface between `Resource` and `Field` models.