### PR TITLE
[BUG] Handle invalid term key changes gracefully

### DIFF
--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -13,7 +13,8 @@ class Term < ApplicationRecord
   before_validation :set_key
 
   def to_param
-    key
+    # Use #key_was instead of #key when present to prevent attempts to route objects via non-persisted route keys
+    key_was || key
   end
 
   def to_partial_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,16 +57,16 @@ Rails.application.routes.draw do
 
   direct :term do |term|
     if term.key
-      { controller: 'admin/terms', action: :show, vocabulary_key: term.vocabulary.key, key: term.key }
+      { controller: 'admin/terms', action: :show, vocabulary_key: term.vocabulary.to_param, key: term.to_param }
     else
       { controller: 'admin/terms', vocabulary_key: term.vocabulary.key }
     end
   end
   direct :edit_term do |term|
-    { controller: 'admin/terms', action: :edit, vocabulary_key: term.vocabulary.key, key: term.key }
+    { controller: 'admin/terms', action: :edit, vocabulary_key: term.vocabulary.to_param, key: term.to_param }
   end
   direct :terms do |term|
-    { controller: 'admin/terms', vocabulary_key: term.vocabulary.key }
+    { controller: 'admin/terms', vocabulary_key: term.vocabulary.to_param }
   end
 
   # When app is firt booted and no Solr config exists, use this as the application root

--- a/spec/requests/admin/terms_spec.rb
+++ b/spec/requests/admin/terms_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe 'admin/terms' do
         patch term_url(term), params: { term: invalid_attributes }
         expect(response).to have_http_status(:unprocessable_entity)
       end
+
+      it 'routes correctly on invalid key changes', :aggregate_failures do
+        term = Term.create! valid_attributes
+        old_key = term.key
+        term.key = '!invalid~key'
+        expect { get term_url(term) }.not_to raise_exception
+        expect(term_url(term)).to match(old_key)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes an error that can occur when attempting to route to Terms that have unpersisted key changes.

For more detail see PR #285