### PR TITLE
Add initial search capability

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -184,40 +184,40 @@ class CatalogController < ApplicationController
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
 
-    config.add_search_field 'all_fields', label: 'All Fields'
+    # config.add_search_field 'all_fields', label: 'All Fields'
 
     # Now we see how to over-ride Solr request handler defaults, in this
     # case for a BL "search field", which is really a dismax aggregate
     # of Solr search fields.
 
-    config.add_search_field('title') do |field|
-      # solr_parameters hash are sent to Solr as ordinary url query params.
-      field.solr_parameters = {
-        'spellcheck.dictionary': 'title',
-        qf: '${title_qf}',
-        pf: '${title_pf}'
-      }
-    end
+    # config.add_search_field('title') do |field|
+    #   # solr_parameters hash are sent to Solr as ordinary url query params.
+    #   field.solr_parameters = {
+    #     'spellcheck.dictionary': 'title',
+    #     qf: '${title_qf}',
+    #     pf: '${title_pf}'
+    #   }
+    # end
 
-    config.add_search_field('author') do |field|
-      field.solr_parameters = {
-        'spellcheck.dictionary': 'author',
-        qf: '${author_qf}',
-        pf: '${author_pf}'
-      }
-    end
+    # config.add_search_field('author') do |field|
+    #   field.solr_parameters = {
+    #     'spellcheck.dictionary': 'author',
+    #     qf: '${author_qf}',
+    #     pf: '${author_pf}'
+    #   }
+    # end
 
     # Specifying a :qt only to show it's possible, and so our internal automated
     # tests can test it. In this case it's the same as
     # config[:default_solr_parameters][:qt], so isn't actually neccesary.
-    config.add_search_field('subject') do |field|
-      field.qt = 'search'
-      field.solr_parameters = {
-        'spellcheck.dictionary': 'subject',
-        qf: '${subject_qf}',
-        pf: '${subject_pf}'
-      }
-    end
+    # config.add_search_field('subject') do |field|
+    #   field.qt = 'search'
+    #   field.solr_parameters = {
+    #     'spellcheck.dictionary': 'subject',
+    #     qf: '${subject_qf}',
+    #     pf: '${subject_pf}'
+    #   }
+    # end
 
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the Solr field to sort by and

--- a/app/models/solr_service.rb
+++ b/app/models/solr_service.rb
@@ -17,6 +17,10 @@ class SolrService < ApplicationRecord
     SolrService.first || SolrService.create(DEFAULT_CONFIG)
   end
 
+  def url
+    "#{solr_host}/solr/#{solr_core}"
+  end
+
   def verified?
     solr_version.present?
   end

--- a/app/services/catalog_config_service.rb
+++ b/app/services/catalog_config_service.rb
@@ -7,11 +7,12 @@ class CatalogConfigService
 
   def update_catalog_controller # rubocop:disable Metrics/AbcSize
     CatalogController.configure_blacklight do |config|
-      config.connection_config[:url] = solr_connection_from_config
+      config.connection_config[:url] = SolrService.current.url
+      config.search_fields = blacklight_fields_from_config.search_fields
       config.facet_fields = blacklight_fields_from_config.facet_fields
       config.index_fields = blacklight_fields_from_config.index_fields
       config.show_fields = blacklight_fields_from_config.show_fields
-      config.index.title_field = title_field_from_config
+      config.index.title_field = title_field
     end
   end
 
@@ -19,6 +20,9 @@ class CatalogConfigService
 
   def blacklight_fields_from_config
     config = Blacklight::Configuration.new
+    add_all_field_search(config)
+    add_title_search(config)
+
     # NOTE: skip the first field because it's always used as the main title field for Blacklight
     Field.active_in_sequence[1..]&.each do |field|
       update_field(config, field)
@@ -27,17 +31,56 @@ class CatalogConfigService
     config
   end
 
+  def add_all_field_search(config)
+    config.add_search_field('all_fields', label: 'All Fields') do |field|
+      all_names = Field.active_in_sequence.map(&:solr_field_name).join(' ')
+      field.solr_parameters = {
+        qf: "#{all_names} id",
+        pf: title_field
+      }
+    end
+  end
+
+  def add_title_search(config)
+    return unless title_field
+
+    config.add_search_field(title_field, label: title_label) do |field|
+      field.solr_parameters = { qf: title_field }
+    end
+  end
+
   def update_field(config, field)
+    configure_search(config, field)
+    configure_facet(config, field)
+    configure_index(config, field)
+    configure_show(config, field)
+  end
+
+  def configure_search(config, field)
+    return unless field.searchable
+
+    config.add_search_field(field.solr_field_name,
+                            label: field.name,
+                            solr_parameters: { qf: field.solr_field_name })
+  end
+
+  def configure_facet(config, field)
     config.add_facet_field(field.solr_facet_field, label: field.name, limit: 10) if field.facetable
