### PR TITLE
[REFACTOR] Cache term ID lookup tables

### DIFF
--- a/app/models/concerns/solrization.rb
+++ b/app/models/concerns/solrization.rb
@@ -73,9 +73,13 @@ module Solrization
     return value unless vocabulary?
 
     if multiple
-      value.map { |id| Term.find(id).label }
+      value.map { |id| term_label(id) }
     else
-      Term.find(value).label
+      term_label(value)
     end
+  end
+
+  def term_label(id)
+    Term.find_by(id: id).label
   end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -191,9 +191,7 @@ class Resource < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def cast_term(field, term)
-    id = field.vocabulary.terms.find_by(key: term)&.id
-    id ||= field.vocabulary.terms.find_by(label: term)&.id
-    id ||= field.vocabulary.terms.find_by(id: term)&.id
+    id = field.vocabulary.resolve_term(term)
     TermFactory.call(field, term, id)
   end
 

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -16,6 +16,14 @@ class Vocabulary < ApplicationRecord
     key
   end
 
+  # Return the id for a given a term key, label, id, or id in string form
+  # Returns nil if supplied value does not exist in the vocabulary
+  # @param [String, Integer] - value to match
+  # @return [Integer, nil] - id of matching term or nil
+  def resolve_term(target)
+    id_map[target.to_s]
+  end
+
   private
 
   # Set the key attribute if it is blank
@@ -25,5 +33,17 @@ class Vocabulary < ApplicationRecord
   # * whitespace and other non-alphanumeric characters collapsed into single dashes
   def set_key
     self.key = label&.gsub('_', '-')&.parameterize if key.blank?
+  end
+
+  # Return a lookup hash mapping the string version of each ID, the key, and the label
+  # for each term to it's corresponding database ID
+  def id_map
+    @id_map ||= terms.map do |term|
+      [
+        [term.id.to_s, term.id],
+        [term.key, term.id],
+        [term.label, term.id]
+      ]
+    end.flatten(1).to_h
   end
 end


### PR DESCRIPTION
Move term lookup from the ImportJob to the Vocabulary object. This allows us to create a lookup table for Term ids that persists for the duration of the Vocabulary object.

This ensures that vocabularies are stable for the duration of import jobs.