### PR TITLE
Log invalid vocabulary terms during ingests

### DIFF
--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -47,16 +47,7 @@ class ImportJob < ApplicationJob
 
   # Return a hash with incoming document keys mapped to their blueprint targets
   def build_description(blueprint, doc)
-    process_vocabularies(blueprint, doc)
     doc.transform_keys(blueprint.key_map).merge({ ingest_snippet: doc.to_json[0..99] })
-  end
-
-  # Transform vocabulary terms to corresponding ids
-  def process_vocabularies(blueprint, doc)
-    blueprint.fields.select(&:vocabulary?).each do |field|
-      values = doc[field.source_field]
-      doc[field.source_field] = field.vocabulary.id_lookup(values)
-    end
   end
 
   # Save a new Item, rescuing & capturing exceptions

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -16,16 +16,6 @@ class Vocabulary < ApplicationRecord
     key
   end
 
-  def id_lookup(values)
-    ids = []
-    Array(values).each do |value|
-      term = terms.find_by(key: value)
-      term ||= terms.find_by(label: value)
-      ids << term.id if term
-    end
-    values.respond_to?(:each) ? ids : ids.first
-  end
-
   private
 
   # Set the key attribute if it is blank

--- a/spec/models/resource_shared_examples.rb
+++ b/spec/models/resource_shared_examples.rb
@@ -76,7 +76,7 @@ RSpec.shared_examples 'a resource' do
   describe 'with vocabulary fields' do
     let(:vocabulary) { FactoryBot.create(:vocabulary, label: 'Test Vocab') }
     # let(:awaiting_approval) { FactoryBot.create(:term, label: 'Awaiting final approval', vocabulary: vocabulary) }
-    let(:unpublished) { FactoryBot.create(:term, label: 'Unpulished Text', vocabulary: vocabulary) }
+    let(:unpublished) { FactoryBot.create(:term, label: 'Unpulished Text', key: 'unpub', vocabulary: vocabulary) }
 
     before do
       allow(blueprint).to receive(:fields).and_return(
@@ -98,7 +98,24 @@ RSpec.shared_examples 'a resource' do
       expect(resource).to be_valid
     end
 
-    example 'when terms are not valid' do
+    it 'accepts term keys' do
+      resource.metadata['Publication Status'] = [unpublished.key]
+      expect(resource).to be_valid
+    end
+
+    it 'accepts term values' do
+      resource.metadata['Publication Status'] = [unpublished.label]
+      expect(resource).to be_valid
+    end
+
+    it 'persists term ids' do
+      resource.metadata['Publication Status'] = [unpublished.key]
+      resource.save!
+      resource.reload
+      expect(resource.metadata['Publication Status']).to eq [unpublished.id]
+    end
+
+    it 'gives validation errors when terms are not valid' do
       # e.g. assign a term from a vocabulary not associated with the field
       foreign_term = FactoryBot.create(:term, vocabulary: FactoryBot.create(:vocabulary))
       resource.metadata['Publication Status'] = [foreign_term.id]


### PR DESCRIPTION
**ISSUE**
The previous code silently discarded any terms in vocabulary fields that could not be matched to a corresponding entry in the vocabulary. This could result in data loss without users' knowleged.

**RESOLUTION**
Allow the assignment of any value(s) to vocabulary fields. Look up the fields as keys, labels, or ids against the vocabulary during validation AND convert them to the corresponding Term id before saving.