### PR TITLE
[REFACTOR] Make a separate service for dynanamic Catalog configuration

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -242,5 +242,5 @@ class CatalogController < ApplicationController
   end
 
   # Apply any dynamic field configurations from the current configuration record
-  SolrService.current.update_catalog_controller
+  CatalogConfigService.update_catalog_controller
 end

--- a/app/models/field.rb
+++ b/app/models/field.rb
@@ -42,7 +42,7 @@ class Field < ApplicationRecord
   before_save :check_sequence
   after_save :clear_solr_field
   after_save { Field.resequence } # Call before :update_catalog_controller to reflect field order changes
-  after_save :update_catalog_controller
+  after_save { CatalogConfigService.update_catalog_controller }
   after_destroy { Field.resequence }
 
   class << self
@@ -109,10 +109,6 @@ class Field < ApplicationRecord
   end
 
   private
-
-  def update_catalog_controller
-    SolrService.current.update_catalog_controller
-  end
 
   # Put the field at the end of the sequence if it's sequence order has not ben set
   def check_sequence

--- a/app/models/solr_service.rb
+++ b/app/models/solr_service.rb
@@ -11,7 +11,7 @@ class SolrService < ApplicationRecord
 
   before_create :check_for_existing
   before_destroy :check_for_existing
-  after_commit :update_catalog_controller
+  after_commit { CatalogConfigService.update_catalog_controller }
 
   def self.current
     SolrService.first || SolrService.create(DEFAULT_CONFIG)
@@ -72,45 +72,11 @@ class SolrService < ApplicationRecord
     true
   end
 
-  def update_catalog_controller # rubocop:disable Metrics/AbcSize
-    CatalogController.configure_blacklight do |config|
-      config.connection_config[:url] = solr_connection_from_config
-      config.facet_fields = blacklight_fields_from_config.facet_fields
-      config.index_fields = blacklight_fields_from_config.index_fields
-      config.show_fields = blacklight_fields_from_config.show_fields
-      config.index.title_field = title_field_from_config
-    end
-  end
-
   def self.solr_connection
     CatalogController.blacklight_config.repository.connection
   end
 
   private
-
-  def blacklight_fields_from_config
-    config = Blacklight::Configuration.new
-    # NOTE: skip the first field because it's always used as the main title field for Blacklight
-    Field.active_in_sequence[1..]&.each do |field|
-      update_field(config, field)
-    end
-    config.add_show_field 'files_ssm', label: 'Files', helper_method: :file_links
-    config
-  end
-
-  def update_field(config, field)
-    config.add_facet_field(field.solr_facet_field, label: field.name, limit: 10) if field.facetable
-    config.add_index_field(field.solr_field_name, label: field.name) if field.list_view
-    config.add_show_field(field.solr_field_name, label: field.name) if field.item_view
-  end
-
-  def title_field_from_config
-    Field.active_in_sequence.first&.solr_field_name
-  end
-
-  def solr_connection_from_config
-    "#{solr_host}/solr/#{solr_core}"
-  end
 
   def check_for_existing
     raise ActiveRecord::RecordInvalid if SolrService.count >= 1

--- a/app/services/catalog_config_service.rb
+++ b/app/services/catalog_config_service.rb
@@ -1,0 +1,43 @@
+# Encapsulates logic that builds Blacklight Catalog configuration from
+# current Field configurations
+class CatalogConfigService
+  def self.update_catalog_controller
+    new.update_catalog_controller
+  end
+
+  def update_catalog_controller # rubocop:disable Metrics/AbcSize
+    CatalogController.configure_blacklight do |config|
+      config.connection_config[:url] = solr_connection_from_config
+      config.facet_fields = blacklight_fields_from_config.facet_fields
+      config.index_fields = blacklight_fields_from_config.index_fields
+      config.show_fields = blacklight_fields_from_config.show_fields
+      config.index.title_field = title_field_from_config
+    end
+  end
+
+  private
+
+  def blacklight_fields_from_config
+    config = Blacklight::Configuration.new
+    # NOTE: skip the first field because it's always used as the main title field for Blacklight
+    Field.active_in_sequence[1..]&.each do |field|
+      update_field(config, field)
+    end
+    config.add_show_field 'files_ssm', label: 'Files', helper_method: :file_links
+    config
+  end
+
+  def update_field(config, field)
+    config.add_facet_field(field.solr_facet_field, label: field.name, limit: 10) if field.facetable
+    config.add_index_field(field.solr_field_name, label: field.name) if field.list_view
+    config.add_show_field(field.solr_field_name, label: field.name) if field.item_view
+  end
+
+  def title_field_from_config
+    Field.active_in_sequence.first&.solr_field_name
+  end
+
+  def solr_connection_from_config
+    "#{SolrService.current.solr_host}/solr/#{SolrService.current.solr_core}"
+  end
+end

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -377,49 +377,9 @@ RSpec.describe Field do
 
   describe '#save' do
     it 'updates the blacklight configuration' do
-      allow(field).to receive(:update_catalog_controller)
+      allow(CatalogConfigService).to receive(:update_catalog_controller)
       field.save!
