### PR TITLE
Ensure facets with more than 10 values display the "more≫" link

### DIFF
--- a/app/models/solr_service.rb
+++ b/app/models/solr_service.rb
@@ -99,9 +99,9 @@ class SolrService < ApplicationRecord
   end
 
   def update_field(config, field)
-    config.add_facet_field field.solr_facet_field, label: field.name if field.facetable
-    config.add_index_field field.solr_field_name, label: field.name if field.list_view
-    config.add_show_field field.solr_field_name, label: field.name if field.item_view
+    config.add_facet_field(field.solr_facet_field, label: field.name, limit: 10) if field.facetable
+    config.add_index_field(field.solr_field_name, label: field.name) if field.list_view
+    config.add_show_field(field.solr_field_name, label: field.name) if field.item_view
   end
 
   def title_field_from_config


### PR DESCRIPTION
**ISSUE**
When a facet field had more than 10 items, teh facet panel was not displaying a link to view the remaining terms.

**RESOLUTION**
Blacklight requires the facet limit to be set explicitly in order to display the link. Otherwise, the list is just truncated after the first 10 items.

**BEFORE**
![image](https://github.com/user-attachments/assets/92dce0fc-c09a-4da3-92a7-d22d05e2a5f0)


**AFTER**
![image](https://github.com/user-attachments/assets/1f6e3e8c-80cf-4bdd-9fbc-b059393209a7)

