### PR TITLE
[FIX] Duplicate source_fields only populate last field

### DIFF
--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -36,6 +36,7 @@ class Field < ApplicationRecord
                                       'separated by single spaces or dashes' }
 
   validates :data_type, presence: true
+  validates :source_field, uniqueness: { case_sensitive: false }, allow_nil: true
   validate :valid_vocabulary
 
   before_save :check_sequence

--- a/db/migrate/20240718190620_add_source_field_index_to_fields.rb
+++ b/db/migrate/20240718190620_add_source_field_index_to_fields.rb
@@ -1,0 +1,5 @@
+class AddSourceFieldIndexToFields < ActiveRecord::Migration[7.1]
+  def change
+    add_index :fields, :source_field, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_08_144104) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_18_190620) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -86,6 +86,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_08_144104) do
     t.bigint "vocabulary_id"
     t.index ["name"], name: "index_fields_on_name", unique: true
     t.index ["sequence"], name: "index_fields_on_sequence"
+    t.index ["source_field"], name: "index_fields_on_source_field", unique: true
     t.index ["vocabulary_id"], name: "index_fields_on_vocabulary_id"
   end
 

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -147,6 +147,16 @@ RSpec.describe Field do
     end
   end
 
+  describe '#source_field' do
+    it 'cannot be the same for multiple fields' do
+      field.source_field = 'field_ssi'
+      field.save!
+      conflicting_field = FactoryBot.build(:field, source_field: 'field_ssi')
+      conflicting_field.validate
+      expect(conflicting_field.errors.where(:source_field, :taken)).to be_present
+    end
+  end
+
   describe '#type_selection=' do
     it 'sets the data_type' do
       field.type_selection = 'boolean'


### PR DESCRIPTION
**ISSUE**
When multiple fields have the same value for `source_field` only the last field is populated, any earlier Fields defined with the same source field are omitted on import.

**RESOUTION**
Don't allow multiple fields to use the same source field. If behavior like this is required, use an external tool to modify the manifest prior to importing it. Create a differently named field in the manifest with a copy of the relevant metadata. Now, each uniquely named field in the manifest can be mapped to a different field for import.