### PR TITLE
Improve field-level search

### DIFF
--- a/app/services/catalog_config_service.rb
+++ b/app/services/catalog_config_service.rb
@@ -61,7 +61,7 @@ class CatalogConfigService
 
     config.add_search_field(field.solr_field_name,
                             label: field.name,
-                            solr_parameters: { qf: field.solr_field_name })
+                            solr_parameters: { df: field.solr_field_name })
   end
 
   def configure_facet(config, field)

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -35,6 +35,6 @@ RSpec.describe 'Search' do
     fill_in 'q', with: 'έννοιες που ψάχνω'
     click_on 'search'
     expect(solr_client).to have_received(:send_and_receive)
-      .with('select', hash_including(params: hash_including(q: 'έννοιες που ψάχνω', qf: /description/)))
+      .with('select', hash_including(params: hash_including(q: 'έννοιες που ψάχνω', df: /description/)))
   end
 end


### PR DESCRIPTION
This change updates the query configuration to override the default field (`df`) specified in the Solr schema. This yeilds better search results when searching on a specific field and allows us to do partial field matches on string fields.