### PR TITLE
Enhance Vocabulary editing form

### DIFF
--- a/app/views/admin/vocabularies/_form.html.erb
+++ b/app/views/admin/vocabularies/_form.html.erb
@@ -1,3 +1,22 @@
+<script>
+    function resizeTextArea(node) {
+        node.style.height = 'auto';
+        node.style.height = node.scrollHeight + 'px';
+    }
+    function suggestKey() {
+        label = document.getElementById('vocabulary_label');
+        key = document.getElementById('vocabulary_key');
+        key.placeholder =
+            label.value
+            .normalize('NFKD')
+            .replace(/\p{Diacritic}/gu, "")
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g,'-')
+            .replace(/(^-|-$)/g,'');
+    }
+    window.onload = resizeTextArea(document.getElementById('vocabulary_note'));
+</script>
+
 <%= form_with(model: vocabulary, class: 'card-body') do |form| %>
     <div class="form_buttons">
       <div>
@@ -30,19 +49,14 @@
         <% end %>
 
         <%= form.label :label %>
-        <%= form.text_field :label %>
+        <%= form.text_field :label, oninput: 'suggestKey()' %>
 
         <%= form.label :key %>
         <%= form.text_field :key %>
 
         <%= form.label :note %>
-        <%= form.text_area :note, oninput: 'this.style.height = this.scrollHeight + "px"', onfocus: 'this.style.height = this.scrollHeight + "px"' %>
+        <%= form.text_area :note, oninput: 'resizeTextArea(this);', data: {lpignore:'true'} %>
       </fieldset>
     </div>
 
 <% end %>
-
-<script>
-  note = document.getElementById('vocabulary_note')
-  note.style.height = note.scrollHeight + 'px'
-</script>


### PR DESCRIPTION
This change adds two usability features to the Vocabulary editor (creating and editing vocabularies).

1. Dynamically displays the suggested vocabulary key used in the URL for the vocabulary. Users can override the suggested value by typing in the respective field.

2. Dynamically resizes the text area for the note input. The note is able to span multiple lines if needed.

![T3 Vocab UI 4x](https://github.com/user-attachments/assets/5ff46a51-6067-4406-8c99-e05b0b1ac9be)


NOTE:
The fragment ` data: {lpignore:'true'} ` instructs LastPass to ignore the form field (for LP autocomplete) to prevent errors due to both LastPass and the application adding listeners to the field.