### PR TITLE
Add ingest support for vocabulary fields

### DIFF
--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -47,7 +47,16 @@ class ImportJob < ApplicationJob
 
   # Return a hash with incoming document keys mapped to their blueprint targets
   def build_description(blueprint, doc)
+    process_vocabularies(blueprint, doc)
     doc.transform_keys(blueprint.key_map).merge({ ingest_snippet: doc.to_json[0..99] })
+  end
+
+  # Transform vocabulary terms to corresponding ids
+  def process_vocabularies(blueprint, doc)
+    blueprint.fields.select(&:vocabulary?).each do |field|
+      values = doc[field.source_field]
+      doc[field.source_field] = field.vocabulary.id_lookup(values)
+    end
   end
 
   # Save a new Item, rescuing & capturing exceptions

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -16,6 +16,16 @@ class Vocabulary < ApplicationRecord
     key
   end
 
+  def id_lookup(values)
+    ids = []
+    Array(values).each do |value|
+      term = terms.find_by(key: value)
+      term ||= terms.find_by(label: value)
+      ids << term.id if term
+    end
+    values.respond_to?(:each) ? ids : ids.first
+  end
+
   private
 
   # Set the key attribute if it is blank


### PR DESCRIPTION
**ISSUE**
When importing content from a foreign system, we don't necessarily have access to internal database ids for vocabulary terms. Therefore, we'd like to be able to import using term labels or keys.

**RESOLUTION**
This change adds a pre-processor to the imorter that scans vocabulary fields and maps the contents to the corresponding term IDs before attempting to create a respository item.