### PR TITLE
[REFACTOR] Clean up Solr field naming

### DIFF
--- a/app/models/concerns/solrization.rb
+++ b/app/models/concerns/solrization.rb
@@ -24,20 +24,40 @@ module Solrization
 
   # Transform definition into a dynamic field suffix for Solr
   # see solr/conf/schema.xml
-  def solr_suffix
+  def solr_suffix(type = data_type, stored: true, indexed: true)
     suffix = '_'
-    suffix += TYPE_TO_SOLR[data_type]
-    suffix += 'si' # store and index all fields (until we have a clear reason not to)
+    suffix += TYPE_TO_SOLR[type]
+    suffix += 's' if stored
+    suffix += 'i' if indexed
     suffix += 'm' if multiple?
     suffix
   end
 
   # Generate a solr field name based onf the field name and the dynamic suffix derived from field settings
   def solr_field_name
-    @solr_field_name ||= name.downcase.gsub(/[- ]/, '_') + solr_suffix
+    @solr_field_name ||= solr_base_name + solr_suffix
   end
 
+  # Return a facet friendly - i.e. non-tokenized - version of the field name
   def solr_facet_field
-    @solr_facet_field ||= data_type == 'text_en' ? solr_field_name.gsub('_tesi', '_si') : solr_field_name
+    @solr_facet_field ||= text_en? ? indexed_as_symbol : solr_field_name
+  end
+
+  private
+
+  # Generate a solr-friendly version of the field name
+  # see Name - https://solr.apache.org/guide/solr/latest/indexing-guide/fields.html#field-properties
+  def solr_base_name
+    name.parameterize.gsub('-', '_') # parameterize retains dashes and underscores; Solr names want only underscores
+  end
+
+  # Version of the field name that is indexed as a literal version of the field, but not stored
+  def indexed_as_symbol
+    solr_base_name + solr_suffix('string', stored: false)
+  end
+
+  def clear_solr_field
+    @solr_field_name = nil
+    @solr_facet_field = nil
   end
 end

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -109,11 +109,6 @@ class Field < ApplicationRecord
 
   private
 
-  def clear_solr_field
-    @solr_field_name = nil
-    @solr_facet_field = nil
-  end
-
   def update_catalog_controller
     SolrService.current.update_catalog_controller
   end


### PR DESCRIPTION
This commit refactors the Solr field naming code in anticipation of extendig it to provide additional support for vocabulary fields.