+  end
+
+  def configure_index(config, field)
     config.add_index_field(field.solr_field_name, label: field.name) if field.list_view
+  end
+
+  def configure_show(config, field)
     config.add_show_field(field.solr_field_name, label: field.name) if field.item_view
   end
 
-  def title_field_from_config
-    Field.active_in_sequence.first&.solr_field_name
+  def title_field
+    @title_field ||= Field.active_in_sequence.first&.solr_field_name
   end
 
-  def solr_connection_from_config
-    "#{SolrService.current.solr_host}/solr/#{SolrService.current.solr_core}"
+  def title_label
+    Field.active_in_sequence.first&.name
   end
 end

--- a/spec/models/solr_service_spec.rb
+++ b/spec/models/solr_service_spec.rb
@@ -128,6 +128,18 @@ RSpec.describe SolrService, :aggregate_failures do
     expect(service.errors.messages[:solr_core]).to include("can't be blank")
   end
 
+  describe '#url' do
+    it 'has a sane default' do
+      expect(service.url).to eq 'http://localhost:8983/solr/blacklight-core'
+    end
+
+    it 'reflects the assigned host and core' do
+      service.solr_host = 'https://secure-solr.local'
+      service.solr_core = 'tenejo'
+      expect(service.url).to eq 'https://secure-solr.local/solr/tenejo'
+    end
+  end
+
   describe '#verified?' do
     it 'proxies solr_version' do
       service.solr_version = nil

--- a/spec/services/catalog_config_service_spec.rb
+++ b/spec/services/catalog_config_service_spec.rb
@@ -39,5 +39,11 @@ RSpec.describe CatalogConfigService do
         .to change { CatalogController.blacklight_config.facet_fields.values.map(&:label) }
         .from([]).to(['field2', 'field3'])
     end
+
+    it 'updates search fields', :aggregate_failures do
+      expect { described_class.send(:update_catalog_controller) }
+        .to change { CatalogController.blacklight_config.search_fields.values.map(&:label) }
+        .from([]).to(['All Fields', 'field1', 'field3'])
+    end
   end
 end

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'Search' do
+  let(:field_seeds) do
+    [{ name: 'Title',       data_type: 'text_en', list_view: true,  item_view: true },
+     { name: 'Identifier',  data_type: 'string',  list_view: true,  item_view: true, searchable: false },
+     { name: 'Description', data_type: 'text_en', list_view: false, item_view: true, multiple: true, searchable: true }]
+    # NOTE: 'Files' --> 'files_ssm' is injected automatically to handle file attachments
+  end
+
+  # Stub out a minimal solr server
+  let(:solr_client) { instance_double RSolr::Client }
+  let(:admin_info) { { 'lucene' => { 'solr-spec-version' => '9.2.1' } } }
+
+  before do
+    allow(RSolr).to receive(:connect).and_return(solr_client)
+    allow(solr_client).to receive(:get).with('/solr/admin/info/system', anything).and_return(admin_info)
+    allow(solr_client).to receive(:send_and_receive)
+    field_seeds.each do |seed|
+      Field.create!(seed)
+    end
+  end
+
+  it 'has the expected search options', :aggregate_failures do
+    visit search_catalog_path
+    expect(page).to have_selector('#search_field option', text: 'All Fields')
+    expect(page).to have_selector('#search_field option', text: 'Title')
+    expect(page).to have_selector('#search_field option', text: 'Description')
+    expect(page).not_to have_selector('#search_field option', text: 'Identifier')
+  end
+
+  it 'sends the expected Solr query' do # rubocop:disable RSpec/ExampleLength
+    visit search_catalog_path
+    select 'Description', from: 'search_field'
+    fill_in 'q', with: 'έννοιες που ψάχνω'
+    click_on 'search'
+    expect(solr_client).to have_received(:send_and_receive)
+      .with('select', hash_including(params: hash_including(q: 'έννοιες που ψάχνω', qf: /description/)))
+  end
+end


### PR DESCRIPTION
This change implements an initial search capability with the following behaviors:

* **'All Field' search** - executes a tokenized search over all indexed fields. Matches against the Title field are boosted
* **'Title' search** - executes a tokenized search against the default title field - i.e. the first field in the field list
* **Individual field search** - executes a tokenized search against any field configured as `searchable`

This feature inherits basic Blacklight (& Solr) functionality such as
* **Wildcard Search** - an asterisk (`*`) can be used to specify any number of matching characters after a word. E.G. `ma*` matches "mark", "markets", "may", "machine" and any other words beginning with the letters "ma".
* **Exact match** - enclosing a search term in double quotes will force and exact match. E.G. `"The Exact Title"` will only match the string _The Exact Title_