-      expect(field).to have_received(:update_catalog_controller)
-    end
-  end
-
-  describe '#update_catalog_controller' do
-    let(:sample_fields) do
-      [FactoryBot.build(:field, name: 'field1', list_view: true, item_view: true, facetable: false),
-       FactoryBot.build(:field, name: 'field2', list_view: true, item_view: false, facetable: true),
-       FactoryBot.build(:field, name: 'field3', list_view: false, item_view: true, facetable: true)]
-    end
-    let(:blacklight_config) { Blacklight::Configuration.new }
-
-    before do
-      # Run these tests against an empty blacklight configuration
-      allow(CatalogController).to receive(:blacklight_config).and_return(blacklight_config)
-      # Stub Field#in_seqeuence
-      allow(described_class).to receive(:in_sequence).and_return(sample_fields)
-      # Mimic #in_sequence returning an  ActiveRecord::Relation instead of an Array
-      without_partial_double_verification do
-        allow(described_class.in_sequence).to receive(:where).and_return(sample_fields)
-      end
-    end
-
-    it 'updates index fields', :aggregate_failures do
-      # NOTE: the first active field is used as the title field and already displays in index and show views
-      expect { field.send(:update_catalog_controller) }
-        .to change { CatalogController.blacklight_config.index_fields.values.map(&:label) }
-        .from([]).to(['field2'])
-    end
-
-    it 'updates show fields', :aggregate_failures do
-      # NOTE: the first active field is used as the title field and already displays in index and show views
-      expect { field.send(:update_catalog_controller) }
-        .to change { CatalogController.blacklight_config.show_fields.values.map(&:label) }
-        .from([]).to(array_including('field3'))
-    end
-
-    it 'updates facet fields', :aggregate_failures do
-      expect { field.send(:update_catalog_controller) }
-        .to change { CatalogController.blacklight_config.facet_fields.values.map(&:label) }
-        .from([]).to(['field2', 'field3'])
+      expect(CatalogConfigService).to have_received(:update_catalog_controller)
     end
   end
 

--- a/spec/models/solr_service_spec.rb
+++ b/spec/models/solr_service_spec.rb
@@ -72,10 +72,9 @@ RSpec.describe SolrService, :aggregate_failures do
   end
 
   it 'updates the catalog controller on saves' do
-    service = described_class.current
-    allow(service).to receive(:update_catalog_controller)
+    allow(CatalogConfigService).to receive(:update_catalog_controller)
     service.save!
-    expect(service).to have_received(:update_catalog_controller)
+    expect(CatalogConfigService).to have_received(:update_catalog_controller)
   end
 
   it 'validates' do

--- a/spec/services/catalog_config_service_spec.rb
+++ b/spec/services/catalog_config_service_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe CatalogConfigService do
+  describe '.update_catalog_controller' do
+    let(:sample_fields) do
+      [FactoryBot.build(:field, name: 'field1', list_view: true, item_view: true, searchable: true, facetable: false),
+       FactoryBot.build(:field, name: 'field2', list_view: true, item_view: false, searchable: false, facetable: true),
+       FactoryBot.build(:field, name: 'field3', list_view: false, item_view: true, searchable: true, facetable: true)]
+    end
+    let(:blacklight_config) { Blacklight::Configuration.new }
+
+    before do
+      # Run these tests against an empty blacklight configuration
+      allow(CatalogController).to receive(:blacklight_config).and_return(blacklight_config)
+      # Stub Field#in_seqeuence
+      allow(Field).to receive(:in_sequence).and_return(sample_fields)
+      # Mimic #in_sequence returning an  ActiveRecord::Relation instead of an Array
+      without_partial_double_verification do
+        allow(Field.in_sequence).to receive(:where).and_return(sample_fields)
+      end
+    end
+
+    it 'updates index fields', :aggregate_failures do
+      # NOTE: the first active field is used as the title field and already displays in index and show views
+      expect { described_class.send(:update_catalog_controller) }
+        .to change { CatalogController.blacklight_config.index_fields.values.map(&:label) }
+        .from([]).to(['field2'])
+    end
+
+    it 'updates show fields', :aggregate_failures do
+      # NOTE: the first active field is used as the title field and already displays in index and show views
+      expect { described_class.send(:update_catalog_controller) }
+        .to change { CatalogController.blacklight_config.show_fields.values.map(&:label) }
+        .from([]).to(array_including('field3'))
+    end
+
+    it 'updates facet fields', :aggregate_failures do
+      expect { described_class.send(:update_catalog_controller) }
+        .to change { CatalogController.blacklight_config.facet_fields.values.map(&:label) }
+        .from([]).to(['field2', 'field3'])
+    end
+  end
+end


### PR DESCRIPTION
**RATIONALE**
The `SolrService` has grown to contain two relatively different sets of functionality over time:
1. Managing and persisting the connection to a Solr host
2. Translating `Field` settings into the desired CatalogController configuration

This change extracts the CatalogController related logic to a separate service. This change is made in anticipation of extending the configuration logic to add support for search field configuration.