### PR TITLE
[BUG] Handle invalid vocabulary key changes gracefully

### DIFF
--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -13,7 +13,8 @@ class Vocabulary < ApplicationRecord
   has_many :terms, dependent: :destroy
 
   def to_param
-    key
+    # Use #key_was instead of #key when present to prevent attempts to route objects via non-persisted route keys
+    key_was || key
   end
 
   # Return the id for a given a term key, label, id, or id in string form

--- a/spec/requests/admin/vocabularies_spec.rb
+++ b/spec/requests/admin/vocabularies_spec.rb
@@ -101,6 +101,12 @@ RSpec.describe '/admin/vocabularies' do
         vocabulary.reload
         expect(response).to redirect_to(vocabulary_url(vocabulary))
       end
+
+      it 'handles key changes successfuly' do
+        vocabulary = Vocabulary.create! valid_attributes
+        patch vocabulary_url(vocabulary), params: { vocabulary: { key: 'new-key' } }
+        expect(response.location).to match(/new-key/)
+      end
     end
 
     context 'with invalid parameters' do
@@ -108,6 +114,14 @@ RSpec.describe '/admin/vocabularies' do
         vocabulary = Vocabulary.create! valid_attributes
         patch vocabulary_url(vocabulary), params: { vocabulary: invalid_attributes }
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'routes correctly on invalid key changes', :aggregate_failures do
+        vocabulary = Vocabulary.create! valid_attributes
+        old_key = vocabulary.key
+        vocabulary.key = '!invalid~key'
+        expect { get vocabulary_url(vocabulary) }.not_to raise_exception
+        expect(vocabulary_url(vocabulary)).to match(old_key)
       end
     end
   end


### PR DESCRIPTION
**ISSUE**
When editing a vocabulary and entering an invalid key, or valid key with other invalid data that will not validate, clicking the "cancel" button attempted to route to a link generated using the unpersisted key.

**FIX**
Instead of using the unpersisted, and possibly invalid, key; check for the existence of the persisted value (i.e. #key_was instead of #key) available through the ActiveModel interface.

For more details, see https://api.rubyonrails.org/classes/ActiveModel/Dirty.html