### PR TITLE
Support Markdown in Vocabulary notes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,9 @@ gem 'omniauth-rails_csrf_protection'
 # Implement user authorization within the app
 gem 'cancancan'
 
+# Provide Markdown rendering support
+gem 'commonmarker'
+
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    commonmarker (1.1.5-x86_64-darwin)
+    commonmarker (1.1.5-x86_64-linux)
     concurrent-ruby (1.3.1)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -522,6 +524,7 @@ DEPENDENCIES
   capistrano-sidekiq
   capistrano3-puma (= 6.0.0.beta.1)
   capybara
+  commonmarker
   debug
   devise
   devise-guests (~> 0.8)

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -12,4 +12,10 @@ module DocumentHelper
       to_sentence(links)
     end
   end
+
+  def render_markdown(string)
+    return if string.blank?
+
+    Commonmarker.to_html(string).html_safe # rubocop:disable Rails/OutputSafety
+  end
 end

--- a/app/views/admin/vocabularies/index.html.erb
+++ b/app/views/admin/vocabularies/index.html.erb
@@ -29,7 +29,7 @@
             <%= vocabulary.terms.count -%>
           </div>
           <div class="vocabulary_note">
-            <%= vocabulary.note -%>
+            <%= render_markdown(vocabulary.note) -%>
           </div>
         </div>
       <% end %>

--- a/spec/helpers/document_helper_spec.rb
+++ b/spec/helpers/document_helper_spec.rb
@@ -29,4 +29,25 @@ RSpec.describe DocumentHelper do
       end.to raise_exception ActiveSupport::MessageVerifier::InvalidSignature
     end
   end
+
+  describe '#render_markdwon' do
+    it 'renders markdown as HTML' do
+      sample = '[**CommonMark**](https://commonmark.org/help/) examples'
+      expect(helper.render_markdown(sample))
+        .to include '<a href="https://commonmark.org/help/"><strong>CommonMark</strong></a> examples'
+    end
+
+    it 'returns unescaped HTML' do
+      sample = 'Some *markdown* formatted `text`'
+      rendered = helper.render_markdown(sample)
+      expect(rendered).to be_html_safe
+    end
+
+    it 'suppresses raw HTML', :aggregate_failures do
+      sample = '<script>window.alert("danger");</sript>'
+      rendered = helper.render_markdown(sample)
+      expect(rendered).to include '<!-- raw HTML omitted -->'
+      expect(rendered).not_to include '<script>'
+    end
+  end
 end

--- a/spec/views/admin/vocabularies/index.html.erb_spec.rb
+++ b/spec/views/admin/vocabularies/index.html.erb_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe 'admin/vocabularies/index' do
     expect(rendered).to include(*vocabulary_notes)
   end
 
+  it 'renders markdown in notes' do
+    vocabularies[1].note = '[**CommonMark**](https://commonmark.org/help/) examples'
+    render
+    expect(rendered).to include '<a href="https://commonmark.org/help/"><strong>CommonMark</strong></a> examples'
+  end
+
   it 'provides links to each vocabulary' do
     render
     expect(rendered).to have_link(href: url_for(vocabularies[1]))


### PR DESCRIPTION
**RATIONALE**
We want to be able to provide a basic level of formatting along with supporting reference links in vocabulary notes.