### PR TITLE
Improve ImportJob performance by caching blueprints

### DIFF
--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -41,8 +41,17 @@ class ImportJob < ApplicationJob
 
   # Return the blueprint object matching the name from the input document
   def find_blueprint(doc)
-    blueprint_name = doc['has_model_ssim']&.first
-    Blueprint.find_by(name: blueprint_name) || Blueprint.find_by(name: 'Default')
+    name = doc['has_model_ssim']&.first
+    fetch_blueprint(name)
+  end
+
+  # Lookup a blueprint based on it's name
+  # NOTE: Caches previous lookups for the duration of the ImportJob
+  def fetch_blueprint(name)
+    @blueprint_cache ||= Hash.new do |hash, key|
+      hash[key] = Blueprint.find_by(name: key) || Blueprint.find_by(name: 'Default')
+    end
+    @blueprint_cache[name]
   end
 
   # Return a hash with incoming document keys mapped to their blueprint targets


### PR DESCRIPTION
Previously, import jobs would do a database lookup for each record in the manifest to resolve the blueprint name in the record to a blueprint loaded from the database.

Typically many records, if not all, in an ingest manifest share the same blueprint. Reloading the same blueprint from the database for each record is a relatively expensive operation.

This change adds a cache to the lookup so each job only loads a blueprint from the database once regardless of how many records in the manifest use it.